### PR TITLE
fix: probe Whisper CUDA availability at runtime

### DIFF
--- a/docs/architecture/platform-runtime-dependencies.md
+++ b/docs/architecture/platform-runtime-dependencies.md
@@ -126,10 +126,10 @@ Accelerator probing lives on the `Runtime` layer (D-008). Each compiled `Runtime
 | Runtime | Probe method |
 |---|---|
 | `whisper_cpp` (Metal) | Compile-time: reports available if built with `gpu-metal` on macOS |
-| `whisper_cpp` (CUDA) | Fast heuristic: checks for `/dev/nvidiactl` and `/dev/nvidia0` device nodes |
+| `whisper_cpp` (CUDA) | Runtime probe: `dlopen`/`LoadLibrary` the CUDA runtime (`libcudart.so.12`, `libcudart.so`, or `cudart64_12.dll`), resolve `cudaGetDeviceCount`, and require at least one device |
 | `onnx_runtime` (CUDA) | Full probe: attempts ONNX Runtime CUDA EP registration via `CUDAExecutionProvider::is_available()` + `.build().error_on_failure()` |
 
-The `onnx_runtime` probe is stronger — it catches missing userspace libraries, driver mismatches, and cuDNN version issues. The `whisper_cpp` probe confirms the driver is loaded but does not verify the full library chain. If the Whisper probe reports CUDA available but inference fails, the root cause is usually a missing CUDA userspace library.
+The `onnx_runtime` probe is still stronger — it catches the full ONNX Runtime provider stack, driver mismatches, and cuDNN version issues. The `whisper_cpp` probe now verifies that the CUDA runtime library is loadable and that `cudaGetDeviceCount` can see at least one device, but it still does not validate every downstream CUDA library whisper.cpp may need during inference.
 
 ## Bundling Principles
 

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -753,6 +753,7 @@ dependencies = [
  "directories",
  "futures-util",
  "half",
+ "libloading",
  "ndarray",
  "ort",
  "realfft",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -19,6 +19,7 @@ futures-util = "0.3"
 directories = "6.0"
 ndarray = "0.17"
 half = { version = "2", optional = true, features = ["num-traits"] }
+libloading = { version = "0.8", optional = true }
 ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "download-binaries", "copy-dylibs", "ndarray", "tls-rustls"] }
 realfft = { version = "3.5", optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
@@ -33,5 +34,5 @@ default = ["engine-whisper"]
 engine-whisper = []
 engine-cohere-transcribe = ["half", "ort/half", "realfft"]
 gpu-metal = ["whisper-rs/metal"]
-gpu-cuda = ["whisper-rs/cuda"]
+gpu-cuda = ["whisper-rs/cuda", "libloading"]
 gpu-ort-cuda = ["engine-cohere-transcribe", "ort/cuda"]

--- a/native/src/runtimes/whisper_cpp.rs
+++ b/native/src/runtimes/whisper_cpp.rs
@@ -1,4 +1,9 @@
 use std::collections::HashMap;
+#[cfg(feature = "gpu-cuda")]
+use std::ffi::c_int;
+
+#[cfg(feature = "gpu-cuda")]
+use libloading::{Library, Symbol};
 
 use crate::engine::capabilities::{
     AcceleratorAvailability, AcceleratorId, ModelFormat, RuntimeCapabilities, RuntimeId,
@@ -20,7 +25,13 @@ impl WhisperCppRuntime {
         accelerator_details.insert(AcceleratorId::Metal, AcceleratorAvailability::available());
 
         #[cfg(feature = "gpu-cuda")]
-        accelerator_details.insert(AcceleratorId::Cuda, AcceleratorAvailability::available());
+        accelerator_details.insert(
+            AcceleratorId::Cuda,
+            match probe_whisper_cuda() {
+                Ok(()) => AcceleratorAvailability::available(),
+                Err(reason) => AcceleratorAvailability::unavailable(reason),
+            },
+        );
 
         Self {
             capabilities: RuntimeCapabilities::from_details(
@@ -39,4 +50,72 @@ impl Runtime for WhisperCppRuntime {
     fn capabilities(&self) -> &RuntimeCapabilities {
         &self.capabilities
     }
+}
+
+#[cfg(feature = "gpu-cuda")]
+#[cfg(target_os = "linux")]
+const CUDA_RUNTIME_LIBRARIES: &[&str] = &["libcudart.so.12", "libcudart.so"];
+
+#[cfg(feature = "gpu-cuda")]
+#[cfg(target_os = "windows")]
+const CUDA_RUNTIME_LIBRARIES: &[&str] = &["cudart64_12.dll"];
+
+#[cfg(feature = "gpu-cuda")]
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+const CUDA_RUNTIME_LIBRARIES: &[&str] = &[];
+
+#[cfg(all(feature = "gpu-cuda", target_os = "windows"))]
+type CudaGetDeviceCount = unsafe extern "system" fn(*mut c_int) -> c_int;
+
+#[cfg(all(feature = "gpu-cuda", not(target_os = "windows")))]
+type CudaGetDeviceCount = unsafe extern "C" fn(*mut c_int) -> c_int;
+
+#[cfg(feature = "gpu-cuda")]
+fn probe_whisper_cuda() -> Result<(), String> {
+    if CUDA_RUNTIME_LIBRARIES.is_empty() {
+        return Err("Whisper CUDA probing is unsupported on this platform.".to_string());
+    }
+
+    let mut last_discovery_error: Option<String> = None;
+
+    for library_name in CUDA_RUNTIME_LIBRARIES {
+        let library = match unsafe { Library::new(library_name) } {
+            Ok(library) => library,
+            Err(error) => {
+                last_discovery_error = Some(format!(
+                    "Failed to load CUDA runtime library `{library_name}`: {error}"
+                ));
+                continue;
+            }
+        };
+
+        let cuda_get_device_count: Symbol<'_, CudaGetDeviceCount> = match unsafe {
+            library.get(b"cudaGetDeviceCount")
+        } {
+            Ok(symbol) => symbol,
+            Err(error) => {
+                last_discovery_error = Some(format!(
+                    "CUDA runtime library `{library_name}` does not export `cudaGetDeviceCount`: {error}"
+                ));
+                continue;
+            }
+        };
+
+        let mut device_count: c_int = 0;
+        let error_code = unsafe { cuda_get_device_count(&mut device_count) };
+        if error_code != 0 {
+            return Err(format!(
+                "`cudaGetDeviceCount` via `{library_name}` returned error code {error_code}."
+            ));
+        }
+        if device_count == 0 {
+            return Err(format!(
+                "CUDA runtime library `{library_name}` reported no CUDA devices."
+            ));
+        }
+        return Ok(());
+    }
+
+    Err(last_discovery_error
+        .unwrap_or_else(|| "Failed to probe Whisper CUDA availability.".to_string()))
 }


### PR DESCRIPTION
## Summary
- Replace the compile-time-only `gpu-cuda` flag check in `WhisperCppRuntime::probe()` with a real runtime probe: `dlopen` the CUDA runtime, resolve `cudaGetDeviceCount`, require at least one device.
- Candidate library list: `libcudart.so.12` / `libcudart.so` on Linux, `cudart64_12.dll` on Windows (shape is Windows-correct now so the upcoming Windows PR doesn't need to revisit probe logic).
- Plugs into the existing `AcceleratorAvailability::unavailable(reason)` path — settings card and startup logs now report honest status instead of claiming CUDA on hosts without NVIDIA libraries.
- Updates `docs/architecture/platform-runtime-dependencies.md` to describe the actual probe (the old `/dev/nvidiactl` heuristic was aspirational and never implemented).
- Adds `libloading` as an optional dep gated on `gpu-cuda`.

Closes #43

## Test plan
- [x] `cargo check` (default features) — passes
- [x] `cargo check --features gpu-cuda` — passes
- [ ] Manual on Linux box with CUDA installed: sidecar reports `cuda.available: true`
- [ ] Manual on Linux box without CUDA libs on path: sidecar reports `cuda.available: false` with informative reason; settings card shows "CPU (CUDA unavailable)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)