### PR TITLE
feat(stages): hallucination filter v2 (HARD/SOFT + corroboration)

### DIFF
--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -326,6 +326,16 @@ Cargo features: `engine-whisper`, `engine-cohere-transcribe`, `gpu-metal`, `gpu-
 
 During inference, the preset's silence window (400–2000 ms) is fully overlapped with model compute — on smaller models the user is typically still pausing when inference completes.
 
+### Stage 4.5: Hallucination Filter
+
+The first post-engine stage is a conservative hallucination filter in the Rust sidecar. It drops only whole segments and preserves the original timing boundaries for all retained segments. If nothing is dropped, the stage records `Skipped { reason: "no_hallucinations" }`; if segments are dropped, it emits a new revision plus a compact payload under the hallucination-filter stage result.
+
+Signals are segment-aligned and stay in-process unless a drop payload is emitted. Whisper contributes `no_speech_prob`, average token log probability, and token count. Cohere contributes selected-token average log probability, token count, and whether autoregressive decoding reached EOS. The stage combines those model diagnostics with per-segment voiced fraction from the Silero probability trace and utterance-level VAD evidence.
+
+Rules are intentionally narrow. Hard text artifacts such as empty text, punctuation-only output, known bracketed non-speech tags, and caption/source attributions can drop on text alone. Soft artifacts such as courtesy endings, CTAs, bare `you`, and URL-like segments require corroborating model or VAD evidence. Normal-looking text drops as silence only when Whisper silence and VAD silence are both strong. Repetition and prompt-leak rules also require corroboration. Partial revisions run only the hard text subset.
+
+Dropped segment payloads include the reason, raw text, timing provenance, and compact signals. Developer mode logs those payloads to the console for local tuning; normal mode does not surface hallucination diagnostics in user-visible transcript text.
+
 ---
 
 ### Stage 5: Text Insertion

--- a/native/src/adapters/cohere_transcribe.rs
+++ b/native/src/adapters/cohere_transcribe.rs
@@ -12,8 +12,8 @@ use crate::engine::traits::{LoadedModel, ModelFamilyAdapter};
 use crate::protocol::{TimestampGranularity, TimestampSource, TranscriptSegment};
 use crate::runtimes::onnx::build_session;
 use crate::transcription::{
-    EngineTranscriptOutput, GpuConfig, TranscriptionError, TranscriptionRequest,
-    validate_audio_samples, validate_language, validate_model_path,
+    EngineTranscriptOutput, GpuConfig, SegmentDiagnostics, TranscriptionError,
+    TranscriptionRequest, validate_audio_samples, validate_language, validate_model_path,
 };
 
 const NUM_DECODER_LAYERS: usize = 8;
@@ -143,7 +143,7 @@ impl LoadedModel for LoadedCohereModel {
             TranscriptionError::transcription_failure("encoder", "produced no output")
         })?;
 
-        let text = autoregressive_decode(
+        let decode = autoregressive_decode(
             &mut self.decoder,
             &encoder_hidden,
             &self.vocab,
@@ -152,7 +152,7 @@ impl LoadedModel for LoadedCohereModel {
             &self.prompt_tokens,
         )?;
 
-        let trimmed = text.trim().to_string();
+        let trimmed = decode.text.trim().to_string();
         let segments = if trimmed.is_empty() {
             Vec::new()
         } else {
@@ -165,8 +165,21 @@ impl LoadedModel for LoadedCohereModel {
                 timestamp_source: TimestampSource::Vad,
             }]
         };
+        let diagnostics = if segments.is_empty() {
+            Vec::new()
+        } else {
+            vec![SegmentDiagnostics {
+                avg_logprob: decode.avg_logprob,
+                decode_reached_eos: Some(decode.reached_eos),
+                no_speech_prob: None,
+                token_count: Some(decode.token_count),
+            }]
+        };
 
-        Ok(EngineTranscriptOutput { segments })
+        Ok(EngineTranscriptOutput {
+            segments,
+            diagnostics,
+        })
     }
 }
 
@@ -495,6 +508,13 @@ fn decode_bpe_bytes(text: &str) -> String {
 
 type NamedInput<'v> = (Cow<'v, str>, SessionInputValue<'v>);
 
+struct DecodeResult {
+    avg_logprob: Option<f32>,
+    reached_eos: bool,
+    text: String,
+    token_count: u32,
+}
+
 fn autoregressive_decode(
     decoder: &mut Session,
     encoder_hidden: &DynValue,
@@ -502,10 +522,13 @@ fn autoregressive_decode(
     cache_names: &[String],
     use_fp16: bool,
     prompt: &[i64],
-) -> Result<String, TranscriptionError> {
+) -> Result<DecodeResult, TranscriptionError> {
     let mut generated_ids: Vec<i64> = Vec::new();
     let mut kv_cache: Option<Vec<DynValue>> = None;
     let mut past_seq_len: i64 = 0;
+    let mut reached_eos = false;
+    let mut logprob_sum = 0.0_f32;
+    let mut logprob_count = 0_u32;
 
     for step in 0..MAX_SEQ_LEN {
         let input_ids: Vec<i64> = if step == 0 {
@@ -572,13 +595,16 @@ fn autoregressive_decode(
             TranscriptionError::transcription_failure("decoder", "produced no output")
         })?;
 
-        let best_id = greedy_argmax(&logits_value)?;
+        let (best_id, selected_logprob) = greedy_argmax_with_logprob(&logits_value)?;
 
         if best_id == TOKEN_END_OF_TRANSCRIPT {
+            reached_eos = true;
             break;
         }
 
         generated_ids.push(best_id);
+        logprob_sum += selected_logprob;
+        logprob_count += 1;
         past_seq_len += seq_len as i64;
 
         let new_cache: Vec<DynValue> = output_iter.map(|(_, v)| v).collect();
@@ -587,10 +613,15 @@ fn autoregressive_decode(
         }
     }
 
-    Ok(detokenize(&generated_ids, vocab))
+    Ok(DecodeResult {
+        avg_logprob: (logprob_count > 0).then_some(logprob_sum / logprob_count as f32),
+        reached_eos,
+        text: detokenize(&generated_ids, vocab),
+        token_count: generated_ids.len() as u32,
+    })
 }
 
-fn greedy_argmax(logits_value: &DynValue) -> Result<i64, TranscriptionError> {
+fn greedy_argmax_with_logprob(logits_value: &DynValue) -> Result<(i64, f32), TranscriptionError> {
     if let Ok((shape, data)) = logits_value.try_extract_tensor::<f32>() {
         return argmax_from_logits(shape, data);
     }
@@ -601,7 +632,7 @@ fn greedy_argmax(logits_value: &DynValue) -> Result<i64, TranscriptionError> {
     argmax_from_logits(shape, &data_f32)
 }
 
-fn argmax_from_logits(dims: &[i64], logits_data: &[f32]) -> Result<i64, TranscriptionError> {
+fn argmax_from_logits(dims: &[i64], logits_data: &[f32]) -> Result<(i64, f32), TranscriptionError> {
     if dims.len() != 3 || dims[0] != 1 {
         return Err(TranscriptionError::transcription_failure(
             "logits shape",
@@ -618,20 +649,39 @@ fn argmax_from_logits(dims: &[i64], logits_data: &[f32]) -> Result<i64, Transcri
         ));
     }
 
+    // Fused argmax + streaming logsumexp in one O(vocab) pass: as we scan, we
+    // maintain `sum_exp = Σ exp(x_i - running_max)` and rescale when a new max
+    // appears. Because the chosen token's score equals the running max,
+    // `selected_logprob = best_score - logsumexp = -ln(sum_exp)`. Pre-fix this
+    // was three passes (argmax + max + sum) over a 64k vocab per decoded token.
     let last_pos = seq_len - 1;
     let logits_offset = last_pos * vocab_size;
+    let logits = &logits_data[logits_offset..logits_offset + vocab_size];
+
     let mut best_id: i64 = 0;
     let mut best_score = f32::NEG_INFINITY;
+    let mut sum_exp: f32 = 0.0;
 
-    for v in 0..vocab_size {
-        let score = logits_data[logits_offset + v];
+    for (v, &score) in logits.iter().enumerate() {
         if score > best_score {
+            sum_exp = if best_score.is_finite() {
+                sum_exp * (best_score - score).exp() + 1.0
+            } else {
+                1.0
+            };
             best_score = score;
             best_id = v as i64;
+        } else {
+            sum_exp += (score - best_score).exp();
         }
     }
 
-    Ok(best_id)
+    let selected_logprob = if best_score.is_finite() {
+        -sum_exp.ln()
+    } else {
+        f32::NEG_INFINITY
+    };
+    Ok((best_id, selected_logprob))
 }
 
 fn build_prompt_tokens() -> Vec<i64> {
@@ -860,6 +910,38 @@ mod tests {
         assert_eq!(vocab.get(&1), Some(&" world".to_string()));
 
         let _ = std::fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn argmax_from_logits_returns_index_and_token_logprob() {
+        // Three-class softmax: scores [1.0, 2.0, 3.0]. Expected logprobs
+        // log_softmax = score - logsumexp = [-2.4076, -1.4076, -0.4076].
+        let dims = [1_i64, 1, 3];
+        let logits = [1.0_f32, 2.0, 3.0];
+        let (best_id, logprob) = argmax_from_logits(&dims, &logits).expect("should succeed");
+        assert_eq!(best_id, 2);
+        assert!((logprob - -0.4076059).abs() < 1.0e-5, "got {logprob}");
+    }
+
+    #[test]
+    fn argmax_from_logits_handles_large_positive_scores_without_overflow() {
+        // Streaming form must be numerically stable for huge logits.
+        let dims = [1_i64, 1, 3];
+        let logits = [1000.0_f32, 1001.0, 1002.0];
+        let (best_id, logprob) = argmax_from_logits(&dims, &logits).expect("should succeed");
+        assert_eq!(best_id, 2);
+        assert!(logprob.is_finite(), "logprob must stay finite");
+        assert!((logprob - -0.4076059).abs() < 1.0e-5, "got {logprob}");
+    }
+
+    #[test]
+    fn argmax_from_logits_handles_uniform_logits() {
+        // Uniform distribution over V=4: each token has logprob -ln(4).
+        let dims = [1_i64, 1, 4];
+        let logits = [0.5_f32; 4];
+        let (best_id, logprob) = argmax_from_logits(&dims, &logits).expect("should succeed");
+        assert_eq!(best_id, 0);
+        assert!((logprob - -(4.0_f32).ln()).abs() < 1.0e-5, "got {logprob}");
     }
 
     #[test]

--- a/native/src/adapters/whisper.rs
+++ b/native/src/adapters/whisper.rs
@@ -8,8 +8,8 @@ use crate::engine::capabilities::{
 use crate::engine::traits::{LoadedModel, ModelFamilyAdapter};
 use crate::protocol::{TimestampGranularity, TimestampSource, TranscriptSegment};
 use crate::transcription::{
-    EngineTranscriptOutput, GpuConfig, TranscriptionError, TranscriptionRequest,
-    validate_audio_samples, validate_language, validate_model_path,
+    EngineTranscriptOutput, GpuConfig, SegmentDiagnostics, TranscriptionError,
+    TranscriptionRequest, validate_audio_samples, validate_language, validate_model_path,
 };
 
 #[derive(Default)]
@@ -91,9 +91,11 @@ impl LoadedModel for LoadedWhisperModel {
             })?;
 
         let mut segments = Vec::new();
+        let mut diagnostics = Vec::new();
 
         for segment in state.as_iter() {
             let segment_text = segment.to_string();
+            diagnostics.push(whisper_segment_diagnostics(&segment));
             segments.push(TranscriptSegment {
                 end_ms: whisper_timestamp_to_millis(segment.end_timestamp()),
                 start_ms: whisper_timestamp_to_millis(segment.start_timestamp()),
@@ -103,7 +105,51 @@ impl LoadedModel for LoadedWhisperModel {
             });
         }
 
-        Ok(EngineTranscriptOutput { segments })
+        Ok(EngineTranscriptOutput {
+            segments,
+            diagnostics,
+        })
+    }
+}
+
+fn whisper_segment_diagnostics(segment: &whisper_rs::WhisperSegment<'_>) -> SegmentDiagnostics {
+    let token_count = segment.n_tokens().max(0) as u32;
+    SegmentDiagnostics {
+        avg_logprob: average_token_logprob(segment),
+        decode_reached_eos: None,
+        no_speech_prob: Some(segment.no_speech_probability()),
+        token_count: Some(token_count),
+    }
+}
+
+fn average_token_logprob(segment: &whisper_rs::WhisperSegment<'_>) -> Option<f32> {
+    let mut count = 0_u32;
+    let mut sum = 0.0_f32;
+
+    for index in 0..segment.n_tokens() {
+        let Some(token) = segment.get_token(index) else {
+            continue;
+        };
+        if !token_has_visible_text(&token) {
+            continue;
+        }
+        // Floor to 1e-9 so quantization noise can't drive the running sum to
+        // -inf via ln(0); cap at 1.0 so a slightly-over-one probability does
+        // not produce a positive logprob.
+        sum += token.token_probability().clamp(1.0e-9, 1.0).ln();
+        count += 1;
+    }
+
+    (count > 0).then_some(sum / count as f32)
+}
+
+fn token_has_visible_text(token: &whisper_rs::WhisperToken<'_, '_>) -> bool {
+    // Borrow the raw bytes (no allocation) and skip tokens whose text is empty
+    // or whitespace-only — that matches the prior `to_string().trim().is_empty()`
+    // behavior without churning a String per token.
+    match token.to_bytes() {
+        Ok(bytes) => bytes.iter().any(|byte| !byte.is_ascii_whitespace()),
+        Err(_) => false,
     }
 }
 

--- a/native/src/app.rs
+++ b/native/src/app.rs
@@ -442,7 +442,7 @@ impl AppState {
                                 model_file_path: resolved_model.resolved_path.clone(),
                                 session_start_unix_ms,
                                 session_id: session_id.clone(),
-                                stage_enablement: StageEnablement,
+                                stage_enablement: StageEnablement::default(),
                             }))
                             .is_err()
                         {
@@ -1341,6 +1341,7 @@ mod tests {
             _request: &TranscriptionRequest,
         ) -> Result<EngineTranscriptOutput, TranscriptionError> {
             Ok(EngineTranscriptOutput {
+                diagnostics: Vec::new(),
                 segments: Vec::new(),
             })
         }

--- a/native/src/stages/hallucination_filter.rs
+++ b/native/src/stages/hallucination_filter.rs
@@ -1,0 +1,977 @@
+use serde::Serialize;
+
+use crate::audio_metadata::{VOICED_THRESHOLD, voiced_fraction};
+use crate::protocol::{StageId, TranscriptSegment};
+use crate::stages::{StageContext, StageProcess, StageProcessor};
+use crate::transcription::{SegmentDiagnostics, Transcript};
+
+const VERSION: u32 = 1;
+
+// Strong corroborators — any one drops a SOFT phrase on a final revision and is
+// the only path that drops a Normal-classified segment as silence. Tuned
+// against PLANS.md "Runtime Signals" / "Classification Rules" — change these
+// in lockstep with the plan.
+const STRONG_NO_SPEECH_PROB: f32 = 0.60;
+const STRONG_AVG_LOGPROB: f32 = -1.00;
+const STRONG_VAD_VOICED_FRACTION: f32 = 0.10;
+const STRONG_VAD_VOICED_MS: u64 = 200;
+
+// Weak corroborators — ≥2 needed to drop a SOFT phrase, ≥1 needed for the
+// repetition and prompt-leak rules. None of these alone may drop normal text.
+const WEAK_VAD_VOICED_FRACTION: f32 = 0.35;
+const WEAK_AVG_LOGPROB: f32 = -0.70;
+const SHORT_VOICE_MS: u64 = 1_200;
+const SHORT_VOICE_MIN_WORDS: usize = 3;
+
+// Repetition / character-run thresholds.
+const NGRAM_3_MIN_COUNT: usize = 3;
+const NGRAM_5_MIN_COUNT: usize = 2;
+const SUFFIX_MIN_REPEATS: usize = 3;
+const PATHOLOGICAL_RUN: usize = 20;
+
+// Prompt-leak window length, in words. Shorter spans are common in legitimate
+// dictation and would otherwise cause false drops.
+const PROMPT_LEAK_NGRAM: usize = 8;
+
+pub struct HallucinationFilterStage;
+
+impl StageProcessor for HallucinationFilterStage {
+    fn id(&self) -> StageId {
+        StageId::HallucinationFilter
+    }
+
+    fn runs_on_partials(&self) -> bool {
+        true
+    }
+
+    fn needs_context(&self) -> bool {
+        false
+    }
+
+    fn process(&self, transcript: &Transcript, ctx: &StageContext<'_>) -> StageProcess {
+        if !ctx.stage_enabled.hallucination_filter {
+            return StageProcess::Skipped {
+                reason: "disabled".to_string(),
+                payload: None,
+            };
+        }
+
+        // Normalize the prompt context once per revision; without this hoist
+        // the prompt-leak rule would re-lowercase + re-split the same context
+        // string for every segment.
+        let normalized_context = ctx.context.map(|context| normalize_text(&context.text));
+
+        let mut kept = Vec::with_capacity(transcript.segments.len());
+        let mut dropped = Vec::new();
+
+        for (index, segment) in transcript.segments.iter().enumerate() {
+            let diagnostics = ctx.segment_diagnostics.get(index);
+            let evidence = SegmentEvidence::from_segment(segment, diagnostics, ctx);
+            if let Some(reason) =
+                classify_drop(segment, &evidence, ctx.is_final, normalized_context.as_deref())
+            {
+                dropped.push(DroppedSegment::from_segment(
+                    index,
+                    reason,
+                    segment,
+                    &evidence,
+                    diagnostics,
+                ));
+            } else {
+                kept.push(segment.clone());
+            }
+        }
+
+        if dropped.is_empty() {
+            StageProcess::Skipped {
+                reason: "no_hallucinations".to_string(),
+                payload: None,
+            }
+        } else {
+            StageProcess::Ok {
+                segments: kept,
+                payload: Some(
+                    serde_json::to_value(FilterPayload {
+                        version: VERSION,
+                        dropped_segments: dropped,
+                    })
+                    .expect("hallucination payload should serialize"),
+                ),
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum DropReason {
+    BlocklistHard,
+    BlocklistSoftCorroborated,
+    PromptLeakCorroborated,
+    Repetition,
+    Silence,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TextClass {
+    Hard,
+    Normal,
+    Soft,
+}
+
+#[derive(Debug, Clone)]
+struct SegmentEvidence {
+    avg_logprob: Option<f32>,
+    decode_reached_eos: Option<bool>,
+    no_speech_prob: Option<f32>,
+    normalized_text: String,
+    repeated_ngram: bool,
+    repeated_suffix: bool,
+    character_run: bool,
+    vad_available: bool,
+    segment_voiced_fraction: f32,
+    segment_voiced_ms: u64,
+    word_count: usize,
+}
+
+impl SegmentEvidence {
+    fn from_segment(
+        segment: &TranscriptSegment,
+        diagnostics: Option<&SegmentDiagnostics>,
+        ctx: &StageContext<'_>,
+    ) -> Self {
+        let duration_ms = segment.end_ms.saturating_sub(segment.start_ms);
+        let segment_voiced_fraction = voiced_fraction(
+            ctx.vad_probabilities,
+            segment.start_ms,
+            segment.end_ms,
+            VOICED_THRESHOLD,
+        );
+        let segment_voiced_ms = ((duration_ms as f32) * segment_voiced_fraction).round() as u64;
+        let normalized_text = normalize_text(&segment.text);
+        let words = words(&normalized_text);
+        let repeated_ngram = repeated_ngram_dominates(&words);
+        let repeated_suffix = repeated_suffix_dominates(&words);
+        let word_count = words.len();
+
+        Self {
+            avg_logprob: diagnostics.and_then(|d| d.avg_logprob),
+            decode_reached_eos: diagnostics.and_then(|d| d.decode_reached_eos),
+            no_speech_prob: diagnostics.and_then(|d| d.no_speech_prob),
+            normalized_text,
+            repeated_ngram,
+            repeated_suffix,
+            character_run: has_pathological_character_run(&segment.text),
+            vad_available: !ctx.vad_probabilities.is_empty(),
+            segment_voiced_fraction,
+            segment_voiced_ms,
+            word_count,
+        }
+    }
+
+    fn has_any_corroborator(&self) -> bool {
+        self.strong_whisper_silence()
+            || self.strong_vad_silence()
+            || self.weak_corroborator_count() > 0
+    }
+
+    fn strong_whisper_silence(&self) -> bool {
+        matches!(
+            (self.no_speech_prob, self.avg_logprob),
+            (Some(no_speech), Some(avg_logprob))
+                if no_speech >= STRONG_NO_SPEECH_PROB && avg_logprob <= STRONG_AVG_LOGPROB
+        )
+    }
+
+    fn strong_vad_silence(&self) -> bool {
+        self.vad_available
+            && self.segment_voiced_fraction <= STRONG_VAD_VOICED_FRACTION
+            && self.segment_voiced_ms <= STRONG_VAD_VOICED_MS
+    }
+
+    fn weak_corroborator_count(&self) -> u8 {
+        let mut count = 0;
+        if self.vad_available && self.segment_voiced_fraction < WEAK_VAD_VOICED_FRACTION {
+            count += 1;
+        }
+        if self.avg_logprob.is_some_and(|value| value <= WEAK_AVG_LOGPROB) {
+            count += 1;
+        }
+        if self.vad_available
+            && self.segment_voiced_ms < SHORT_VOICE_MS
+            && self.word_count > SHORT_VOICE_MIN_WORDS
+        {
+            count += 1;
+        }
+        if self.decode_reached_eos == Some(false) {
+            count += 1;
+        }
+        count
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FilterPayload {
+    version: u32,
+    dropped_segments: Vec<DroppedSegment>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DroppedSegment {
+    index: usize,
+    reason: DropReason,
+    text: String,
+    start_ms: u64,
+    end_ms: u64,
+    timestamp_source: crate::protocol::TimestampSource,
+    timestamp_granularity: crate::protocol::TimestampGranularity,
+    signals: DroppedSignals,
+}
+
+impl DroppedSegment {
+    fn from_segment(
+        index: usize,
+        reason: DropReason,
+        segment: &TranscriptSegment,
+        evidence: &SegmentEvidence,
+        diagnostics: Option<&SegmentDiagnostics>,
+    ) -> Self {
+        Self {
+            index,
+            reason,
+            text: segment.text.clone(),
+            start_ms: segment.start_ms,
+            end_ms: segment.end_ms,
+            timestamp_source: segment.timestamp_source,
+            timestamp_granularity: segment.timestamp_granularity,
+            signals: DroppedSignals {
+                avg_logprob: evidence.avg_logprob,
+                decode_reached_eos: evidence.decode_reached_eos,
+                no_speech_prob: evidence.no_speech_prob,
+                segment_voiced_fraction: evidence.segment_voiced_fraction,
+                segment_voiced_ms: evidence.segment_voiced_ms,
+                token_count: diagnostics.and_then(|d| d.token_count),
+            },
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DroppedSignals {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    avg_logprob: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    decode_reached_eos: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    no_speech_prob: Option<f32>,
+    segment_voiced_fraction: f32,
+    segment_voiced_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    token_count: Option<u32>,
+}
+
+fn classify_drop(
+    segment: &TranscriptSegment,
+    evidence: &SegmentEvidence,
+    is_final: bool,
+    normalized_context: Option<&str>,
+) -> Option<DropReason> {
+    let class = classify_text(&evidence.normalized_text, &segment.text);
+    if class == TextClass::Hard {
+        return Some(DropReason::BlocklistHard);
+    }
+
+    // Partial revisions only run the HARD subset — every rule below requires
+    // diagnostics that may still be in flux on a non-final revision.
+    if !is_final {
+        return None;
+    }
+
+    if class == TextClass::Soft {
+        let strong = evidence.strong_whisper_silence() || evidence.strong_vad_silence();
+        let two_weak = evidence.weak_corroborator_count() >= 2;
+        if strong || two_weak {
+            return Some(DropReason::BlocklistSoftCorroborated);
+        }
+        return None;
+    }
+
+    // TextClass::Normal — only drop on hard model+VAD silence agreement, on
+    // pathological repetition with a corroborator, or on a clear prompt leak.
+    if evidence.strong_whisper_silence() && evidence.strong_vad_silence() {
+        return Some(DropReason::Silence);
+    }
+
+    if (evidence.repeated_ngram || evidence.repeated_suffix || evidence.character_run)
+        && evidence.has_any_corroborator()
+    {
+        return Some(DropReason::Repetition);
+    }
+
+    if is_prompt_leak(evidence, normalized_context) && evidence.has_any_corroborator() {
+        return Some(DropReason::PromptLeakCorroborated);
+    }
+
+    None
+}
+
+fn classify_text(normalized: &str, raw: &str) -> TextClass {
+    if raw.trim().is_empty() || is_punctuation_only(raw) {
+        return TextClass::Hard;
+    }
+
+    if is_hard_nonspeech_tag(normalized) || is_caption_attribution(normalized) {
+        return TextClass::Hard;
+    }
+
+    if is_soft_artifact(normalized) || is_bare_domain(normalized) {
+        return TextClass::Soft;
+    }
+
+    TextClass::Normal
+}
+
+fn normalize_text(text: &str) -> String {
+    let collapsed = text
+        .to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    collapsed
+        .trim_matches(|ch: char| ch.is_ascii_punctuation() || ch.is_whitespace())
+        .to_string()
+}
+
+fn is_punctuation_only(text: &str) -> bool {
+    let trimmed = text.trim();
+    !trimmed.is_empty()
+        && trimmed
+            .chars()
+            .all(|ch| ch.is_ascii_punctuation() || ch.is_whitespace())
+}
+
+fn is_hard_nonspeech_tag(normalized: &str) -> bool {
+    matches!(
+        normalized,
+        "music" | "applause" | "laughter" | "noise" | "silence" | "blank audio"
+    )
+}
+
+fn is_caption_attribution(normalized: &str) -> bool {
+    ["subtitles by", "captions by", "transcribed by", "sync by"]
+        .iter()
+        .any(|prefix| normalized.starts_with(prefix))
+}
+
+fn is_soft_artifact(normalized: &str) -> bool {
+    matches!(
+        normalized,
+        "thank you"
+            | "thanks"
+            | "thank you for watching"
+            | "thanks for watching"
+            | "thank you for listening"
+            | "goodbye"
+            | "bye"
+            | "bye bye"
+            | "see you next time"
+            | "please subscribe"
+            | "like and subscribe"
+            | "let me know in the comments"
+            | "you"
+    )
+}
+
+fn is_bare_domain(normalized: &str) -> bool {
+    let text = normalized
+        .strip_prefix("https://")
+        .or_else(|| normalized.strip_prefix("http://"))
+        .unwrap_or(normalized);
+    !text.contains(' ')
+        && text.contains('.')
+        && text
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '/' | '_' | '?'))
+}
+
+fn words(text: &str) -> Vec<&str> {
+    text.split_whitespace().collect()
+}
+
+fn repeated_ngram_dominates(words: &[&str]) -> bool {
+    ngram_dominates(words, 3, NGRAM_3_MIN_COUNT) || ngram_dominates(words, 5, NGRAM_5_MIN_COUNT)
+}
+
+fn ngram_dominates(words: &[&str], size: usize, min_count: usize) -> bool {
+    if words.len() < size * min_count {
+        return false;
+    }
+    for window in words.windows(size) {
+        let count = words
+            .windows(size)
+            .filter(|candidate| *candidate == window)
+            .count();
+        if count >= min_count && count * size >= words.len().div_ceil(2) {
+            return true;
+        }
+    }
+    false
+}
+
+fn repeated_suffix_dominates(words: &[&str]) -> bool {
+    for size in 1..=words.len() / SUFFIX_MIN_REPEATS {
+        let suffix = &words[words.len() - size..];
+        let mut count = 0;
+        let mut offset = words.len();
+        while offset >= size && &words[offset - size..offset] == suffix {
+            count += 1;
+            offset -= size;
+        }
+        if count >= SUFFIX_MIN_REPEATS {
+            return true;
+        }
+    }
+    false
+}
+
+fn has_pathological_character_run(text: &str) -> bool {
+    let mut previous = None;
+    let mut run = 0;
+    for ch in text.chars() {
+        if Some(ch) == previous {
+            run += 1;
+        } else {
+            previous = Some(ch);
+            run = 1;
+        }
+        if run >= PATHOLOGICAL_RUN && !ch.is_whitespace() {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_prompt_leak(evidence: &SegmentEvidence, normalized_context: Option<&str>) -> bool {
+    let Some(normalized_context) = normalized_context else {
+        return false;
+    };
+    if evidence.normalized_text.starts_with("glossary:") {
+        return true;
+    }
+
+    let context_words = words(normalized_context);
+    let segment_words = words(&evidence.normalized_text);
+    if context_words.len() < PROMPT_LEAK_NGRAM || segment_words.len() < PROMPT_LEAK_NGRAM {
+        return false;
+    }
+
+    context_words.windows(PROMPT_LEAK_NGRAM).any(|span| {
+        segment_words
+            .windows(PROMPT_LEAK_NGRAM)
+            .any(|candidate| candidate == span)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio_metadata::VoiceActivityEvidence;
+    use crate::engine::capabilities::{LanguageSupport, ModelFamilyCapabilities};
+    use crate::protocol::{ContextWindow, TimestampGranularity, TimestampSource};
+    use crate::stages::StageEnablement;
+    use uuid::Uuid;
+
+    fn segment(text: &str) -> TranscriptSegment {
+        TranscriptSegment {
+            end_ms: 1_000,
+            start_ms: 0,
+            text: text.to_string(),
+            timestamp_granularity: TimestampGranularity::Segment,
+            timestamp_source: TimestampSource::Engine,
+        }
+    }
+
+    fn transcript(text: &str) -> Transcript {
+        Transcript {
+            utterance_id: Uuid::nil(),
+            revision: 0,
+            segments: vec![segment(text)],
+            stage_history: Vec::new(),
+        }
+    }
+
+    fn ctx<'a>(
+        diagnostics: &'a [SegmentDiagnostics],
+        vad_probabilities: &'a [f32],
+        context: Option<&'a ContextWindow>,
+        is_final: bool,
+    ) -> StageContext<'a> {
+        StageContext {
+            context,
+            family_capabilities: &CAPS,
+            stage_enabled: &ENABLEMENT,
+            is_final,
+            segment_diagnostics: diagnostics,
+            vad_probabilities,
+            voice_activity: &VOICE,
+        }
+    }
+
+    static CAPS: ModelFamilyCapabilities = ModelFamilyCapabilities {
+        supports_segment_timestamps: true,
+        supports_word_timestamps: false,
+        supports_initial_prompt: true,
+        supports_language_selection: false,
+        supported_languages: LanguageSupport::EnglishOnly,
+        max_audio_duration_secs: None,
+        produces_punctuation: true,
+    };
+    static ENABLEMENT: StageEnablement = StageEnablement {
+        hallucination_filter: true,
+    };
+    static VOICE: VoiceActivityEvidence = VoiceActivityEvidence {
+        audio_start_ms: 0,
+        audio_end_ms: 1_000,
+        speech_start_ms: 0,
+        speech_end_ms: 1_000,
+        voiced_ms: 1_000,
+        unvoiced_ms: 0,
+        mean_probability: 0.9,
+        max_probability: 1.0,
+    };
+
+    #[test]
+    fn hard_drops_punctuation_and_sound_tags() {
+        assert_eq!(classify_text("", " ... "), TextClass::Hard);
+        assert_eq!(
+            classify_text(&normalize_text("[music]"), "[music]"),
+            TextClass::Hard
+        );
+        assert_eq!(
+            classify_text(&normalize_text("[project x]"), "[project x]"),
+            TextClass::Normal
+        );
+    }
+
+    #[test]
+    fn hard_drops_caption_attributions() {
+        assert_eq!(
+            classify_text(&normalize_text("Subtitles by Amara"), "Subtitles by Amara"),
+            TextClass::Hard
+        );
+    }
+
+    #[test]
+    fn soft_phrases_do_not_drop_without_corroboration() {
+        let result =
+            HallucinationFilterStage.process(&transcript("Thank you."), &ctx(&[], &[], None, true));
+        assert!(
+            matches!(result, StageProcess::Skipped { reason, .. } if reason == "no_hallucinations")
+        );
+    }
+
+    #[test]
+    fn soft_phrase_drops_with_strong_whisper_silence() {
+        let diagnostics = [SegmentDiagnostics {
+            avg_logprob: Some(-1.2),
+            no_speech_prob: Some(0.72),
+            token_count: Some(2),
+            decode_reached_eos: None,
+        }];
+        let result = HallucinationFilterStage.process(
+            &transcript("Thank you."),
+            &ctx(&diagnostics, &[], None, true),
+        );
+        assert!(matches!(result, StageProcess::Ok { .. }));
+    }
+
+    #[test]
+    fn partial_revisions_run_hard_rules_only() {
+        let diagnostics = [SegmentDiagnostics {
+            avg_logprob: Some(-1.2),
+            no_speech_prob: Some(0.72),
+            token_count: Some(2),
+            decode_reached_eos: None,
+        }];
+        let result = HallucinationFilterStage.process(
+            &transcript("Thank you."),
+            &ctx(&diagnostics, &[], None, false),
+        );
+        assert!(
+            matches!(result, StageProcess::Skipped { reason, .. } if reason == "no_hallucinations")
+        );
+
+        let result =
+            HallucinationFilterStage.process(&transcript("[noise]"), &ctx(&[], &[], None, false));
+        assert!(matches!(result, StageProcess::Ok { .. }));
+    }
+
+    #[test]
+    fn normal_text_with_low_vad_is_kept() {
+        let result = HallucinationFilterStage.process(
+            &transcript("Please subscribe to the newsletter"),
+            &ctx(&[], &[0.0; 50], None, true),
+        );
+        assert!(
+            matches!(result, StageProcess::Skipped { reason, .. } if reason == "no_hallucinations")
+        );
+    }
+
+    #[test]
+    fn repetition_drops_only_with_corroboration() {
+        let text = "hello world again hello world again hello world again";
+        let result =
+            HallucinationFilterStage.process(&transcript(text), &ctx(&[], &[], None, true));
+        assert!(matches!(result, StageProcess::Skipped { .. }));
+
+        let diagnostics = [SegmentDiagnostics {
+            avg_logprob: Some(-0.8),
+            no_speech_prob: None,
+            token_count: Some(9),
+            decode_reached_eos: None,
+        }];
+        let result = HallucinationFilterStage
+            .process(&transcript(text), &ctx(&diagnostics, &[], None, true));
+        assert!(matches!(result, StageProcess::Ok { .. }));
+    }
+
+    #[test]
+    fn prompt_leak_requires_context_and_corroboration() {
+        let context = ContextWindow {
+            budget_chars: 100,
+            sources: Vec::new(),
+            text: "Glossary: AlphaTerm, BetaTerm, GammaTerm, DeltaTerm".to_string(),
+            truncated: false,
+        };
+        let diagnostics = [SegmentDiagnostics {
+            avg_logprob: Some(-0.8),
+            no_speech_prob: None,
+            token_count: Some(5),
+            decode_reached_eos: None,
+        }];
+        let result = HallucinationFilterStage.process(
+            &transcript("Glossary: AlphaTerm, BetaTerm"),
+            &ctx(&diagnostics, &[], Some(&context), true),
+        );
+        assert!(matches!(result, StageProcess::Ok { .. }));
+    }
+
+    #[test]
+    fn hard_drops_every_known_nonspeech_tag() {
+        for tag in [
+            "[music]",
+            "[applause]",
+            "[laughter]",
+            "[noise]",
+            "[silence]",
+            "[blank audio]",
+        ] {
+            assert_eq!(
+                classify_text(&normalize_text(tag), tag),
+                TextClass::Hard,
+                "{tag} should classify Hard",
+            );
+        }
+    }
+
+    #[test]
+    fn bare_domain_classifies_soft_and_is_kept_without_corroboration() {
+        assert_eq!(
+            classify_text(&normalize_text("example.com"), "example.com"),
+            TextClass::Soft,
+        );
+        // No corroborating diagnostics or VAD: a dictated URL stays.
+        let result = HallucinationFilterStage
+            .process(&transcript("example.com"), &ctx(&[], &[], None, true));
+        assert!(
+            matches!(result, StageProcess::Skipped { reason, .. } if reason == "no_hallucinations"),
+        );
+    }
+
+    #[test]
+    fn longer_sentence_containing_soft_phrase_is_normal() {
+        assert_eq!(
+            classify_text(
+                &normalize_text("I said thank you after the call"),
+                "I said thank you after the call",
+            ),
+            TextClass::Normal,
+        );
+    }
+
+    #[test]
+    fn bare_you_classifies_soft_and_is_kept_without_corroboration() {
+        assert_eq!(classify_text(&normalize_text("you"), "you"), TextClass::Soft);
+        let result = HallucinationFilterStage
+            .process(&transcript("You."), &ctx(&[], &[], None, true));
+        assert!(
+            matches!(result, StageProcess::Skipped { reason, .. } if reason == "no_hallucinations"),
+        );
+    }
+
+    #[test]
+    fn soft_phrase_drops_with_strong_vad_silence() {
+        // 50 frames at 10 ms each = 500 ms covered by VAD trace; all silent.
+        let trace = [0.0_f32; 50];
+        let result = HallucinationFilterStage
+            .process(&transcript("Thank you."), &ctx(&[], &trace, None, true));
+        assert!(matches!(result, StageProcess::Ok { .. }));
+    }
+
+    #[test]
+    fn soft_phrase_drops_with_two_weak_corroborators() {
+        // Weak corroborator 1: avg_logprob <= -0.70.
+        // Weak corroborator 2: VAD voiced fraction < 0.35.
+        let diagnostics = [SegmentDiagnostics {
+            avg_logprob: Some(-0.85),
+            no_speech_prob: None,
+            token_count: Some(2),
+            decode_reached_eos: None,
+        }];
+        let trace = [0.0_f32; 50];
+        let result = HallucinationFilterStage.process(
+            &transcript("Thank you for watching."),
+            &ctx(&diagnostics, &trace, None, true),
+        );
+        assert!(matches!(result, StageProcess::Ok { .. }));
+    }
+
+    #[test]
+    fn soft_phrase_with_single_weak_corroborator_is_kept() {
+        // Only one weak signal — avg_logprob below threshold, no VAD trace.
+        let diagnostics = [SegmentDiagnostics {
+            avg_logprob: Some(-0.85),
+            no_speech_prob: None,
+            token_count: Some(2),
+            decode_reached_eos: None,
+        }];
+        let result = HallucinationFilterStage.process(
+            &transcript("Thank you."),
+            &ctx(&diagnostics, &[], None, true),
+        );
+        assert!(
+            matches!(result, StageProcess::Skipped { reason, .. } if reason == "no_hallucinations"),
+        );
+    }
+
+    #[test]
+    fn normal_text_drops_as_silence_only_when_both_strongs_agree() {
+        let trace = [0.0_f32; 50];
+        let diagnostics = [SegmentDiagnostics {
+            avg_logprob: Some(-1.5),
+            no_speech_prob: Some(0.85),
+            token_count: Some(6),
+            decode_reached_eos: None,
+        }];
+        // Strong Whisper silence alone — kept (Normal class needs both).
+        let result = HallucinationFilterStage.process(
+            &transcript("the quick brown fox jumps"),
+            &ctx(&diagnostics, &[], None, true),
+        );
+        assert!(
+            matches!(result, StageProcess::Skipped { reason, .. } if reason == "no_hallucinations"),
+        );
+
+        // Both strongs — drops with reason `silence`.
+        let result = HallucinationFilterStage.process(
+            &transcript("the quick brown fox jumps"),
+            &ctx(&diagnostics, &trace, None, true),
+        );
+        let StageProcess::Ok { payload, .. } = result else {
+            panic!("expected Ok");
+        };
+        let dropped = payload
+            .as_ref()
+            .and_then(|p| p.get("droppedSegments"))
+            .and_then(|v| v.as_array())
+            .expect("payload has droppedSegments");
+        assert_eq!(dropped[0].get("reason").and_then(|v| v.as_str()), Some("silence"));
+    }
+
+    #[test]
+    fn five_gram_repetition_drops_with_corroboration() {
+        let text = "alpha beta gamma delta epsilon alpha beta gamma delta epsilon \
+                    alpha beta gamma delta epsilon";
+        let diagnostics = [SegmentDiagnostics {
+            avg_logprob: Some(-0.85),
+            no_speech_prob: None,
+            token_count: Some(15),
+            decode_reached_eos: None,
+        }];
+        let result = HallucinationFilterStage
+            .process(&transcript(text), &ctx(&diagnostics, &[], None, true));
+        assert!(matches!(result, StageProcess::Ok { .. }));
+    }
+
+    #[test]
+    fn pathological_character_run_drops_with_corroboration() {
+        let text = "a".repeat(40);
+        let diagnostics = [SegmentDiagnostics {
+            avg_logprob: Some(-0.9),
+            no_speech_prob: None,
+            token_count: Some(1),
+            decode_reached_eos: None,
+        }];
+        let result = HallucinationFilterStage
+            .process(&transcript(&text), &ctx(&diagnostics, &[], None, true));
+        assert!(matches!(result, StageProcess::Ok { .. }));
+
+        // Without any corroborator the same pathological run is kept.
+        let result = HallucinationFilterStage
+            .process(&transcript(&text), &ctx(&[], &[], None, true));
+        assert!(
+            matches!(result, StageProcess::Skipped { reason, .. } if reason == "no_hallucinations"),
+        );
+    }
+
+    #[test]
+    fn disabled_filter_returns_skipped_disabled() {
+        static OFF: StageEnablement = StageEnablement {
+            hallucination_filter: false,
+        };
+        let ctx = StageContext {
+            context: None,
+            family_capabilities: &CAPS,
+            stage_enabled: &OFF,
+            is_final: true,
+            segment_diagnostics: &[],
+            vad_probabilities: &[],
+            voice_activity: &VOICE,
+        };
+        let result = HallucinationFilterStage.process(&transcript("[music]"), &ctx);
+        assert!(matches!(result, StageProcess::Skipped { reason, .. } if reason == "disabled"));
+    }
+
+    #[test]
+    fn dropping_only_segment_returns_ok_with_empty_list() {
+        let result = HallucinationFilterStage
+            .process(&transcript("[music]"), &ctx(&[], &[], None, true));
+        let StageProcess::Ok { segments, payload } = result else {
+            panic!("expected Ok");
+        };
+        assert!(segments.is_empty());
+        let dropped = payload
+            .as_ref()
+            .and_then(|p| p.get("droppedSegments"))
+            .and_then(|v| v.as_array())
+            .expect("payload has droppedSegments");
+        assert_eq!(dropped.len(), 1);
+    }
+
+    #[test]
+    fn payload_carries_reason_index_text_timing_and_signals() {
+        let segment = TranscriptSegment {
+            end_ms: 900,
+            start_ms: 100,
+            text: "Thank you for watching.".to_string(),
+            timestamp_granularity: TimestampGranularity::Segment,
+            timestamp_source: TimestampSource::Engine,
+        };
+        let transcript = Transcript {
+            utterance_id: Uuid::nil(),
+            revision: 0,
+            segments: vec![segment],
+            stage_history: Vec::new(),
+        };
+        let diagnostics = [SegmentDiagnostics {
+            avg_logprob: Some(-1.2),
+            no_speech_prob: Some(0.72),
+            token_count: Some(4),
+            decode_reached_eos: Some(true),
+        }];
+        let result = HallucinationFilterStage
+            .process(&transcript, &ctx(&diagnostics, &[], None, true));
+        let StageProcess::Ok { payload, .. } = result else {
+            panic!("expected Ok drop");
+        };
+        let payload = payload.expect("payload populated on drop");
+        assert_eq!(payload.get("version").and_then(|v| v.as_u64()), Some(1));
+        let dropped = payload
+            .get("droppedSegments")
+            .and_then(|v| v.as_array())
+            .expect("droppedSegments");
+        assert_eq!(dropped.len(), 1);
+        let entry = &dropped[0];
+        assert_eq!(entry.get("index").and_then(|v| v.as_u64()), Some(0));
+        assert_eq!(
+            entry.get("reason").and_then(|v| v.as_str()),
+            Some("blocklist_soft_corroborated"),
+        );
+        assert_eq!(
+            entry.get("text").and_then(|v| v.as_str()),
+            Some("Thank you for watching."),
+        );
+        assert_eq!(entry.get("startMs").and_then(|v| v.as_u64()), Some(100));
+        assert_eq!(entry.get("endMs").and_then(|v| v.as_u64()), Some(900));
+        assert_eq!(
+            entry.get("timestampSource").and_then(|v| v.as_str()),
+            Some("engine"),
+        );
+        assert_eq!(
+            entry.get("timestampGranularity").and_then(|v| v.as_str()),
+            Some("segment"),
+        );
+        let signals = entry.get("signals").expect("signals present");
+        let no_speech = signals
+            .get("noSpeechProb")
+            .and_then(|v| v.as_f64())
+            .expect("noSpeechProb populated");
+        assert!((no_speech - 0.72).abs() < 1.0e-5, "got {no_speech}");
+        assert_eq!(signals.get("decodeReachedEos").and_then(|v| v.as_bool()), Some(true));
+        assert_eq!(signals.get("tokenCount").and_then(|v| v.as_u64()), Some(4));
+    }
+
+    #[test]
+    fn partial_revision_keeps_soft_phrase_even_with_strong_diagnostics() {
+        let diagnostics = [SegmentDiagnostics {
+            avg_logprob: Some(-1.4),
+            no_speech_prob: Some(0.85),
+            token_count: Some(2),
+            decode_reached_eos: Some(false),
+        }];
+        let trace = [0.0_f32; 50];
+        let result = HallucinationFilterStage.process(
+            &transcript("Thank you."),
+            &ctx(&diagnostics, &trace, None, false),
+        );
+        assert!(
+            matches!(result, StageProcess::Skipped { reason, .. } if reason == "no_hallucinations"),
+        );
+    }
+
+    #[test]
+    fn dropping_first_segment_preserves_second_unchanged() {
+        let transcript = Transcript {
+            utterance_id: Uuid::nil(),
+            revision: 0,
+            segments: vec![
+                TranscriptSegment {
+                    end_ms: 500,
+                    start_ms: 0,
+                    text: "[music]".to_string(),
+                    timestamp_granularity: TimestampGranularity::Segment,
+                    timestamp_source: TimestampSource::Engine,
+                },
+                TranscriptSegment {
+                    end_ms: 1_000,
+                    start_ms: 500,
+                    text: "Hello world.".to_string(),
+                    timestamp_granularity: TimestampGranularity::Segment,
+                    timestamp_source: TimestampSource::Engine,
+                },
+            ],
+            stage_history: Vec::new(),
+        };
+        let result = HallucinationFilterStage.process(&transcript, &ctx(&[], &[], None, true));
+        let StageProcess::Ok { segments, .. } = result else {
+            panic!("expected Ok");
+        };
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].text, "Hello world.");
+        assert_eq!(segments[0].start_ms, 500);
+        assert_eq!(segments[0].end_ms, 1_000);
+    }
+}

--- a/native/src/stages/hallucination_filter.rs
+++ b/native/src/stages/hallucination_filter.rs
@@ -67,9 +67,12 @@ impl StageProcessor for HallucinationFilterStage {
         for (index, segment) in transcript.segments.iter().enumerate() {
             let diagnostics = ctx.segment_diagnostics.get(index);
             let evidence = SegmentEvidence::from_segment(segment, diagnostics, ctx);
-            if let Some(reason) =
-                classify_drop(segment, &evidence, ctx.is_final, normalized_context.as_deref())
-            {
+            if let Some(reason) = classify_drop(
+                segment,
+                &evidence,
+                ctx.is_final,
+                normalized_context.as_deref(),
+            ) {
                 dropped.push(DroppedSegment::from_segment(
                     index,
                     reason,
@@ -194,7 +197,10 @@ impl SegmentEvidence {
         if self.vad_available && self.segment_voiced_fraction < WEAK_VAD_VOICED_FRACTION {
             count += 1;
         }
-        if self.avg_logprob.is_some_and(|value| value <= WEAK_AVG_LOGPROB) {
+        if self
+            .avg_logprob
+            .is_some_and(|value| value <= WEAK_AVG_LOGPROB)
+        {
             count += 1;
         }
         if self.vad_available
@@ -704,9 +710,12 @@ mod tests {
 
     #[test]
     fn bare_you_classifies_soft_and_is_kept_without_corroboration() {
-        assert_eq!(classify_text(&normalize_text("you"), "you"), TextClass::Soft);
-        let result = HallucinationFilterStage
-            .process(&transcript("You."), &ctx(&[], &[], None, true));
+        assert_eq!(
+            classify_text(&normalize_text("you"), "you"),
+            TextClass::Soft
+        );
+        let result =
+            HallucinationFilterStage.process(&transcript("You."), &ctx(&[], &[], None, true));
         assert!(
             matches!(result, StageProcess::Skipped { reason, .. } if reason == "no_hallucinations"),
         );
@@ -788,7 +797,10 @@ mod tests {
             .and_then(|p| p.get("droppedSegments"))
             .and_then(|v| v.as_array())
             .expect("payload has droppedSegments");
-        assert_eq!(dropped[0].get("reason").and_then(|v| v.as_str()), Some("silence"));
+        assert_eq!(
+            dropped[0].get("reason").and_then(|v| v.as_str()),
+            Some("silence")
+        );
     }
 
     #[test]
@@ -820,8 +832,8 @@ mod tests {
         assert!(matches!(result, StageProcess::Ok { .. }));
 
         // Without any corroborator the same pathological run is kept.
-        let result = HallucinationFilterStage
-            .process(&transcript(&text), &ctx(&[], &[], None, true));
+        let result =
+            HallucinationFilterStage.process(&transcript(&text), &ctx(&[], &[], None, true));
         assert!(
             matches!(result, StageProcess::Skipped { reason, .. } if reason == "no_hallucinations"),
         );
@@ -847,8 +859,8 @@ mod tests {
 
     #[test]
     fn dropping_only_segment_returns_ok_with_empty_list() {
-        let result = HallucinationFilterStage
-            .process(&transcript("[music]"), &ctx(&[], &[], None, true));
+        let result =
+            HallucinationFilterStage.process(&transcript("[music]"), &ctx(&[], &[], None, true));
         let StageProcess::Ok { segments, payload } = result else {
             panic!("expected Ok");
         };
@@ -882,8 +894,8 @@ mod tests {
             token_count: Some(4),
             decode_reached_eos: Some(true),
         }];
-        let result = HallucinationFilterStage
-            .process(&transcript, &ctx(&diagnostics, &[], None, true));
+        let result =
+            HallucinationFilterStage.process(&transcript, &ctx(&diagnostics, &[], None, true));
         let StageProcess::Ok { payload, .. } = result else {
             panic!("expected Ok drop");
         };
@@ -920,7 +932,10 @@ mod tests {
             .and_then(|v| v.as_f64())
             .expect("noSpeechProb populated");
         assert!((no_speech - 0.72).abs() < 1.0e-5, "got {no_speech}");
-        assert_eq!(signals.get("decodeReachedEos").and_then(|v| v.as_bool()), Some(true));
+        assert_eq!(
+            signals.get("decodeReachedEos").and_then(|v| v.as_bool()),
+            Some(true)
+        );
         assert_eq!(signals.get("tokenCount").and_then(|v| v.as_u64()), Some(4));
     }
 

--- a/native/src/stages/mod.rs
+++ b/native/src/stages/mod.rs
@@ -5,16 +5,29 @@ use crate::audio_metadata::VoiceActivityEvidence;
 use crate::engine::capabilities::ModelFamilyCapabilities;
 use crate::panic_util::format_panic_message;
 use crate::protocol::{StageId, StageOutcome, StageStatus, TranscriptSegment};
-use crate::transcription::Transcript;
+use crate::transcription::{SegmentDiagnostics, Transcript};
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct StageEnablement;
+mod hallucination_filter;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StageEnablement {
+    pub hallucination_filter: bool,
+}
+
+impl Default for StageEnablement {
+    fn default() -> Self {
+        Self {
+            hallucination_filter: true,
+        }
+    }
+}
 
 pub struct StageContext<'a> {
     pub context: Option<&'a crate::protocol::ContextWindow>,
     pub family_capabilities: &'a ModelFamilyCapabilities,
     pub stage_enabled: &'a StageEnablement,
     pub is_final: bool,
+    pub segment_diagnostics: &'a [SegmentDiagnostics],
     pub vad_probabilities: &'a [f32],
     pub voice_activity: &'a VoiceActivityEvidence,
 }
@@ -48,7 +61,7 @@ pub trait StageProcessor: Send + Sync {
 /// Build the registered post-engine processor chain in canonical order. The
 /// engine stage outcome is appended separately by `assemble_transcript`.
 pub fn post_engine_processors() -> Vec<Box<dyn StageProcessor>> {
-    Vec::new()
+    vec![Box::new(hallucination_filter::HallucinationFilterStage)]
 }
 
 pub fn any_registered_stage_needs_context() -> bool {
@@ -273,13 +286,14 @@ mod tests {
 
     fn run(transcript: &mut Transcript, processors: Vec<Box<dyn StageProcessor>>) {
         let caps = whisper_caps();
-        let enablement = StageEnablement;
+        let enablement = StageEnablement::default();
         let voice_activity = voice_activity();
         let ctx = StageContext {
             context: None,
             family_capabilities: &caps,
             stage_enabled: &enablement,
             is_final: true,
+            segment_diagnostics: &[],
             vad_probabilities: &[],
             voice_activity: &voice_activity,
         };
@@ -288,13 +302,14 @@ mod tests {
 
     fn run_partial(transcript: &mut Transcript, processors: Vec<Box<dyn StageProcessor>>) {
         let caps = whisper_caps();
-        let enablement = StageEnablement;
+        let enablement = StageEnablement::default();
         let voice_activity = voice_activity();
         let ctx = StageContext {
             context: None,
             family_capabilities: &caps,
             stage_enabled: &enablement,
             is_final: false,
+            segment_diagnostics: &[],
             vad_probabilities: &[],
             voice_activity: &voice_activity,
         };

--- a/native/src/transcription.rs
+++ b/native/src/transcription.rs
@@ -30,9 +30,18 @@ pub struct TranscriptionRequest {
 /// What an adapter returns from `transcribe`. Adapters own only the engine
 /// inference output; revisioning, stage history, and identity are added by
 /// the worker as it wraps this into the canonical `Transcript`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct EngineTranscriptOutput {
     pub segments: Vec<TranscriptSegment>,
+    pub diagnostics: Vec<SegmentDiagnostics>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SegmentDiagnostics {
+    pub avg_logprob: Option<f32>,
+    pub decode_reached_eos: Option<bool>,
+    pub no_speech_prob: Option<f32>,
+    pub token_count: Option<u32>,
 }
 
 /// Canonical transcript revision. Segments are the source of truth; joined

--- a/native/src/worker.rs
+++ b/native/src/worker.rs
@@ -295,6 +295,10 @@ struct TranscriptAssembly<'a> {
 fn assemble_transcript(input: TranscriptAssembly<'_>) -> Transcript {
     let revision: u32 = 0;
     let mut stage_history: Vec<StageOutcome> = Vec::with_capacity(1 + input.processors.len());
+    let EngineTranscriptOutput {
+        segments,
+        diagnostics,
+    } = input.engine_output;
 
     stage_history.push(StageOutcome {
         duration_ms: input.engine_duration_ms,
@@ -314,7 +318,7 @@ fn assemble_transcript(input: TranscriptAssembly<'_>) -> Transcript {
     let mut transcript = Transcript {
         utterance_id: input.utterance_id,
         revision,
-        segments: input.engine_output.segments,
+        segments,
         stage_history,
     };
 
@@ -323,6 +327,7 @@ fn assemble_transcript(input: TranscriptAssembly<'_>) -> Transcript {
         family_capabilities: input.family_capabilities,
         stage_enabled: input.stage_enablement,
         is_final: input.is_final,
+        segment_diagnostics: &diagnostics,
         vad_probabilities: input.vad_probabilities,
         voice_activity: &input.voice_activity,
     };
@@ -392,7 +397,7 @@ mod tests {
             family_capabilities: &whisper_caps(),
             is_final: true,
             processors: &[],
-            stage_enablement: &StageEnablement,
+            stage_enablement: &StageEnablement::default(),
             utterance_id: Uuid::nil(),
             vad_probabilities: &[],
             voice_activity,
@@ -422,7 +427,7 @@ mod tests {
             family_capabilities: &whisper_caps(),
             is_final: true,
             processors: &processors,
-            stage_enablement: &StageEnablement,
+            stage_enablement: &StageEnablement::default(),
             utterance_id: Uuid::nil(),
             vad_probabilities: &[],
             voice_activity,
@@ -453,7 +458,7 @@ mod tests {
             family_capabilities: &whisper_caps(),
             is_final: true,
             processors: &processors,
-            stage_enablement: &StageEnablement,
+            stage_enablement: &StageEnablement::default(),
             utterance_id: Uuid::nil(),
             vad_probabilities: &trace,
             voice_activity,
@@ -469,6 +474,7 @@ mod tests {
 
     fn engine_output() -> EngineTranscriptOutput {
         EngineTranscriptOutput {
+            diagnostics: Vec::new(),
             segments: vec![TranscriptSegment {
                 start_ms: 0,
                 end_ms: 1_000,

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -3,10 +3,10 @@ import { randomUUID } from 'node:crypto';
 import type { AudioCaptureStream } from '../audio/audio-capture-stream';
 import type { NotePlacementOptions } from '../editor/note-surface';
 import type { Session } from '../session/session';
+import type { StageId } from '../session/session-journal';
 import type { PluginSettings } from '../settings/plugin-settings';
 import { formatErrorMessage } from '../shared/format-utils';
 import type { PluginLogger } from '../shared/plugin-logger';
-import type { StageId } from '../session/session-journal';
 import type {
   ContextRequestEvent,
   ContextWindow,

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -6,6 +6,7 @@ import type { Session } from '../session/session';
 import type { PluginSettings } from '../settings/plugin-settings';
 import { formatErrorMessage } from '../shared/format-utils';
 import type { PluginLogger } from '../shared/plugin-logger';
+import type { StageId } from '../session/session-journal';
 import type {
   ContextRequestEvent,
   ContextWindow,
@@ -459,6 +460,7 @@ export class DictationSessionController {
         `capability gate dropped "${warning.field}": ${warning.reason}`,
       );
     }
+    this.logDroppedHallucinations(event);
 
     const text = event.text.trim();
 
@@ -482,6 +484,22 @@ export class DictationSessionController {
     if (result.kind === 'rejected') {
       this.handleError('Failed to record the local transcript', new Error(result.reason));
       void this.abortSessionAfterError(event.sessionId);
+    }
+  }
+
+  private logDroppedHallucinations(event: TranscriptReadyEvent): void {
+    const targetStageId: StageId = 'hallucination_filter';
+    for (const stage of event.stageResults) {
+      if (stage.stageId !== targetStageId || stage.status.kind !== 'ok') {
+        continue;
+      }
+      const droppedSegments = stage.payload?.droppedSegments;
+      if (!Array.isArray(droppedSegments)) {
+        continue;
+      }
+      for (const segment of droppedSegments) {
+        this.dependencies.logger?.debug('session', 'hallucination segment dropped', segment);
+      }
     }
   }
 

--- a/timeline.md
+++ b/timeline.md
@@ -94,7 +94,7 @@ they establish. After that, the order optimizes for landing the user-visible
 filter fix (PR 3) early, then layering speculative + UX features on the stable
 finality and timing contracts.
 
-### PR 1 — Infrastructure baseline
+### PR 1 — Infrastructure baseline ✅ shipped (#61)
 
 Lock the contracts so every later PR plugs into a stable surface.
 
@@ -119,7 +119,7 @@ outcome, `is_final` parameter on `assemble_transcript`, typed finality on
 `StageOutcome`, `utterance_start_ms_in_session`, session-scoped feature
 snapshot.
 
-### PR 2 — VAD evidence through the pipeline
+### PR 2 — VAD evidence through the pipeline ✅ shipped (#67)
 
 The VAD signal becomes a first-class pipeline input. Every downstream stage
 that wants it (filter today, timestamp renderer tomorrow) reads it from a
@@ -173,7 +173,7 @@ Cohere adapter wiring that calls `voiced_fraction` per segment land with the
 hallucination filter that consumes them. Defining the wire shape now would
 risk rework when the only real consumer arrives.
 
-### PR 3 — Hallucination filter v2 (HARD / SOFT + corroboration)
+### PR 3 — Hallucination filter v2 (HARD / SOFT + corroboration) ⬅ next
 
 The user-visible quality fix. Today's filter drops `thank you` and `bye`
 unconditionally; this PR replaces that with evidence-based classification.


### PR DESCRIPTION
## Summary
- Replaces phrase-only hallucination filtering with a multi-signal classifier registered first in `post_engine_processors()`. HARD text artifacts (empty, punctuation-only, `[music]`-class tags, caption attributions) drop on text alone. SOFT artifacts (courtesy phrases, CTAs, bare URLs, bare "you") require one strong or two weak corroborators. Normal text drops as silence only when Whisper silence and VAD silence both agree, or as repetition / prompt-leak when corroborated. Partial revisions run the HARD subset only.
- Threads `SegmentDiagnostics` through `EngineTranscriptOutput` and `StageContext`. Whisper populates `no_speech_prob`, average token logprob (clamped, non-allocating empty-text check), and token count. Cohere populates selected-token logprob — computed via a fused argmax + streaming logsumexp in a single O(vocab) pass (was three passes per decoded token), plus `decode_reached_eos` and token count.
- Drops whole segments only and preserves engine timing for retained segments. Emits a compact `droppedSegments` payload (reason, index, raw text, timing provenance, model + VAD signals); developer-mode logs each entry from `DictationSessionController` using a typed `StageId` comparison. Skipped reasons are `disabled` (session-scoped flag) and `no_hallucinations` (nothing dropped, no revision churn).

## Alignment with research
- Dual-threshold model evidence (`no_speech_prob ≥ 0.60`, `avg_logprob ≤ -1.00`) matches OpenAI Whisper's defaults and the dual-gate pattern faster-whisper uses.
- Phrase blocklist covers the specific hallucinations called out in the Cornell *Careless Whisper* study (`Thank you for watching`, `Subtitles by …`) and the 2025 ISCA non-speech-induced hallucination paper.
- VAD corroboration (per-segment Silero voiced fraction + utterance evidence) matches the 2025 guidance that VAD must corroborate, never veto plausible speech.
- Repetition detection (3-gram + 5-gram dominance, suffix repeats, character-run pathology) targets the same failure mode as Whisper's `compression_ratio_threshold` with semantically directed signals.
- Goes beyond standard practice with a HARD/SOFT two-tier blocklist, prompt-leak detection (`Glossary:` scaffolding + 8-gram context match), and a partial-revision-safe rule subset.

## Test plan
- [x] `cargo test --lib` (130 passing, default features)
- [x] `cargo test --lib --features engine-cohere-transcribe` (Cohere argmax + logsumexp tests passing)
- [x] `npm test` (280 passing across 21 suites)
- [x] Hallucination filter has 23 unit tests covering: every HARD non-speech tag, caption attributions, bare URL keep, longer-sentence-with-soft-phrase keep, bare `you` keep, soft + strong-Whisper, soft + strong-VAD, soft + two-weak, soft + one-weak (kept), normal silence reason, 5-gram repetition, character-run pathology, disabled filter, drop-all-segments empty-list, payload shape (reason/index/text/timing/signals), partial-revision keep with strong diagnostics, and multi-segment preservation
- [ ] Manual: dictate "thank you" / "bye" / a URL into a real session and confirm none drop without corroboration
- [ ] Manual: feed a silent clip and confirm soft phrases drop with the reason payload appearing in dev-mode logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)