### PR TITLE
refactor: remove protocolVersion from IPC protocol

### DIFF
--- a/docs/architecture/system-architecture.md
+++ b/docs/architecture/system-architecture.md
@@ -123,7 +123,6 @@ sequenceDiagram
 - **Node.js child_process.spawn** with `stdio: 'pipe'` -- the sidecar is a subprocess of Obsidian
 - **Custom binary framing** (5-byte header: 1 byte kind + 4 byte LE length + payload) -- no HTTP, no WebSocket, no IPC library
 - **FramedMessageParser** (TS) and **read_frame** (Rust) handle stream reassembly across chunk boundaries
-- Protocol version `v3` is checked on every JSON envelope; mismatches are hard errors
 
 **Frame direction rules:**
 - `stdin` (TS → Rust): Both audio frames (`0x02`) and JSON command frames (`0x01`)

--- a/native/src/protocol.rs
+++ b/native/src/protocol.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 use crate::catalog::{CatalogModel, ModelCollection, ModelEngine};
 use crate::model_store::InstalledModelRecord;
 
-pub const PROTOCOL_VERSION: &str = "v3";
 const JSON_FRAME_KIND: u8 = 0x01;
 const AUDIO_FRAME_KIND: u8 = 0x02;
 const FRAME_HEADER_LENGTH: usize = 5;
