### PR TITLE
fix: discard empty transcripts instead of aborting the session

### DIFF
--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -361,9 +361,16 @@ export class DictationSessionController {
       `transcript received (${event.text.length} chars, ${event.processingDurationMs}ms processing)`,
     );
 
+    const text = normalizeTranscriptText(event);
+
+    if (text === null) {
+      this.dependencies.logger?.debug('session', 'discarding empty transcript');
+      return;
+    }
+
     try {
       this.dependencies.editorService.insertTranscript(
-        normalizeTranscriptText(event),
+        text,
         this.dependencies.getSettings().insertionMode,
       );
     } catch (error) {
@@ -447,7 +454,7 @@ function createSessionId(): string {
   return `session-${Date.now()}-${Math.round(Math.random() * 1_000_000)}`;
 }
 
-function normalizeTranscriptText(event: TranscriptReadyEvent): string {
+function normalizeTranscriptText(event: TranscriptReadyEvent): string | null {
   const text = event.text.trim();
 
   if (text.length > 0) {
@@ -459,9 +466,5 @@ function normalizeTranscriptText(event: TranscriptReadyEvent): string {
     .join(' ')
     .trim();
 
-  if (fallbackText.length === 0) {
-    throw new Error('Transcription completed but returned no text.');
-  }
-
-  return fallbackText;
+  return fallbackText.length > 0 ? fallbackText : null;
 }

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -219,7 +219,7 @@ describe('DictationSessionController', () => {
     ]);
   });
 
-  it('notifies when a transcript completes with no usable text', async () => {
+  it('silently discards an empty transcript and continues the session', async () => {
     const notice = vi.fn();
     const sidecarConnection = new FakeSidecarConnection();
     const controller = createController({
@@ -241,10 +241,9 @@ describe('DictationSessionController', () => {
     });
 
     await vi.waitFor(() => {
-      expect(notice).toHaveBeenCalledWith(
-        'Failed to insert the local transcript: Transcription completed but returned no text.',
-      );
-      expect(sidecarConnection.cancelSession).toHaveBeenCalledTimes(1);
+      expect(notice).not.toHaveBeenCalled();
+      expect(sidecarConnection.cancelSession).not.toHaveBeenCalled();
+      expect(controller.getState()).not.toBe('error');
     });
   });
 


### PR DESCRIPTION
## Summary
- When VAD detects speech but Whisper returns no text (background noise, a breath), the plugin now silently discards the empty transcript and continues the session instead of treating it as a fatal error
- `normalizeTranscriptText` returns `null` instead of throwing; caller early-returns on null

Closes #29

## Test plan
- [x] Existing test updated to verify: no error notice, no cancel call, session stays active
- [x] All 120 JS tests + 65 Rust tests pass
- [x] Typecheck, lint, and build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)