### PR TITLE
feat(session): add session journal foundation

### DIFF
--- a/src/session/session-journal.ts
+++ b/src/session/session-journal.ts
@@ -1,0 +1,288 @@
+export type UtteranceId = string;
+
+export type StageId = 'engine' | 'hallucination_filter' | 'punctuation' | 'user_rules';
+
+export interface TranscriptSegment {
+  endMs: number;
+  speaker?: string;
+  startMs: number;
+  text: string;
+}
+
+export type StageStatus =
+  | { kind: 'failed'; error: string }
+  | { kind: 'ok' }
+  | { kind: 'skipped'; reason: string };
+
+export interface StageOutcome {
+  durationMs: number;
+  payload?: Record<string, unknown>;
+  revisionIn: number;
+  revisionOut?: number;
+  stageId: StageId;
+  status: StageStatus;
+}
+
+export interface TranscriptRevision {
+  isFinal: boolean;
+  revision: number;
+  segments: readonly TranscriptSegment[];
+  sessionId: string;
+  stageResults: readonly StageOutcome[];
+  text: string;
+  utteranceId: UtteranceId;
+}
+
+export interface ContextWindowSpec {
+  maxChars: number;
+}
+
+export interface ContextWindowSource {
+  endRevision: number;
+  kind: 'session_utterance';
+  text: string;
+  truncated: boolean;
+  utteranceId: UtteranceId;
+}
+
+export interface ContextWindow {
+  budgetChars: number;
+  sources: readonly ContextWindowSource[];
+  text: string;
+  truncated: boolean;
+}
+
+export type SessionJournalSubscriber = (revision: TranscriptRevision) => void;
+
+export type SessionJournalUpsertResult =
+  | {
+      kind: 'accepted';
+      previous?: TranscriptRevision;
+      revision: TranscriptRevision;
+    }
+  | {
+      existing: TranscriptRevision;
+      incoming: TranscriptRevision;
+      kind: 'duplicate';
+    }
+  | {
+      incoming: TranscriptRevision;
+      kind: 'stale';
+      latest: TranscriptRevision;
+    }
+  | {
+      incoming: TranscriptRevision;
+      kind: 'rejected';
+      reason: string;
+    };
+
+export class SessionJournal {
+  private readonly historyByUtterance = new Map<UtteranceId, TranscriptRevision[]>();
+  private readonly latestByUtterance = new Map<UtteranceId, TranscriptRevision>();
+  private readonly order: UtteranceId[] = [];
+  private readonly subscribers = new Set<SessionJournalSubscriber>();
+  private frozen = false;
+
+  constructor(private readonly sessionId: string) {}
+
+  upsert(incoming: TranscriptRevision): SessionJournalUpsertResult {
+    const rejectionReason = this.getRejectionReason(incoming);
+
+    if (rejectionReason !== null) {
+      return { incoming, kind: 'rejected', reason: rejectionReason };
+    }
+
+    const latest = this.latestByUtterance.get(incoming.utteranceId);
+
+    if (latest !== undefined) {
+      if (incoming.revision < latest.revision) {
+        return { incoming, kind: 'stale', latest };
+      }
+
+      if (incoming.revision === latest.revision) {
+        return { existing: latest, incoming, kind: 'duplicate' };
+      }
+    }
+
+    if (latest === undefined) {
+      this.order.push(incoming.utteranceId);
+      this.historyByUtterance.set(incoming.utteranceId, []);
+    }
+
+    const history = this.historyByUtterance.get(incoming.utteranceId);
+
+    if (history === undefined) {
+      return {
+        incoming,
+        kind: 'rejected',
+        reason: `Missing history for utterance ${incoming.utteranceId}.`,
+      };
+    }
+
+    history.push(incoming);
+    this.latestByUtterance.set(incoming.utteranceId, incoming);
+    this.notify(incoming);
+
+    if (latest === undefined) {
+      return { kind: 'accepted', revision: incoming };
+    }
+
+    return { kind: 'accepted', previous: latest, revision: incoming };
+  }
+
+  latestForUtterance(utteranceId: UtteranceId): TranscriptRevision | undefined {
+    return this.latestByUtterance.get(utteranceId);
+  }
+
+  allUtterancesInOrder(): TranscriptRevision[] {
+    return this.order
+      .map((utteranceId) => this.latestByUtterance.get(utteranceId))
+      .filter((revision): revision is TranscriptRevision => revision !== undefined);
+  }
+
+  revisionHistoryFor(utteranceId: UtteranceId): TranscriptRevision[] {
+    return [...(this.historyByUtterance.get(utteranceId) ?? [])];
+  }
+
+  subscribe(callback: SessionJournalSubscriber): () => void {
+    this.subscribers.add(callback);
+
+    return () => {
+      this.subscribers.delete(callback);
+    };
+  }
+
+  assembleContext(spec: ContextWindowSpec): ContextWindow | null {
+    const budgetChars = Math.max(0, Math.floor(spec.maxChars));
+
+    if (budgetChars === 0) {
+      return null;
+    }
+
+    const finalized = this.allUtterancesInOrder().filter((revision) => revision.isFinal);
+    const selected: ContextWindowSource[] = [];
+    let remaining = budgetChars;
+    let truncated = false;
+
+    for (let index = finalized.length - 1; index >= 0; index -= 1) {
+      const revision = finalized[index];
+
+      if (revision === undefined) {
+        continue;
+      }
+
+      const separatorChars = selected.length === 0 ? 0 : 1;
+      const availableForText = remaining - separatorChars;
+
+      if (availableForText <= 0) {
+        break;
+      }
+
+      if (revision.text.length <= availableForText) {
+        selected.unshift(toContextSource(revision, revision.text, false));
+        remaining -= revision.text.length + separatorChars;
+        continue;
+      }
+
+      if (selected.length === 0) {
+        const truncatedText = truncateAtWordBoundary(revision.text, availableForText);
+
+        if (truncatedText.length > 0) {
+          selected.unshift(toContextSource(revision, truncatedText, true));
+          truncated = true;
+        }
+      }
+
+      break;
+    }
+
+    if (selected.length === 0) {
+      return null;
+    }
+
+    return {
+      budgetChars,
+      sources: selected,
+      text: selected.map((source) => source.text).join('\n'),
+      truncated,
+    };
+  }
+
+  finalize(): void {
+    this.frozen = true;
+  }
+
+  get finalized(): boolean {
+    return this.frozen;
+  }
+
+  private getRejectionReason(revision: TranscriptRevision): string | null {
+    if (this.frozen) {
+      return 'Session journal is finalized.';
+    }
+
+    if (revision.sessionId !== this.sessionId) {
+      return `Revision session ${revision.sessionId} does not match journal session ${this.sessionId}.`;
+    }
+
+    if (revision.utteranceId.length === 0) {
+      return 'Revision utteranceId must not be empty.';
+    }
+
+    if (!Number.isInteger(revision.revision) || revision.revision < 0) {
+      return 'Revision number must be a non-negative integer.';
+    }
+
+    return null;
+  }
+
+  private notify(revision: TranscriptRevision): void {
+    for (const subscriber of this.subscribers) {
+      subscriber(revision);
+    }
+  }
+}
+
+function toContextSource(
+  revision: TranscriptRevision,
+  text: string,
+  truncated: boolean,
+): ContextWindowSource {
+  return {
+    endRevision: revision.revision,
+    kind: 'session_utterance',
+    text,
+    truncated,
+    utteranceId: revision.utteranceId,
+  };
+}
+
+function truncateAtWordBoundary(text: string, maxChars: number): string {
+  if (maxChars <= 0) {
+    return '';
+  }
+
+  const candidate = text.slice(0, maxChars).trimEnd();
+
+  if (candidate.length === text.length) {
+    return candidate;
+  }
+
+  const nextCharacter = text.charAt(candidate.length);
+
+  if (nextCharacter.length === 0 || /\s/u.test(nextCharacter)) {
+    return candidate;
+  }
+
+  let boundary = -1;
+
+  for (const match of candidate.matchAll(/\s+/gu)) {
+    boundary = match.index;
+  }
+
+  if (boundary > 0) {
+    return candidate.slice(0, boundary).trimEnd();
+  }
+
+  return '';
+}