@@ -135,8 +134,6 @@ pub struct RuntimeCapability {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct CommandEnvelope {
-    #[serde(rename = "protocolVersion")]
-    pub protocol_version: String,
     #[serde(flatten)]
     pub command: Command,
 }
@@ -209,8 +206,6 @@ pub enum Command {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct EventEnvelope {
-    #[serde(rename = "protocolVersion")]
-    pub protocol_version: String,
     #[serde(flatten)]
     pub event: Event,
 }
@@ -348,22 +343,13 @@ impl CommandEnvelope {
         let envelope: Self =
             serde_json::from_str(json_text).context("failed to deserialize command envelope")?;
 
-        ensure!(
-            envelope.protocol_version == PROTOCOL_VERSION,
-            "unsupported protocol version {}",
-            envelope.protocol_version
-        );
-
         Ok(envelope.command)
     }
 }
 
 impl EventEnvelope {
     pub fn new(event: Event) -> Self {
-        Self {
-            protocol_version: PROTOCOL_VERSION.to_string(),
-            event,
-        }
+        Self { event }
     }
 }
 
@@ -482,14 +468,13 @@ mod tests {
     use super::{
         AUDIO_FRAME_KIND, AccelerationPreference, Command, EngineId, Event, EventEnvelope,
         FRAME_HEADER_LENGTH, IncomingFrame, JSON_FRAME_KIND, ListeningMode, MAX_FRAME_PAYLOAD,
-        PCM_BYTES_PER_FRAME, PROTOCOL_VERSION, RuntimeCapability, SelectedModel, compiled_backends,
-        compiled_engines, read_frame, write_event_frame, write_frame,
+        PCM_BYTES_PER_FRAME, RuntimeCapability, SelectedModel, compiled_backends, compiled_engines,
+        read_frame, write_event_frame, write_frame,
     };
 
     #[test]
     fn command_frame_round_trip_preserves_start_session_shape() {
         let payload = serde_json::to_vec(&serde_json::json!({
-            "protocolVersion": PROTOCOL_VERSION,
             "type": "start_session",
             "sessionId": "session-1",
             "mode": "always_on",
@@ -529,7 +514,6 @@ mod tests {
     #[test]
     fn start_session_with_acceleration_preference_auto() {
         let payload = serde_json::to_vec(&serde_json::json!({
-            "protocolVersion": PROTOCOL_VERSION,
             "type": "start_session",
             "sessionId": "session-3",
             "mode": "always_on",
@@ -570,7 +554,6 @@ mod tests {
     #[test]
     fn get_system_info_round_trip() {
         let payload = serde_json::to_vec(&serde_json::json!({
-            "protocolVersion": PROTOCOL_VERSION,
             "type": "get_system_info"
         }))
         .expect("payload should serialize");

--- a/src/sidecar/protocol.ts
+++ b/src/sidecar/protocol.ts
@@ -18,8 +18,6 @@ import {
 import { PCM_BYTES_PER_FRAME } from '../shared/pcm-format';
 import { isRecord } from '../shared/type-guards';
 
-export const SIDECAR_PROTOCOL_VERSION = 'v3' as const;
-
 export const JSON_FRAME_KIND = 0x01;
 export const AUDIO_FRAME_KIND = 0x02;
 export const FRAME_HEADER_LENGTH = 5;
@@ -48,7 +46,6 @@ export interface TranscriptSegment {
 }
 
 interface EnvelopeBase<TType extends string> {
-  protocolVersion: typeof SIDECAR_PROTOCOL_VERSION;
   type: TType;
 }
 
@@ -223,7 +220,7 @@ export function createGetSystemInfoCommand(): GetSystemInfoCommand {
 }
 
 export function createStartSessionCommand(
-  payload: Omit<StartSessionCommand, 'protocolVersion' | 'type'>,
+  payload: Omit<StartSessionCommand, 'type'>,
 ): StartSessionCommand {
   return {
     ...createEnvelope('start_session'),
@@ -252,7 +249,7 @@ export function createListInstalledModelsCommand(
 }
 
 export function createProbeModelSelectionCommand(
-  payload: Omit<ProbeModelSelectionCommand, 'protocolVersion' | 'type'>,
+  payload: Omit<ProbeModelSelectionCommand, 'type'>,
 ): ProbeModelSelectionCommand {
   return {
     ...createEnvelope('probe_model_selection'),
@@ -261,7 +258,7 @@ export function createProbeModelSelectionCommand(
 }
 
 export function createRemoveModelCommand(
-  payload: Omit<RemoveModelCommand, 'protocolVersion' | 'type'>,
+  payload: Omit<RemoveModelCommand, 'type'>,
 ): RemoveModelCommand {
   return {
     ...createEnvelope('remove_model'),
@@ -270,7 +267,7 @@ export function createRemoveModelCommand(
 }
 
 export function createInstallModelCommand(
-  payload: Omit<InstallModelCommand, 'protocolVersion' | 'type'>,
+  payload: Omit<InstallModelCommand, 'type'>,
 ): InstallModelCommand {
   return {
     ...createEnvelope('install_model'),
@@ -390,13 +387,11 @@ export function parseEventFrame(jsonText: string): SidecarEvent {
     throw new Error('Sidecar event must be a JSON object.');
   }
 
-  const protocolVersion = readProtocolVersion(parsedValue.protocolVersion);
   const type = readString(parsedValue.type, 'event.type');
 
   switch (type) {
     case 'health_ok':
       return {
-        protocolVersion,
         sidecarVersion: readString(parsedValue.sidecarVersion, 'event.sidecarVersion'),
         status: readReadyStatus(parsedValue.status),
         type,
@@ -406,7 +401,6 @@ export function parseEventFrame(jsonText: string): SidecarEvent {
       return {
         overridePath: readNullableString(parsedValue.overridePath, 'event.overridePath'),
         path: readString(parsedValue.path, 'event.path'),
-        protocolVersion,
         type,
         usingDefaultPath: readBoolean(parsedValue.usingDefaultPath, 'event.usingDefaultPath'),
       };
@@ -417,14 +411,12 @@ export function parseEventFrame(jsonText: string): SidecarEvent {
         collections: readModelCollections(parsedValue.collections),
         engines: readModelEngines(parsedValue.engines),
         models: readCatalogModels(parsedValue.models),
-        protocolVersion,
         type,
       };
 
     case 'installed_models':
       return {
         models: readInstalledModels(parsedValue.models),
-        protocolVersion,
         type,
       };
 
@@ -437,7 +429,6 @@ export function parseEventFrame(jsonText: string): SidecarEvent {
         installed: readBoolean(parsedValue.installed, 'event.installed'),
         message: readString(parsedValue.message, 'event.message'),
         modelId: readNullableString(parsedValue.modelId, 'event.modelId'),
-        protocolVersion,
         resolvedPath: readNullableString(parsedValue.resolvedPath, 'event.resolvedPath'),
         selection: readSelectedModel(parsedValue.selection, 'event.selection'),
         sizeBytes: readNullableNumber(parsedValue.sizeBytes, 'event.sizeBytes'),
@@ -449,7 +440,6 @@ export function parseEventFrame(jsonText: string): SidecarEvent {
       return {
         engineId: readEngineId(parsedValue.engineId, 'event.engineId'),
         modelId: readString(parsedValue.modelId, 'event.modelId'),
-        protocolVersion,
         removed: readBoolean(parsedValue.removed, 'event.removed'),
         type,
       };
@@ -462,7 +452,6 @@ export function parseEventFrame(jsonText: string): SidecarEvent {
         installId: readString(parsedValue.installId, 'event.installId'),
         message: readNullableString(parsedValue.message, 'event.message'),
         modelId: readString(parsedValue.modelId, 'event.modelId'),
-        protocolVersion,
         state: readModelInstallState(parsedValue.state, 'event.state'),
         totalBytes: readNullableNumber(parsedValue.totalBytes, 'event.totalBytes'),
         type,
@@ -472,7 +461,6 @@ export function parseEventFrame(jsonText: string): SidecarEvent {
       return {
         compiledBackends: readStringArray(parsedValue.compiledBackends, 'event.compiledBackends'),
         compiledEngines: readStringArray(parsedValue.compiledEngines, 'event.compiledEngines'),
-        protocolVersion,
         runtimeCapabilities: readRuntimeCapabilities(parsedValue.runtimeCapabilities),
         systemInfo: readString(parsedValue.systemInfo, 'event.systemInfo'),
         type,
@@ -481,14 +469,12 @@ export function parseEventFrame(jsonText: string): SidecarEvent {
     case 'session_started':
       return {
         mode: readListeningMode(parsedValue.mode, 'event.mode'),
-        protocolVersion,
         sessionId: readString(parsedValue.sessionId, 'event.sessionId'),
         type,
       };
 
     case 'session_state_changed':
       return {
-        protocolVersion,
         sessionId: readString(parsedValue.sessionId, 'event.sessionId'),
         state: readSessionState(parsedValue.state, 'event.state'),
         type,
@@ -500,7 +486,6 @@ export function parseEventFrame(jsonText: string): SidecarEvent {
           parsedValue.processingDurationMs,
           'event.processingDurationMs',
         ),
-        protocolVersion,
         segments: readTranscriptSegments(parsedValue.segments),
         sessionId: readString(parsedValue.sessionId, 'event.sessionId'),
         text: readString(parsedValue.text, 'event.text'),
@@ -512,18 +497,17 @@ export function parseEventFrame(jsonText: string): SidecarEvent {
       };
 
     case 'warning':
-      return createWarningEvent(parsedValue, protocolVersion);
+      return createWarningEvent(parsedValue);
 
     case 'session_stopped':
       return {
-        protocolVersion,
         reason: readSessionStopReason(parsedValue.reason, 'event.reason'),
         sessionId: readString(parsedValue.sessionId, 'event.sessionId'),
         type,
       };
 
     case 'error':
-      return createErrorEvent(parsedValue, protocolVersion);
+      return createErrorEvent(parsedValue);
 
     default:
       throw new Error(`Unsupported sidecar event type: ${type}`);
@@ -533,10 +517,7 @@ export function parseEventFrame(jsonText: string): SidecarEvent {
 function createEnvelope<TType extends SidecarCommand['type']>(
   type: TType,
 ): Extract<SidecarCommand, { type: TType }> {
-  return {
-    protocolVersion: SIDECAR_PROTOCOL_VERSION,
-    type,
-  } as Extract<SidecarCommand, { type: TType }>;
+  return { type } as Extract<SidecarCommand, { type: TType }>;
 }
 
 function encodeFrame(kind: number, payload: Uint8Array): Uint8Array {
@@ -622,16 +603,6 @@ function readPositiveInteger(value: unknown, fieldName: string): number {
   }
 
   return value;
-}
-
-function readProtocolVersion(value: unknown): typeof SIDECAR_PROTOCOL_VERSION {
-  const protocolVersion = readString(value, 'event.protocolVersion');
-
-  if (protocolVersion !== SIDECAR_PROTOCOL_VERSION) {
-    throw new Error(`Unsupported sidecar protocol version: ${protocolVersion}`);
-  }
-
-  return protocolVersion;
 }
 
 function readReadyStatus(value: unknown): 'ready' {
@@ -913,28 +884,20 @@ function readRecord(value: unknown, fieldName: string): Record<string, unknown> 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
-function createWarningEvent(
-  value: Record<string, unknown>,
-  protocolVersion: typeof SIDECAR_PROTOCOL_VERSION,
-): WarningEvent {
+function createWarningEvent(value: Record<string, unknown>): WarningEvent {
   return {
     code: readString(value.code, 'event.code'),
     ...readOptionalEventFields(value),
     message: readString(value.message, 'event.message'),
-    protocolVersion,
     type: 'warning',
   };
 }
 
-function createErrorEvent(
-  value: Record<string, unknown>,
-  protocolVersion: typeof SIDECAR_PROTOCOL_VERSION,
-): ErrorEvent {
+function createErrorEvent(value: Record<string, unknown>): ErrorEvent {
   return {
     code: readString(value.code, 'event.code'),
     ...readOptionalEventFields(value),
     message: readString(value.message, 'event.message'),
-    protocolVersion,
     type: 'error',
   };
 }

--- a/src/sidecar/sidecar-connection.ts
+++ b/src/sidecar/sidecar-connection.ts
@@ -211,7 +211,7 @@ export class SidecarConnection {
   }
 
   async startSession(
-    payload: Omit<StartSessionCommand, 'protocolVersion' | 'type'>,
+    payload: Omit<StartSessionCommand, 'type'>,
     timeoutMs = this.options.getRequestTimeoutMs(),
   ): Promise<SessionStartedEvent> {
     return this.sendCommandAndWait(

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -34,13 +34,11 @@ class FakeCaptureStream {
 class FakeSidecarConnection {
   public cancelSession = vi.fn(async (sessionId: string) => {
     this.emit({
-      protocolVersion: 'v3',
       reason: 'user_cancel',
       sessionId,
       type: 'session_stopped',
     });
     return {
-      protocolVersion: 'v3',
       reason: 'user_cancel',
       sessionId,
       type: 'session_stopped',
@@ -50,39 +48,32 @@ class FakeSidecarConnection {
   public lastSessionId: string | null = null;
   public sendAudioFrame = vi.fn(() => {});
   public setGate = vi.fn(async () => {});
-  public startSession = vi.fn(
-    async (payload: Omit<StartSessionCommand, 'protocolVersion' | 'type'>) => {
-      this.lastSessionId = payload.sessionId;
-      this.emit({
-        mode: payload.mode,
-        protocolVersion: 'v3',
-        sessionId: payload.sessionId,
-        type: 'session_started',
-      });
-      this.emit({
-        protocolVersion: 'v3',
-        sessionId: payload.sessionId,
-        state: payload.mode === 'press_and_hold' ? 'idle' : 'listening',
-        type: 'session_state_changed',
-      });
+  public startSession = vi.fn(async (payload: Omit<StartSessionCommand, 'type'>) => {
+    this.lastSessionId = payload.sessionId;
+    this.emit({
+      mode: payload.mode,
+      sessionId: payload.sessionId,
+      type: 'session_started',
+    });
+    this.emit({
+      sessionId: payload.sessionId,
+      state: payload.mode === 'press_and_hold' ? 'idle' : 'listening',
+      type: 'session_state_changed',
+    });
 
-      return {
-        mode: payload.mode,
-        protocolVersion: 'v3',
-        sessionId: payload.sessionId,
-        type: 'session_started',
-      } as const;
-    },
-  );
+    return {
+      mode: payload.mode,
+      sessionId: payload.sessionId,
+      type: 'session_started',
+    } as const;
+  });
   public stopSession = vi.fn(async (sessionId: string) => {
     this.emit({
-      protocolVersion: 'v3',
       reason: 'user_stop',
       sessionId,
       type: 'session_stopped',
     });
     return {
-      protocolVersion: 'v3',
       reason: 'user_stop',
       sessionId,
       type: 'session_stopped',
@@ -203,7 +194,6 @@ describe('DictationSessionController', () => {
 
     sidecarConnection.emit({
       processingDurationMs: 75,
-      protocolVersion: 'v3',
       segments: [],
       sessionId: sidecarConnection.lastSessionId ?? 'session-1',
       text: 'hello obsidian',
@@ -232,7 +222,6 @@ describe('DictationSessionController', () => {
 
     sidecarConnection.emit({
       processingDurationMs: 75,
-      protocolVersion: 'v3',
       segments: [],
       sessionId: sidecarConnection.lastSessionId ?? 'session-1',
       text: '   ',
@@ -285,7 +274,6 @@ describe('DictationSessionController', () => {
     sidecarConnection.emit({
       code: 'session_failed',
       message: 'The engine crashed.',
-      protocolVersion: 'v3',
       sessionId: sidecarConnection.lastSessionId ?? 'session-1',
       type: 'error',
     });
@@ -310,13 +298,11 @@ describe('DictationSessionController', () => {
         await new Promise((resolve) => {
           resolveCancel = () => {
             sidecarConnection.emit({
-              protocolVersion: 'v3',
               reason: 'user_cancel',
               sessionId,
               type: 'session_stopped',
             });
             resolve({
-              protocolVersion: 'v3',
               reason: 'user_cancel',
               sessionId,
               type: 'session_stopped',
@@ -335,14 +321,13 @@ describe('DictationSessionController', () => {
     sidecarConnection.emit({
       code: 'session_failed',
       message: 'The engine crashed.',
-      protocolVersion: 'v3',
+
       sessionId,
       type: 'error',
     });
     sidecarConnection.emit({
       code: 'session_failed',
       message: 'The engine crashed again.',
-      protocolVersion: 'v3',
       sessionId,
       type: 'error',
     });

--- a/test/model-install-manager.test.ts
+++ b/test/model-install-manager.test.ts
@@ -199,7 +199,6 @@ function emitInstallUpdate(
 ) {
   harness.emit({
     ...sampleInstallUpdate(overrides),
-    protocolVersion: 'v3',
     type: 'model_install_update',
   });
 }

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -12,7 +12,6 @@ import {
   FramedMessageParser,
   JSON_FRAME_KIND,
   parseEventFrame,
-  SIDECAR_PROTOCOL_VERSION,
 } from '../src/sidecar/protocol';
 
 describe('sidecar protocol', () => {
@@ -21,7 +20,6 @@ describe('sidecar protocol', () => {
 
     expect(frame[0]).toBe(JSON_FRAME_KIND);
     expect(readPayload(frame)).toEqual({
-      protocolVersion: SIDECAR_PROTOCOL_VERSION,
       type: 'health',
     });
   });
@@ -55,7 +53,6 @@ describe('sidecar protocol', () => {
     const frame = encodeJsonFrame(createGetSystemInfoCommand());
 
     expect(readPayload(frame)).toEqual({
-      protocolVersion: SIDECAR_PROTOCOL_VERSION,
       type: 'get_system_info',
     });
   });
@@ -65,7 +62,6 @@ describe('sidecar protocol', () => {
     const frame = encodeJsonFrame({
       compiledBackends: ['cpu', 'cuda'],
       compiledEngines: ['whisper_cpp', 'cohere_onnx'],
-      protocolVersion: SIDECAR_PROTOCOL_VERSION,
       runtimeCapabilities: [
         {
           available: true,
@@ -84,7 +80,6 @@ describe('sidecar protocol', () => {
       envelope: {
         compiledBackends: ['cpu', 'cuda'],
         compiledEngines: ['whisper_cpp', 'cohere_onnx'],
-        protocolVersion: SIDECAR_PROTOCOL_VERSION,
         runtimeCapabilities: [
           {
             available: true,
@@ -105,7 +100,6 @@ describe('sidecar protocol', () => {
     const frame = encodeRawJsonFrame({
       compiledBackends: ['cpu', 'cuda'],
       compiledEngines: ['whisper_cpp'],
-      protocolVersion: SIDECAR_PROTOCOL_VERSION,
       systemInfo: 'AVX = 1 | CUDA = 1',
       type: 'system_info',
     });
@@ -116,7 +110,6 @@ describe('sidecar protocol', () => {
       envelope: {
         compiledBackends: ['cpu', 'cuda'],
         compiledEngines: ['whisper_cpp'],
-        protocolVersion: SIDECAR_PROTOCOL_VERSION,
         runtimeCapabilities: [],
         systemInfo: 'AVX = 1 | CUDA = 1',
         type: 'system_info',
@@ -131,26 +124,17 @@ describe('sidecar protocol', () => {
   });
 
   it('rejects missing type field in parseEventFrame', () => {
-    expect(() =>
-      parseEventFrame(JSON.stringify({ protocolVersion: SIDECAR_PROTOCOL_VERSION })),
-    ).toThrow('event.type must be a string.');
+    expect(() => parseEventFrame(JSON.stringify({}))).toThrow('event.type must be a string.');
   });
 
   it('rejects unknown event type in parseEventFrame', () => {
     expect(() =>
       parseEventFrame(
         JSON.stringify({
-          protocolVersion: SIDECAR_PROTOCOL_VERSION,
           type: 'nonexistent_event',
         }),
       ),
     ).toThrow('Unsupported sidecar event type: nonexistent_event');
-  });
-
-  it('rejects wrong protocol version in parseEventFrame', () => {
-    expect(() =>
-      parseEventFrame(JSON.stringify({ protocolVersion: 'v999', type: 'health_ok' })),
-    ).toThrow('Unsupported sidecar protocol version: v999');
   });
 
   it('rejects unknown frame kind byte in FramedMessageParser.pushChunk', () => {
@@ -177,7 +161,6 @@ describe('sidecar protocol', () => {
       parseEventFrame(
         JSON.stringify({
           processingDurationMs: 100,
-          protocolVersion: SIDECAR_PROTOCOL_VERSION,
           segments: [],
           text: 'hello',
           type: 'transcript_ready',
@@ -191,7 +174,6 @@ describe('sidecar protocol', () => {
     const parser = new FramedMessageParser(parseEventFrame);
     const transcriptFrame = encodeJsonFrame({
       processingDurationMs: 125,
-      protocolVersion: SIDECAR_PROTOCOL_VERSION,
       segments: [],
       sessionId: 'session-1',
       text: 'hello world',
@@ -213,7 +195,6 @@ describe('sidecar protocol', () => {
     expect(frames[0]).toEqual({
       envelope: {
         processingDurationMs: 125,
-        protocolVersion: SIDECAR_PROTOCOL_VERSION,
         segments: [],
         sessionId: 'session-1',
         text: 'hello world',


### PR DESCRIPTION
## Summary
- Remove `protocolVersion` field from all IPC commands and events on both TS and Rust sides
- Remove version validation (`readProtocolVersion`, `ensure!()`) — the plugin bundles its own sidecar, so mismatched versions cannot communicate
- Remove the version-mismatch rejection test and update all test fixtures (−90 LOC net)

## Changes
- **Rust** (`native/src/protocol.rs`): remove `PROTOCOL_VERSION` constant, `protocol_version` from `CommandEnvelope`/`EventEnvelope`, version check in `parse_json`, version assignment in `EventEnvelope::new`
- **TypeScript** (`src/sidecar/protocol.ts`): remove `SIDECAR_PROTOCOL_VERSION`, `protocolVersion` from `EnvelopeBase`/`createEnvelope`/`parseEventFrame`, `readProtocolVersion()`, update `Omit` types
- **Connection** (`src/sidecar/sidecar-connection.ts`): update `startSession` param type
- **Tests**: remove `protocolVersion` from all fixtures across 3 test files
- **Docs**: remove protocol version line from `system-architecture.md`

## Verification
- `npm run check` passes (typecheck + lint + 119 TS tests + build)
- `cargo test` passes (65 Rust tests)
- `cargo clippy` passes with `DOCS_RS=1 WHISPER_DONT_GENERATE_BINDINGS=1`

## Test plan
- [x] All existing tests pass with protocolVersion removed
- [x] Verify no remaining references to `protocolVersion`, `SIDECAR_PROTOCOL_VERSION`, or `PROTOCOL_VERSION`
- [x] Build output verified (sidecar + frontend bundle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)