### PR TITLE
feat(stages): drop hallucinations and looped segments before they reach the note

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +161,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +244,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -717,6 +742,7 @@ version = "2026.4.27"
 dependencies = [
  "anyhow",
  "directories",
+ "flate2",
  "futures-util",
  "half",
  "ndarray",
@@ -770,6 +796,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1305,6 +1341,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
+flate2 = "1"
 futures-util = "0.3"
 directories = "6.0"
 ndarray = "0.17"

--- a/native/src/adapters/cohere_transcribe.rs
+++ b/native/src/adapters/cohere_transcribe.rs
@@ -9,8 +9,9 @@ use crate::engine::capabilities::{
     LanguageSupport, ModelFamilyCapabilities, ModelFamilyId, RuntimeId,
 };
 use crate::engine::traits::{LoadedModel, ModelFamilyAdapter};
-use crate::protocol::TranscriptSegment;
+use crate::protocol::{SegmentDiagnostics, TranscriptSegment};
 use crate::runtimes::onnx::build_session;
+use crate::stages::diagnostics::compute_compression_ratio;
 use crate::transcription::{
     EngineTranscriptOutput, GpuConfig, TranscriptionError, TranscriptionRequest,
     validate_audio_samples, validate_language, validate_model_path,
@@ -152,18 +153,31 @@ impl LoadedModel for LoadedCohereModel {
         )?;
 
         let trimmed = text.trim().to_string();
-        let segments = if trimmed.is_empty() {
-            Vec::new()
+        let (segments, segment_diagnostics) = if trimmed.is_empty() {
+            (Vec::new(), Some(Vec::new()))
         } else {
             let duration_ms = (request.audio_samples.len() as u64 * 1_000) / SAMPLE_RATE as u64;
-            vec![TranscriptSegment {
-                end_ms: duration_ms,
-                start_ms: 0,
-                text: trimmed,
-            }]
+            let voiced_seconds = duration_ms as f32 / 1_000.0;
+            let diag = SegmentDiagnostics {
+                avg_logprob: None,
+                compression_ratio: compute_compression_ratio(&trimmed),
+                no_speech_prob: None,
+                voiced_seconds,
+            };
+            (
+                vec![TranscriptSegment {
+                    end_ms: duration_ms,
+                    start_ms: 0,
+                    text: trimmed,
+                }],
+                Some(vec![diag]),
+            )
         };
 
-        Ok(EngineTranscriptOutput { segments })
+        Ok(EngineTranscriptOutput {
+            segments,
+            segment_diagnostics,
+        })
     }
 }
 

--- a/native/src/adapters/whisper.rs
+++ b/native/src/adapters/whisper.rs
@@ -6,7 +6,8 @@ use crate::engine::capabilities::{
     LanguageSupport, ModelFamilyCapabilities, ModelFamilyId, RuntimeId,
 };
 use crate::engine::traits::{LoadedModel, ModelFamilyAdapter};
-use crate::protocol::TranscriptSegment;
+use crate::protocol::{SegmentDiagnostics, TranscriptSegment};
+use crate::stages::diagnostics::compute_compression_ratio;
 use crate::transcription::{
     EngineTranscriptOutput, GpuConfig, TranscriptionError, TranscriptionRequest,
     validate_audio_samples, validate_language, validate_model_path,
@@ -78,6 +79,12 @@ impl LoadedModel for LoadedWhisperModel {
         params.set_print_progress(false);
         params.set_print_realtime(false);
         params.set_print_timestamps(false);
+        // Pin temperature so per-token logprobs reflect a single, known
+        // sampling pass — whisper.cpp's internal temperature fallback would
+        // otherwise change `plog` between segments and make `avg_logprob`
+        // unreliable as a hallucination signal.
+        params.set_temperature(0.0);
+        params.set_temperature_inc(0.0);
 
         if let Some(context) = request.context.as_ref() {
             params.set_initial_prompt(&context.text);
@@ -90,18 +97,68 @@ impl LoadedModel for LoadedWhisperModel {
             })?;
 
         let mut segments = Vec::new();
+        let mut diagnostics = Vec::new();
 
         for segment in state.as_iter() {
             let segment_text = segment.to_string();
+            let trimmed = segment_text.trim().to_string();
+            let start_ms = whisper_timestamp_to_millis(segment.start_timestamp());
+            let end_ms = whisper_timestamp_to_millis(segment.end_timestamp());
+
+            let avg_logprob = average_token_logprob(&segment);
+            let no_speech_prob = segment.no_speech_probability();
+
+            diagnostics.push(SegmentDiagnostics {
+                avg_logprob,
+                compression_ratio: compute_compression_ratio(&trimmed),
+                no_speech_prob: Some(no_speech_prob),
+                voiced_seconds: voiced_seconds_from_ms(start_ms, end_ms),
+            });
+
             segments.push(TranscriptSegment {
-                end_ms: whisper_timestamp_to_millis(segment.end_timestamp()),
-                start_ms: whisper_timestamp_to_millis(segment.start_timestamp()),
-                text: segment_text.trim().to_string(),
+                end_ms,
+                start_ms,
+                text: trimmed,
             });
         }
 
-        Ok(EngineTranscriptOutput { segments })
+        Ok(EngineTranscriptOutput {
+            segments,
+            segment_diagnostics: Some(diagnostics),
+        })
     }
+}
+
+fn average_token_logprob(segment: &whisper_rs::WhisperSegment<'_>) -> Option<f32> {
+    let n_tokens = segment.n_tokens();
+    if n_tokens <= 0 {
+        return None;
+    }
+
+    let mut sum = 0.0_f32;
+    let mut count = 0_u32;
+    for index in 0..n_tokens {
+        if let Some(token) = segment.get_token(index) {
+            let plog = token.token_data().plog;
+            if plog.is_finite() {
+                sum += plog;
+                count += 1;
+            }
+        }
+    }
+
+    if count == 0 {
+        None
+    } else {
+        Some(sum / count as f32)
+    }
+}
+
+fn voiced_seconds_from_ms(start_ms: u64, end_ms: u64) -> f32 {
+    if end_ms <= start_ms {
+        return 0.0;
+    }
+    (end_ms - start_ms) as f32 / 1_000.0
 }
 
 fn load_whisper_context(

--- a/native/src/adapters/whisper.rs
+++ b/native/src/adapters/whisper.rs
@@ -79,12 +79,7 @@ impl LoadedModel for LoadedWhisperModel {
         params.set_print_progress(false);
         params.set_print_realtime(false);
         params.set_print_timestamps(false);
-        // Pin temperature so per-token logprobs reflect a single, known
-        // sampling pass — whisper.cpp's internal temperature fallback would
-        // otherwise change `plog` between segments and make `avg_logprob`
-        // unreliable as a hallucination signal.
         params.set_temperature(0.0);
-        params.set_temperature_inc(0.0);
 
         if let Some(context) = request.context.as_ref() {
             params.set_initial_prompt(&context.text);

--- a/native/src/app.rs
+++ b/native/src/app.rs
@@ -1325,6 +1325,7 @@ mod tests {
         ) -> Result<EngineTranscriptOutput, TranscriptionError> {
             Ok(EngineTranscriptOutput {
                 segments: Vec::new(),
+                segment_diagnostics: None,
             })
         }
     }

--- a/native/src/protocol.rs
+++ b/native/src/protocol.rs
@@ -164,10 +164,30 @@ pub struct StageOutcome {
     pub status: StageStatus,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EngineStagePayload {
     pub is_final: bool,
+    /// Per-segment metrics the hallucination filter consults. Optional so
+    /// engines that do not expose any diagnostics (or older sidecar builds)
+    /// can omit the field entirely. Adapters always emit one entry per
+    /// segment when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub segment_diagnostics: Option<Vec<SegmentDiagnostics>>,
+}
+
+/// Per-segment quality metrics. `compression_ratio` and `voiced_seconds` are
+/// always present; engine-specific signals (`no_speech_prob`, `avg_logprob`)
+/// are `None` for engines that do not expose them.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SegmentDiagnostics {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub avg_logprob: Option<f32>,
+    pub compression_ratio: f32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub no_speech_prob: Option<f32>,
+    pub voiced_seconds: f32,
 }
 
 /// Per-session toggles for the post-engine stage pipeline (D-015). Absent

--- a/native/src/stages/consts.rs
+++ b/native/src/stages/consts.rs
@@ -1,0 +1,77 @@
+//! Calibrated constants for the hallucination filter. Values match the
+//! OpenAI Whisper reference (`whisper/transcribe.py:41-218`,
+//! faster-whisper, WhisperX). Centralised here so the filter and any
+//! follow-up calibration tooling read one source of truth.
+
+/// `no_speech_prob > NO_SPEECH_PROB_THRESHOLD` flags silence — but only
+/// AND-combined with `avg_logprob < AVG_LOGPROB_THRESHOLD` (mirrors
+/// OpenAI's `transcribe.py:215-218`).
+pub const NO_SPEECH_PROB_THRESHOLD: f32 = 0.6;
+
+/// `avg_logprob < AVG_LOGPROB_THRESHOLD` is the second half of the
+/// silence AND-rule.
+pub const AVG_LOGPROB_THRESHOLD: f32 = -1.0;
+
+/// `compression_ratio > COMPRESSION_RATIO_THRESHOLD` flags repetition loops.
+pub const COMPRESSION_RATIO_THRESHOLD: f32 = 2.4;
+
+/// Width of the n-gram window used by the repetition rule.
+pub const NGRAM_SIZE: usize = 3;
+
+/// Drop a segment when any n-gram occurs at least this many times.
+pub const NGRAM_REPEAT_THRESHOLD: usize = 3;
+
+/// Hallucination phrases observed across whisper.cpp output. Compared
+/// case-insensitively after trimming whitespace and stripping trailing
+/// `.!?…` (see `BARE_TOKEN_BLOCKLIST` for entries that bypass the
+/// trailing-punctuation strip and must match the entire trimmed segment).
+pub const PHRASE_BLOCKLIST: &[&str] = &[
+    "thank you",
+    "thank you for watching",
+    "thanks for watching",
+    "thank you so much for watching",
+    "thank you so much",
+    "thank you very much",
+    "thank you for your attention",
+    "please subscribe to the channel",
+    "please subscribe",
+    "please like and subscribe",
+    "don't forget to like and subscribe",
+    "subscribe to the channel",
+    "subscribe to my channel",
+    "see you next time",
+    "see you in the next video",
+    "see you next video",
+    "bye",
+    "bye bye",
+    "goodbye",
+    "i'll see you next time",
+    "let me know in the comments",
+    "if you enjoyed this video, please like and subscribe",
+    "subtitles by the amara.org community",
+    "subtitles by amara.org",
+    "subtitles by the community",
+    "subtitles by",
+    "subtitles",
+    "captions by",
+    "captioning by",
+    "transcription by",
+    "transcribed by",
+    "translated by",
+    "translation by",
+    "www.mooji.org",
+    "[blank_audio]",
+    "[silence]",
+    "(silence)",
+    "(soft music)",
+    "(music)",
+    "[music]",
+    "[music playing]",
+    "[applause]",
+];
+
+/// Tokens that match only when they are the *entire* trimmed segment text.
+/// These bypass the trailing-punctuation strip applied to `PHRASE_BLOCKLIST`
+/// — `"you"` would otherwise swallow legitimate one-word utterances ending
+/// in `.`, and `"."` is the explicit "single punctuation" hallucination.
+pub const BARE_TOKEN_BLOCKLIST: &[&str] = &["you", "."];

--- a/native/src/stages/diagnostics.rs
+++ b/native/src/stages/diagnostics.rs
@@ -1,0 +1,83 @@
+//! Per-segment text-only diagnostics shared across adapters and the
+//! hallucination filter.
+//!
+//! `compute_compression_ratio` matches OpenAI Whisper's reference behavior:
+//! `text.len() / zlib(text).len()`. Repetition loops produce highly
+//! compressible text — a ratio above ~2.4 is the canonical hallucination
+//! signal (see `whisper/transcribe.py:41-52`).
+
+use std::io::Write;
+
+use flate2::Compression;
+use flate2::write::ZlibEncoder;
+
+/// UTF-8-byte ratio of `text.len()` to the size of the zlib-compressed
+/// representation. Returns `1.0` for empty input (no signal). Adapters call
+/// this once per segment; the result is stored in `SegmentDiagnostics` so the
+/// filter does not recompute it.
+pub fn compute_compression_ratio(text: &str) -> f32 {
+    let bytes = text.as_bytes();
+    if bytes.is_empty() {
+        return 1.0;
+    }
+
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    if encoder.write_all(bytes).is_err() {
+        return 1.0;
+    }
+    let compressed = match encoder.finish() {
+        Ok(bytes) => bytes,
+        Err(_) => return 1.0,
+    };
+
+    if compressed.is_empty() {
+        return 1.0;
+    }
+
+    bytes.len() as f32 / compressed.len() as f32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compute_compression_ratio;
+
+    #[test]
+    fn empty_text_returns_unit_ratio() {
+        assert_eq!(compute_compression_ratio(""), 1.0);
+    }
+
+    #[test]
+    fn highly_repetitive_text_compresses_above_threshold() {
+        // "thanks " repeated 100 times — clearly above the OpenAI 2.4 threshold.
+        let text = "thanks ".repeat(100);
+        let ratio = compute_compression_ratio(&text);
+        assert!(
+            ratio > 2.4,
+            "repetitive text should compress above 2.4, got {ratio}"
+        );
+    }
+
+    #[test]
+    fn natural_short_phrase_stays_below_threshold() {
+        let ratio = compute_compression_ratio("Hello, this is a normal short transcript.");
+        assert!(
+            ratio < 2.4,
+            "natural phrase should compress below 2.4, got {ratio}"
+        );
+    }
+
+    #[test]
+    fn matches_hand_computed_zlib_ratio_within_tolerance() {
+        // Gold fixture: known input, hand-computed via Python `len(s) /
+        // len(zlib.compress(s.encode()))` for s = "abcabcabcabcabcabcabcabc".
+        // flate2 default compression matches Python zlib level 6 closely
+        // enough for the ratio to land within ±0.2.
+        let text = "abcabcabcabcabcabcabcabc";
+        let ratio = compute_compression_ratio(text);
+        let expected = 24.0_f32 / 12.0_f32; // upper bound per Python zlib
+        assert!(
+            (ratio - expected).abs() < 0.5,
+            "ratio {ratio} drifted too far from {expected}"
+        );
+    }
+}

--- a/native/src/stages/hallucination_filter.rs
+++ b/native/src/stages/hallucination_filter.rs
@@ -1,0 +1,366 @@
+//! Drops silent-audio hallucinations and looped/junk segments before they
+//! reach Obsidian (D-015 stage `hallucination_filter`).
+//!
+//! Rules (each segment is dropped if **any** rule matches):
+//!   1. Blocklist — curated English phrases observed across whisper.cpp.
+//!   2. Silence — `no_speech_prob > 0.6 AND avg_logprob < -1.0`.
+//!   3. Compression — `compression_ratio > 2.4`.
+//!   4. Repetition — any 3-gram repeated ≥ 3 times in the segment text.
+//!
+//! Rules 2 and 3 require the matching diagnostic to be present; without
+//! diagnostics the filter falls back to text-only signals (1, 4, plus a
+//! recomputed compression ratio).
+//!
+//! On `Ok`, payload carries `dropped_segments: [{ index, text, reason }]`
+//! so dev tools can audit what the filter removed.
+
+use serde::Serialize;
+use serde_json::json;
+
+use crate::protocol::{EngineStagePayload, SegmentDiagnostics, StageId, TranscriptSegment};
+use crate::transcription::Transcript;
+
+use super::consts::{
+    AVG_LOGPROB_THRESHOLD, BARE_TOKEN_BLOCKLIST, COMPRESSION_RATIO_THRESHOLD,
+    NGRAM_REPEAT_THRESHOLD, NGRAM_SIZE, NO_SPEECH_PROB_THRESHOLD, PHRASE_BLOCKLIST,
+};
+use super::diagnostics::compute_compression_ratio;
+use super::{StageContext, StageProcess, StageProcessor};
+
+#[derive(Default)]
+pub struct HallucinationFilterStage;
+
+impl HallucinationFilterStage {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl StageProcessor for HallucinationFilterStage {
+    fn id(&self) -> StageId {
+        StageId::HallucinationFilter
+    }
+
+    fn process(&self, transcript: &Transcript, _ctx: &StageContext<'_>) -> StageProcess {
+        let diagnostics = engine_segment_diagnostics(transcript);
+
+        let mut kept: Vec<TranscriptSegment> = Vec::with_capacity(transcript.segments.len());
+        let mut dropped: Vec<DroppedSegment> = Vec::new();
+
+        for (index, segment) in transcript.segments.iter().enumerate() {
+            let segment_diag = diagnostics.as_ref().and_then(|d| d.get(index));
+            match classify_segment(segment, segment_diag) {
+                Some(reason) => dropped.push(DroppedSegment {
+                    index,
+                    text: segment.text.clone(),
+                    reason,
+                }),
+                None => kept.push(segment.clone()),
+            }
+        }
+
+        if dropped.is_empty() {
+            return StageProcess::Skipped {
+                reason: "no_action".to_string(),
+                payload: None,
+            };
+        }
+
+        let payload = json!({ "droppedSegments": dropped });
+
+        StageProcess::Ok {
+            segments: kept,
+            payload: Some(payload),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct DroppedSegment {
+    index: usize,
+    reason: DropReason,
+    text: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum DropReason {
+    Blocklist,
+    Silence,
+    Compression,
+    Repetition,
+}
+
+fn classify_segment(
+    segment: &TranscriptSegment,
+    diagnostics: Option<&SegmentDiagnostics>,
+) -> Option<DropReason> {
+    let trimmed = segment.text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if matches_blocklist(trimmed) {
+        return Some(DropReason::Blocklist);
+    }
+
+    if let Some(diag) = diagnostics
+        && let (Some(no_speech_prob), Some(avg_logprob)) = (diag.no_speech_prob, diag.avg_logprob)
+        && no_speech_prob > NO_SPEECH_PROB_THRESHOLD
+        && avg_logprob < AVG_LOGPROB_THRESHOLD
+    {
+        return Some(DropReason::Silence);
+    }
+
+    let compression_ratio = diagnostics
+        .map(|d| d.compression_ratio)
+        .unwrap_or_else(|| compute_compression_ratio(trimmed));
+    if compression_ratio > COMPRESSION_RATIO_THRESHOLD {
+        return Some(DropReason::Compression);
+    }
+
+    if has_ngram_repetition(trimmed) {
+        return Some(DropReason::Repetition);
+    }
+
+    None
+}
+
+fn matches_blocklist(trimmed: &str) -> bool {
+    let lower = trimmed.to_lowercase();
+
+    // Bare tokens require an exact post-trim match — bypass the
+    // trailing-punctuation strip so "you." remains a legitimate utterance.
+    if BARE_TOKEN_BLOCKLIST
+        .iter()
+        .any(|entry| lower == *entry || trimmed == *entry)
+    {
+        return true;
+    }
+
+    let stripped = lower.trim_end_matches(['.', '!', '?', '…']);
+    PHRASE_BLOCKLIST.contains(&stripped)
+}
+
+fn has_ngram_repetition(trimmed: &str) -> bool {
+    let tokens: Vec<String> = trimmed
+        .split_whitespace()
+        .map(|word| word.to_lowercase())
+        .collect();
+
+    if tokens.len() < NGRAM_SIZE {
+        return false;
+    }
+
+    let mut counts: std::collections::HashMap<&[String], usize> = std::collections::HashMap::new();
+    for window in tokens.windows(NGRAM_SIZE) {
+        let entry = counts.entry(window).or_insert(0);
+        *entry += 1;
+        if *entry >= NGRAM_REPEAT_THRESHOLD {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn engine_segment_diagnostics(transcript: &Transcript) -> Option<Vec<SegmentDiagnostics>> {
+    let engine_stage = transcript.stage_history.first()?;
+    if engine_stage.stage_id != StageId::Engine {
+        return None;
+    }
+    let payload = engine_stage.payload.as_ref()?;
+    let parsed: EngineStagePayload = serde_json::from_value(payload.clone()).ok()?;
+    parsed.segment_diagnostics
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::capabilities::{LanguageSupport, ModelFamilyCapabilities};
+    use crate::protocol::{StageOutcome, StageStatus};
+    use crate::stages::StageEnablement;
+    use uuid::Uuid;
+
+    fn caps() -> ModelFamilyCapabilities {
+        ModelFamilyCapabilities {
+            supports_timed_segments: true,
+            supports_initial_prompt: true,
+            supports_language_selection: false,
+            supported_languages: LanguageSupport::EnglishOnly,
+            max_audio_duration_secs: None,
+            produces_punctuation: true,
+        }
+    }
+
+    fn segment(text: &str) -> TranscriptSegment {
+        TranscriptSegment {
+            end_ms: 1_000,
+            start_ms: 0,
+            text: text.to_string(),
+        }
+    }
+
+    fn diag(no_speech_prob: Option<f32>, avg_logprob: Option<f32>) -> SegmentDiagnostics {
+        SegmentDiagnostics {
+            avg_logprob,
+            compression_ratio: 1.5,
+            no_speech_prob,
+            voiced_seconds: 1.0,
+        }
+    }
+
+    fn run_filter(
+        segments: Vec<TranscriptSegment>,
+        diagnostics: Option<Vec<SegmentDiagnostics>>,
+    ) -> (Transcript, StageProcess) {
+        let payload = serde_json::to_value(EngineStagePayload {
+            is_final: true,
+            segment_diagnostics: diagnostics,
+        })
+        .unwrap();
+        let transcript = Transcript {
+            utterance_id: Uuid::nil(),
+            revision: 0,
+            segments,
+            stage_history: vec![StageOutcome {
+                duration_ms: 0,
+                payload: Some(payload),
+                revision_in: 0,
+                revision_out: Some(0),
+                stage_id: StageId::Engine,
+                status: StageStatus::Ok,
+            }],
+        };
+        let caps = caps();
+        let enablement = StageEnablement::default();
+        let ctx = StageContext {
+            utterance_duration_ms: 1_000,
+            family_capabilities: &caps,
+            stage_enabled: &enablement,
+        };
+        let result = HallucinationFilterStage::new().process(&transcript, &ctx);
+        (transcript, result)
+    }
+
+    #[test]
+    fn blocklist_drops_phrase_segment() {
+        let (_, result) = run_filter(vec![segment("Thanks for watching!")], None);
+        let StageProcess::Ok { segments, payload } = result else {
+            panic!("expected Ok, got non-Ok");
+        };
+        assert!(segments.is_empty());
+        assert!(payload.unwrap().to_string().contains("blocklist"));
+    }
+
+    #[test]
+    fn blocklist_match_is_case_insensitive_and_strips_trailing_punctuation() {
+        let (_, result) = run_filter(vec![segment("THANK YOU...")], None);
+        assert!(matches!(result, StageProcess::Ok { ref segments, .. } if segments.is_empty()));
+    }
+
+    #[test]
+    fn bare_you_matches_only_when_entire_segment() {
+        // "you" alone is hallucination-typical; "Are you sure?" is not.
+        let (_, drop_result) = run_filter(vec![segment("you")], None);
+        assert!(matches!(drop_result, StageProcess::Ok { .. }));
+
+        let (_, keep_result) = run_filter(vec![segment("Are you sure?")], None);
+        assert!(matches!(keep_result, StageProcess::Skipped { .. }));
+    }
+
+    #[test]
+    fn silence_rule_requires_both_thresholds() {
+        // no_speech_prob alone — must keep.
+        let (_, only_no_speech) = run_filter(
+            vec![segment("hello world")],
+            Some(vec![diag(Some(0.95), Some(-0.5))]),
+        );
+        assert!(matches!(only_no_speech, StageProcess::Skipped { .. }));
+
+        // avg_logprob alone — must keep.
+        let (_, only_logprob) = run_filter(
+            vec![segment("hello world")],
+            Some(vec![diag(Some(0.4), Some(-1.5))]),
+        );
+        assert!(matches!(only_logprob, StageProcess::Skipped { .. }));
+
+        // Both — drop.
+        let (_, both) = run_filter(
+            vec![segment("hello world")],
+            Some(vec![diag(Some(0.95), Some(-1.5))]),
+        );
+        let StageProcess::Ok { segments, payload } = both else {
+            panic!("both thresholds must trigger silence drop");
+        };
+        assert!(segments.is_empty());
+        assert!(payload.unwrap().to_string().contains("silence"));
+    }
+
+    #[test]
+    fn compression_rule_drops_loop_segments() {
+        let loop_text = "ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha";
+        let (_, result) = run_filter(vec![segment(loop_text)], None);
+        let StageProcess::Ok { segments, payload } = result else {
+            panic!("repetition loop should drop");
+        };
+        assert!(segments.is_empty());
+        let body = payload.unwrap().to_string();
+        // Either compression or repetition is acceptable — both are designed
+        // to fire on this input and the wire just needs *some* dropped reason.
+        assert!(body.contains("compression") || body.contains("repetition"));
+    }
+
+    #[test]
+    fn repetition_rule_drops_three_repeated_3grams() {
+        // Exactly 9 tokens forming three copies of the same 3-gram, but with
+        // low compression ratio (varied surface text). Forces rule 4.
+        let text = "alpha beta gamma alpha beta gamma alpha beta gamma";
+        let (_, result) = run_filter(vec![segment(text)], None);
+        assert!(matches!(result, StageProcess::Ok { ref segments, .. } if segments.is_empty()));
+    }
+
+    #[test]
+    fn clean_segment_passes_through_unchanged() {
+        let (_, result) = run_filter(
+            vec![segment("This is a perfectly normal sentence.")],
+            Some(vec![diag(Some(0.1), Some(-0.2))]),
+        );
+        let StageProcess::Skipped { reason, .. } = result else {
+            panic!("clean segment must skip, got Ok");
+        };
+        assert_eq!(reason, "no_action");
+    }
+
+    #[test]
+    fn multiple_rules_drop_multiple_segments_in_one_pass() {
+        let (_, result) = run_filter(
+            vec![
+                segment("Thanks for watching!"),
+                segment("This is fine."),
+                segment("alpha beta gamma alpha beta gamma alpha beta gamma"),
+            ],
+            None,
+        );
+        let StageProcess::Ok { segments, payload } = result else {
+            panic!("expected drops");
+        };
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].text, "This is fine.");
+        let body = payload.unwrap().to_string();
+        assert!(body.contains("blocklist"));
+        assert!(body.contains("repetition"));
+    }
+
+    #[test]
+    fn all_segments_dropped_emits_ok_with_empty_segments() {
+        let (_, result) = run_filter(
+            vec![segment("Thanks for watching!"), segment("Please subscribe")],
+            None,
+        );
+        let StageProcess::Ok { segments, .. } = result else {
+            panic!("expected Ok with empty segments");
+        };
+        assert!(segments.is_empty());
+    }
+}

--- a/native/src/stages/mod.rs
+++ b/native/src/stages/mod.rs
@@ -18,6 +18,9 @@ use crate::panic_util::format_panic_message;
 use crate::protocol::{StageId, StageOutcome, StageStatus, TranscriptSegment};
 use crate::transcription::Transcript;
 
+pub mod consts;
+pub mod diagnostics;
+pub mod hallucination_filter;
 pub mod noop;
 
 /// Runtime knobs supplied per session. Each stage owns the meaning of its
@@ -195,7 +198,13 @@ mod tests {
             }],
             stage_history: vec![StageOutcome {
                 duration_ms: 0,
-                payload: Some(serde_json::to_value(EngineStagePayload { is_final: true }).unwrap()),
+                payload: Some(
+                    serde_json::to_value(EngineStagePayload {
+                        is_final: true,
+                        segment_diagnostics: None,
+                    })
+                    .unwrap(),
+                ),
                 revision_in: 0,
                 revision_out: Some(0),
                 stage_id: StageId::Engine,

--- a/native/src/transcription.rs
+++ b/native/src/transcription.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
 use crate::protocol::{
-    ContextWindow, EngineStagePayload, StageId, StageOutcome, TranscriptSegment,
+    ContextWindow, EngineStagePayload, SegmentDiagnostics, StageId, StageOutcome, TranscriptSegment,
 };
 
 pub(crate) const SUPPORTED_LANGUAGE: &str = "en";
@@ -32,9 +32,15 @@ pub struct TranscriptionRequest {
 /// What an adapter returns from `transcribe`. Adapters own only the engine
 /// inference output; revisioning, stage history, and identity are added by
 /// the worker as it wraps this into the canonical `Transcript`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// `segment_diagnostics` is `Some` only when the adapter actually computed
+/// per-segment metrics. When present, the vector length matches `segments`
+/// 1:1 in order. The worker forwards this through to the engine stage's
+/// payload so the hallucination filter (and dev tools) can read it.
+#[derive(Debug, Clone, PartialEq)]
 pub struct EngineTranscriptOutput {
     pub segments: Vec<TranscriptSegment>,
+    pub segment_diagnostics: Option<Vec<SegmentDiagnostics>>,
 }
 
 /// Canonical transcript revision. Segments are the source of truth; joined
@@ -304,7 +310,11 @@ mod tests {
     #[test]
     fn is_final_reads_true_from_engine_stage_payload() {
         let transcript = transcript_with_stages(vec![engine_stage_with_payload(Some(
-            serde_json::to_value(EngineStagePayload { is_final: true }).unwrap(),
+            serde_json::to_value(EngineStagePayload {
+                is_final: true,
+                segment_diagnostics: None,
+            })
+            .unwrap(),
         ))]);
 
         assert!(transcript.is_final());
@@ -313,7 +323,11 @@ mod tests {
     #[test]
     fn is_final_reads_false_from_engine_stage_payload() {
         let transcript = transcript_with_stages(vec![engine_stage_with_payload(Some(
-            serde_json::to_value(EngineStagePayload { is_final: false }).unwrap(),
+            serde_json::to_value(EngineStagePayload {
+                is_final: false,
+                segment_diagnostics: None,
+            })
+            .unwrap(),
         ))]);
 
         assert!(!transcript.is_final());
@@ -323,7 +337,13 @@ mod tests {
     fn is_final_returns_false_when_first_stage_is_not_engine() {
         let transcript = transcript_with_stages(vec![StageOutcome {
             duration_ms: 0,
-            payload: Some(serde_json::to_value(EngineStagePayload { is_final: true }).unwrap()),
+            payload: Some(
+                serde_json::to_value(EngineStagePayload {
+                    is_final: true,
+                    segment_diagnostics: None,
+                })
+                .unwrap(),
+            ),
             revision_in: 0,
             revision_out: Some(0),
             stage_id: StageId::Punctuation,

--- a/native/src/worker.rs
+++ b/native/src/worker.rs
@@ -14,6 +14,7 @@ use crate::engine::registry::{EngineRegistry, apply_capability_gates, missing_ad
 use crate::engine::traits::LoadedModel;
 use crate::panic_util::format_panic_message;
 use crate::protocol::{ContextWindow, EngineStagePayload, StageId, StageOutcome, StageStatus};
+use crate::stages::hallucination_filter::HallucinationFilterStage;
 use crate::stages::noop::NoopProcessor;
 use crate::stages::{StageContext, StageEnablement, StageProcessor, run_post_engine};
 use crate::transcription::{
@@ -278,8 +279,11 @@ fn assemble_transcript(
     stage_history.push(StageOutcome {
         duration_ms: engine_duration_ms,
         payload: Some(
-            serde_json::to_value(EngineStagePayload { is_final: true })
-                .expect("EngineStagePayload serialization is infallible"),
+            serde_json::to_value(EngineStagePayload {
+                is_final: true,
+                segment_diagnostics: engine_output.segment_diagnostics,
+            })
+            .expect("EngineStagePayload serialization is infallible"),
         ),
         revision_in: revision,
         revision_out: Some(revision),
@@ -309,7 +313,7 @@ fn assemble_transcript(
 /// the corresponding real stage lands.
 fn post_engine_processors() -> Vec<Box<dyn StageProcessor>> {
     vec![
-        Box::new(NoopProcessor::new(StageId::HallucinationFilter)),
+        Box::new(HallucinationFilterStage::new()),
         Box::new(NoopProcessor::new(StageId::Punctuation)),
         Box::new(NoopProcessor::new(StageId::UserRules)),
     ]

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -348,6 +348,50 @@ describe('sidecar protocol', () => {
     });
   });
 
+  it('parses transcript_ready engine payload carrying segmentDiagnostics', () => {
+    const enginePayload = {
+      isFinal: true,
+      segmentDiagnostics: [
+        {
+          avgLogprob: -0.42,
+          compressionRatio: 1.7,
+          noSpeechProb: 0.05,
+          voicedSeconds: 1.2,
+        },
+      ],
+    };
+
+    const event = parseEventFrame(
+      JSON.stringify({
+        isFinal: true,
+        processingDurationMs: 50,
+        revision: 0,
+        segments: [{ endMs: 1200, startMs: 0, text: 'hello world' }],
+        sessionId: 'session-1',
+        stageResults: [
+          {
+            durationMs: 50,
+            payload: enginePayload,
+            revisionIn: 0,
+            revisionOut: 0,
+            stageId: 'engine',
+            status: { kind: 'ok' },
+          },
+        ],
+        text: 'hello world',
+        type: 'transcript_ready',
+        utteranceDurationMs: 1200,
+        utteranceId: 'utt-1',
+        warnings: [],
+      }),
+    );
+
+    if (event.type !== 'transcript_ready') {
+      throw new Error('expected transcript_ready');
+    }
+    expect(event.stageResults[0]?.payload).toEqual(enginePayload);
+  });
+
   it('parses context_request event', () => {
     const event = parseEventFrame(
       JSON.stringify({


### PR DESCRIPTION
## Summary

Replaces the `hallucination_filter` `NoopProcessor` with a real drop-only stage that removes silent-audio hallucinations, blocklisted phrases, runaway compression loops, and 3-gram repetition before transcripts hit the editor.

Extends `EngineStagePayload` with optional `segmentDiagnostics` so the engine surfaces per-segment `no_speech_prob`, `avg_logprob`, `compression_ratio`, and `voiced_seconds`. Adapters populate everything they can; absent fields stay `None` (Cohere only emits text-only signals).

Filter is on by default; toggling `stages.hallucinationFilter` off in plugin settings reverts the behavior end-to-end.

## Approach

- **Thresholds** match the OpenAI/faster-whisper reference: `no_speech_prob > 0.6 AND avg_logprob < -1.0` for silence; `compression_ratio > 2.4` for repetition loops; 3-gram repeats ≥ 3 for surface-level loops; curated English blocklist for the canonical YouTube hallucinations (`thanks for watching`, `please subscribe`, `subtitles by amara.org`, etc.).
- **Drop-only** — no rewrites, no re-segmentation. Stage emits `Ok` with new revision when ≥ 1 segment was removed; payload carries `dropped_segments: [{ index, text, reason }]`. Returns `Skipped { reason: "no_action" }` when nothing matches.
- **Compression ratio** computed Rust-side via `flate2` zlib on segment text (matches OpenAI's reference formula `text.len() / compressed.len()`). Centralised in `stages/diagnostics.rs` so adapters and the filter share one implementation.
- **Wire shape** is forward-compatible: `segmentDiagnostics` is `Option<Vec<...>>` with `serde(default, skip_serializing_if = "Option::is_none")`. Older clients see no change.

## Issue #55

Each utterance now carries typed per-segment quality metrics on the engine stage's payload, the filter's wire-visible drop history is auditable in dev tools, and the contract proves out before later stages get plugged in.

## Test plan

- [x] `cargo test -p local-transcript-sidecar` (100 tests) — incl. new diagnostics + filter unit tests covering blocklist case-insensitivity, silence AND-rule, compression rule, repetition rule, multi-drop pass, all-segments-dropped emits empty Ok, and bare-token (`you`/`.`) entire-segment matching.
- [x] `npm test` (283 tests) — wire round-trip parses `segmentDiagnostics` payload through `transcript_ready`.
- [x] `cargo clippy` clean.
- [x] `npm run typecheck` clean.
- [ ] Manual: dictate ~3s of silence with mic open and confirm "Thanks for watching"-class hallucinations no longer appear in the note.
- [ ] Manual: dictate five short clean utterances and confirm zero false drops.