--- a/test/session-journal.test.ts
+++ b/test/session-journal.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  SessionJournal,
+  type TranscriptRevision,
+  type UtteranceId,
+} from '../src/session/session-journal';
+
+describe('SessionJournal', () => {
+  it('accepts newer revisions and returns the previous revision', () => {
+    const journal = new SessionJournal('session-1');
+    const first = transcript({ revision: 0, text: 'rough text', utteranceId: 'u1' });
+    const second = transcript({ revision: 1, text: 'polished text', utteranceId: 'u1' });
+
+    expect(journal.upsert(first)).toEqual({ kind: 'accepted', revision: first });
+    expect(journal.upsert(second)).toEqual({
+      kind: 'accepted',
+      previous: first,
+      revision: second,
+    });
+    expect(journal.latestForUtterance('u1')).toBe(second);
+  });
+
+  it('reports duplicate and stale revisions without changing the latest revision', () => {
+    const journal = new SessionJournal('session-1');
+    const revision0 = transcript({ revision: 0, text: 'first', utteranceId: 'u1' });
+    const revision1 = transcript({ revision: 1, text: 'second', utteranceId: 'u1' });
+    const duplicate = transcript({ revision: 1, text: 'second again', utteranceId: 'u1' });
+    const stale = transcript({ revision: 0, text: 'late first', utteranceId: 'u1' });
+
+    journal.upsert(revision0);
+    journal.upsert(revision1);
+
+    expect(journal.upsert(duplicate)).toEqual({
+      existing: revision1,
+      incoming: duplicate,
+      kind: 'duplicate',
+    });
+    expect(journal.upsert(stale)).toEqual({
+      incoming: stale,
+      kind: 'stale',
+      latest: revision1,
+    });
+    expect(journal.latestForUtterance('u1')).toBe(revision1);
+    expect(journal.revisionHistoryFor('u1')).toEqual([revision0, revision1]);
+  });
+
+  it('retains revision history and returns latest utterances in dictation order', () => {
+    const journal = new SessionJournal('session-1');
+    const u1r0 = transcript({ revision: 0, text: 'one draft', utteranceId: 'u1' });
+    const u2r0 = transcript({ revision: 0, text: 'two', utteranceId: 'u2' });
+    const u1r1 = transcript({ revision: 1, text: 'one final', utteranceId: 'u1' });
+
+    journal.upsert(u1r0);
+    journal.upsert(u2r0);
+    journal.upsert(u1r1);
+
+    expect(journal.revisionHistoryFor('u1')).toEqual([u1r0, u1r1]);
+    expect(journal.allUtterancesInOrder()).toEqual([u1r1, u2r0]);
+  });
+
+  it('assembles context from finalized utterances only', () => {
+    const journal = new SessionJournal('session-1');
+
+    journal.upsert(transcript({ isFinal: true, text: 'first final', utteranceId: 'u1' }));
+    journal.upsert(transcript({ isFinal: false, text: 'partial draft', utteranceId: 'u2' }));
+    journal.upsert(transcript({ isFinal: true, text: 'third final', utteranceId: 'u3' }));
+
+    expect(journal.assembleContext({ maxChars: 100 })).toEqual({
+      budgetChars: 100,
+      sources: [
+        {
+          endRevision: 0,
+          kind: 'session_utterance',
+          text: 'first final',
+          truncated: false,
+          utteranceId: 'u1',
+        },
+        {
+          endRevision: 0,
+          kind: 'session_utterance',
+          text: 'third final',
+          truncated: false,
+          utteranceId: 'u3',
+        },
+      ],
+      text: 'first final\nthird final',
+      truncated: false,
+    });
+  });
+
+  it('selects the newest finalized utterances within budget and emits chronological text', () => {
+    const journal = new SessionJournal('session-1');
+
+    journal.upsert(transcript({ isFinal: true, text: 'old text', utteranceId: 'u1' }));
+    journal.upsert(transcript({ isFinal: true, text: 'middle text', utteranceId: 'u2' }));
+    journal.upsert(transcript({ isFinal: true, text: 'new text', utteranceId: 'u3' }));
+
+    const context = journal.assembleContext({ maxChars: 'middle text\nnew text'.length });
+
+    expect(context?.text).toBe('middle text\nnew text');
+    expect(context?.sources.map((source) => source.utteranceId)).toEqual(['u2', 'u3']);
+    expect(context?.truncated).toBe(false);
+  });
+
+  it('truncates an oversized newest utterance at a word boundary', () => {
+    const journal = new SessionJournal('session-1');
+
+    journal.upsert(
+      transcript({
+        isFinal: true,
+        text: 'alpha bravo charlie delta',
+        utteranceId: 'u1',
+      }),
+    );
+
+    const context = journal.assembleContext({ maxChars: 18 });
+
+    expect(context?.text).toBe('alpha bravo');
+    expect(context?.truncated).toBe(true);
+    expect(context?.sources).toEqual([
+      {
+        endRevision: 0,
+        kind: 'session_utterance',
+        text: 'alpha bravo',
+        truncated: true,
+        utteranceId: 'u1',
+      },
+    ]);
+  });
+
+  it('keeps a word when truncation budget ends exactly at that word boundary', () => {
+    const journal = new SessionJournal('session-1');
+
+    journal.upsert(
+      transcript({
+        isFinal: true,
+        text: 'alpha bravo charlie',
+        utteranceId: 'u1',
+      }),
+    );
+
+    expect(journal.assembleContext({ maxChars: 'alpha bravo'.length })?.text).toBe('alpha bravo');
+  });
+
+  it('returns null when no finalized utterance fits the context budget', () => {
+    const journal = new SessionJournal('session-1');
+
+    journal.upsert(transcript({ isFinal: false, text: 'draft', utteranceId: 'u1' }));
+
+    expect(journal.assembleContext({ maxChars: 100 })).toBeNull();
+    expect(journal.assembleContext({ maxChars: 0 })).toBeNull();
+  });
+
+  it('returns null rather than splitting the only available word', () => {
+    const journal = new SessionJournal('session-1');
+
+    journal.upsert(transcript({ isFinal: true, text: 'oversized', utteranceId: 'u1' }));
+
+    expect(journal.assembleContext({ maxChars: 4 })).toBeNull();
+  });
+
+  it('notifies subscribers only for accepted revisions', () => {
+    const journal = new SessionJournal('session-1');
+    const seen: TranscriptRevision[] = [];
+    const first = transcript({ text: 'first', utteranceId: 'u1' });
+    const duplicate = transcript({ text: 'duplicate', utteranceId: 'u1' });
+    const second = transcript({ text: 'second', utteranceId: 'u2' });
+    const unsubscribe = journal.subscribe((revision) => {
+      seen.push(revision);
+    });
+
+    journal.upsert(first);
+    journal.upsert(duplicate);
+    unsubscribe();
+    journal.upsert(second);
+
+    expect(seen).toEqual([first]);
+  });
+
+  it('rejects revisions after finalize freezes the journal', () => {
+    const journal = new SessionJournal('session-1');
+    const accepted = transcript({ text: 'accepted', utteranceId: 'u1' });
+    const late = transcript({ text: 'late', utteranceId: 'u2' });
+
+    journal.upsert(accepted);
+    journal.finalize();
+
+    expect(journal.finalized).toBe(true);
+    expect(journal.upsert(late)).toEqual({
+      incoming: late,
+      kind: 'rejected',
+      reason: 'Session journal is finalized.',
+    });
+    expect(journal.allUtterancesInOrder()).toEqual([accepted]);
+  });
+
+  it('rejects impossible identity and revision inputs', () => {
+    const journal = new SessionJournal('session-1');
+    const wrongSession = transcript({
+      sessionId: 'session-2',
+      text: 'wrong session',
+      utteranceId: 'u1',
+    });
+    const emptyUtterance = transcript({ text: 'empty', utteranceId: '' });
+    const invalidRevision = transcript({ revision: -1, text: 'bad revision', utteranceId: 'u2' });
+
+    expect(journal.upsert(wrongSession)).toEqual({
+      incoming: wrongSession,
+      kind: 'rejected',
+      reason: 'Revision session session-2 does not match journal session session-1.',
+    });
+    expect(journal.upsert(emptyUtterance)).toEqual({
+      incoming: emptyUtterance,
+      kind: 'rejected',
+      reason: 'Revision utteranceId must not be empty.',
+    });
+    expect(journal.upsert(invalidRevision)).toEqual({
+      incoming: invalidRevision,
+      kind: 'rejected',
+      reason: 'Revision number must be a non-negative integer.',
+    });
+  });
+});
+
+function transcript(
+  overrides: Partial<TranscriptRevision> & { text: string; utteranceId: UtteranceId },
+): TranscriptRevision {
+  return {
+    isFinal: true,
+    revision: 0,
+    segments: [{ endMs: 100, startMs: 0, text: overrides.text }],
+    sessionId: 'session-1',
+    stageResults: [
+      {
+        durationMs: 10,
+        revisionIn: 0,
+        revisionOut: overrides.revision ?? 0,
+        stageId: 'engine',
+        status: { kind: 'ok' },
+      },
+    ],
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary
- add plugin-side transcript, stage outcome, and context window types for the intelligent dictation foundation
- add SessionJournal with accepted/stale/duplicate/rejected upsert results, revision history, subscribers, and finalize freeze behavior
- add finalized-only context assembly using newest-within-budget selection with chronological output and word-boundary truncation

## Verification
- npm test -- --run test/session-journal.test.ts
- npm run typecheck
- npm run check:frontend