### PR TITLE
refactor: remove pause-while-processing mode

### DIFF
--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -296,8 +296,7 @@ Cargo features: `engine-whisper`, `engine-cohere-transcribe`, `gpu-metal`, `gpu-
 - Dedicated thread communicating via two `mpsc` channels (commands in, events out)
 - Holds `Arc<EngineRegistry>`; dispatches via `(runtimeId, familyId)` lookup on each `BeginSession`
 - All inference is **synchronous and blocking** in the worker thread
-- Back-pressure: `MAX_QUEUED_UTTERANCES = 1`. If a transcription is in-flight and 1 is already queued, additional utterances are **dropped** with a warning event
-- `pause_while_processing` setting (default `true`): discards incoming audio frames while the worker is busy, preventing unbounded queue growth
+- Back-pressure: the app queues finalized utterances while inference is in-flight, reports queue tiers, and stops the session at the hard cap instead of silently discarding audio during normal processing
 - Panic safety: `catch_unwind` wraps model loading and inference; panics produce `SessionError` events rather than crashing
 
 **Available models:**
@@ -377,8 +376,7 @@ flowchart LR
 | `listening` | audio-lines | Listening |
 | `speech_detected` | audio-lines | Hearing speech |
 | `speech_ending` | audio-lines | Hearing speech |
-| `transcribing` | audio-lines | Transcribing... |
-| `paused` | audio-lines | Processing... |
+| `transcribing` | loader | Transcribing... |
 | `error` | mic-off | Error |
 
 `speech_ending` fires when `frames_since_confident_speech >= silence_end_frames` *before* finalization runs on the same frame, so in today's flow it is only externally observable when the probability sits in the intermediate range (between the end and start thresholds) rather than true silence. The ribbon and in-note anchor intentionally treat it as part of the speaking phase — the hysteresis detail is internal to the state machine. See architectural seams below.
@@ -387,10 +385,10 @@ flowchart LR
 
 | Setting | Default | Purpose |
 |---------|---------|---------|
-| `listeningMode` | `one_sentence` | Dictation trigger behavior |
-| `insertionMode` | `insert_at_cursor` | Where transcript text lands |
+| `listeningMode` | `always_on` | Dictation trigger behavior |
+| `dictationAnchor` | `at_cursor` | Where transcript text lands |
+| `phraseSeparator` | `space` | How consecutive phrases are joined |
 | `speakingStyle` | `balanced` | UX preset driving the VAD tuning table (Responsive / Balanced / Patient) |
-| `pauseWhileProcessing` | `true` | Discard audio during inference |
 | `accelerationPreference` | `auto` | GPU vs CPU-only |
 | `selectedModel` | `null` | Active model selection |
 | `sidecarRequestTimeoutMs` | 300,000 (5 min) | Command/response timeout |

--- a/native/src/app.rs
+++ b/native/src/app.rs
@@ -68,7 +68,6 @@ struct ActiveSession {
     last_reported_queue_tier: QueueBackpressureTier,
     last_reported_state: Option<SessionState>,
     overload_draining: bool,
-    pause_while_processing: bool,
     pending_context_requests: Vec<PendingContextRequest>,
     queued_utterances: usize,
     session: ListeningSession,
@@ -176,22 +175,6 @@ impl AppState {
                 message: "Received audio without an active listening session.".to_string(),
                 session_id: None,
             });
-            return events;
-        }
-
-        let should_pause = self
-            .active_session
-            .as_ref()
-            .map(|active_session| {
-                active_session.pause_while_processing && active_session.transcription_active
-            })
-            .unwrap_or(false);
-
-        if should_pause {
-            if let Some(active_session) = self.active_session.as_mut() {
-                active_session.session.clear_activity();
-            }
-            self.emit_state_if_changed(&mut events);
             return events;
         }
 
@@ -399,7 +382,6 @@ impl AppState {
                 mode,
                 model_selection,
                 model_store_path_override,
-                pause_while_processing,
                 session_start_unix_ms,
                 session_id,
                 speaking_style,
@@ -475,7 +457,6 @@ impl AppState {
                             last_reported_queue_tier: QueueBackpressureTier::Normal,
                             last_reported_state: None,
                             overload_draining: false,
-                            pause_while_processing,
                             pending_context_requests: Vec::new(),
                             queued_utterances: 0,
                             session,
@@ -597,7 +578,6 @@ impl AppState {
         let next_state = derive_session_state(
             active_session.transcription_active,
             active_session.queued_utterances,
-            active_session.pause_while_processing,
             &active_session.session,
         );
 
@@ -1203,7 +1183,6 @@ fn resolved_model_supports_initial_prompt(
 fn derive_session_state(
     transcription_active: bool,
     queued_utterances: usize,
-    pause_while_processing: bool,
     session: &ListeningSession,
 ) -> SessionState {
     let base_state = session.base_state();
@@ -1217,10 +1196,6 @@ fn derive_session_state(
     }
 
     if transcription_active {
-        if pause_while_processing {
-            return SessionState::Paused;
-        }
-
         return SessionState::Transcribing;
     }
 
@@ -2107,30 +2082,6 @@ mod tests {
     }
 
     #[test]
-    fn audio_frames_are_ignored_while_transcription_pause_while_processing_is_true() {
-        let model_file_path = create_model_file();
-        let mut app = test_app();
-        let _ = app.handle_command(start_session_command("session-1", &model_file_path));
-
-        if let Some(active) = app.active_session.as_mut() {
-            active.transcription_active = true;
-        }
-
-        let frame = vec![0_u8; crate::protocol::PCM_BYTES_PER_FRAME];
-        let events = app.handle_audio_frame(frame);
-
-        let paused_event = events.iter().find_map(|event| match event {
-            Event::SessionStateChanged { state, .. } => Some(*state),
-            _ => None,
-        });
-        assert_eq!(
-            paused_event,
-            Some(SessionState::Paused),
-            "pause_while_processing must surface Paused state instead of ingesting the frame"
-        );
-    }
-
-    #[test]
     fn stop_with_queued_utterances_defers_session_stopped_until_drain() {
         let model_file_path = create_model_file();
         let mut app = test_app();
@@ -2375,7 +2326,6 @@ mod tests {
                 file_path: model_file_path.display().to_string(),
             },
             model_store_path_override: None,
-            pause_while_processing: true,
             session_start_unix_ms: 1_700_000_000_000,
             session_id: session_id.to_string(),
             speaking_style: SpeakingStyle::Balanced,

--- a/native/src/protocol.rs
+++ b/native/src/protocol.rs
@@ -93,7 +93,6 @@ pub enum SessionState {
     SpeechDetected,
     SpeechEnding,
     Transcribing,
-    Paused,
     Error,
 }
 
@@ -264,7 +263,6 @@ pub enum Command {
         model_selection: SelectedModel,
         #[serde(default)]
         model_store_path_override: Option<String>,
-        pause_while_processing: bool,
         session_start_unix_ms: u64,
         session_id: String,
         #[serde(default)]
@@ -579,7 +577,6 @@ mod tests {
                 "filePath": "/tmp/model.bin"
             },
             "language": "en",
-            "pauseWhileProcessing": true,
             "sessionStartUnixMs": 1_700_000_000_000_u64
         }))
         .expect("payload should serialize");
@@ -602,7 +599,6 @@ mod tests {
                     file_path: "/tmp/model.bin".to_string(),
                 },
                 model_store_path_override: None,
-                pause_while_processing: true,
                 session_start_unix_ms: 1_700_000_000_000,
                 session_id: "session-1".to_string(),
                 speaking_style: SpeakingStyle::Balanced,
@@ -623,7 +619,6 @@ mod tests {
                 "filePath": "/tmp/model.bin"
             },
             "language": "en",
-            "pauseWhileProcessing": true,
             "sessionStartUnixMs": 1_700_000_000_000_u64,
             "unknownFutureField": { "anything": true }
         }))
@@ -659,7 +654,6 @@ mod tests {
                     "filePath": "/tmp/model.bin"
                 },
                 "language": "en",
-                "pauseWhileProcessing": true,
                 "sessionStartUnixMs": 1_700_000_000_000_u64,
                 "speakingStyle": wire,
             }))

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -25,7 +25,6 @@ export type DictationControllerState =
   | 'speech_detected'
   | 'speech_ending'
   | 'transcribing'
-  | 'paused'
   | 'error';
 
 type ControllerSession = Pick<
@@ -39,7 +38,6 @@ interface ActiveSessionSnapshot {
   listeningMode: PluginSettings['listeningMode'];
   modelSelection: NonNullable<PluginSettings['selectedModel']>;
   modelStorePathOverride: string;
-  pauseWhileProcessing: boolean;
   phraseSeparator: PluginSettings['phraseSeparator'];
   sessionStartUnixMs: number;
   speakingStyle: PluginSettings['speakingStyle'];
@@ -152,7 +150,6 @@ export class DictationSessionController {
       listeningMode: settings.listeningMode,
       modelSelection: selectedModel,
       modelStorePathOverride: settings.modelStorePathOverride,
-      pauseWhileProcessing: settings.pauseWhileProcessing,
       phraseSeparator: settings.phraseSeparator,
       sessionStartUnixMs: Date.now(),
       speakingStyle: settings.speakingStyle,
@@ -215,7 +212,6 @@ export class DictationSessionController {
           language: 'en',
           mode: snapshot.listeningMode,
           modelSelection: snapshot.modelSelection,
-          pauseWhileProcessing: snapshot.pauseWhileProcessing,
           sessionStartUnixMs: snapshot.sessionStartUnixMs,
           sessionId,
           speakingStyle: snapshot.speakingStyle,
@@ -609,10 +605,5 @@ function createSessionId(): string {
 }
 
 function isAnchorVisibleSessionState(state: SessionState): boolean {
-  return (
-    state === 'speech_detected' ||
-    state === 'speech_ending' ||
-    state === 'transcribing' ||
-    state === 'paused'
-  );
+  return state === 'speech_detected' || state === 'speech_ending' || state === 'transcribing';
 }

--- a/src/settings/plugin-settings.ts
+++ b/src/settings/plugin-settings.ts
@@ -27,7 +27,6 @@ export interface PluginSettings {
   dictationAnchor: DictationAnchor;
   listeningMode: ListeningMode;
   modelStorePathOverride: string;
-  pauseWhileProcessing: boolean;
   phraseSeparator: PhraseSeparator;
   selectedModel: SelectedModel | null;
   sidecarPathOverride: string;
@@ -42,9 +41,8 @@ export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
   cudaLibraryPath: '',
   developerMode: false,
   dictationAnchor: 'at_cursor',
-  listeningMode: 'one_sentence',
+  listeningMode: 'always_on',
   modelStorePathOverride: '',
-  pauseWhileProcessing: true,
   phraseSeparator: 'space',
   selectedModel: null,
   sidecarPathOverride: '',
@@ -68,10 +66,6 @@ export function resolvePluginSettings(data: unknown): PluginSettings {
     modelStorePathOverride: readString(
       raw.modelStorePathOverride,
       DEFAULT_PLUGIN_SETTINGS.modelStorePathOverride,
-    ),
-    pauseWhileProcessing: readBoolean(
-      raw.pauseWhileProcessing,
-      DEFAULT_PLUGIN_SETTINGS.pauseWhileProcessing,
     ),
     phraseSeparator: isPhraseSeparator(raw.phraseSeparator)
       ? raw.phraseSeparator

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -128,23 +128,7 @@ export class LocalSttSettingTab extends PluginSettingTab {
         dropdown.onChange(async (value) => {
           await this.persistSettings({
             ...this.dependencies.getSettings(),
-            listeningMode:
-              value === 'always_on' || value === 'one_sentence' ? value : 'one_sentence',
-          });
-        });
-      });
-
-    new Setting(containerEl)
-      .setName('Pause while processing')
-      .setDesc(
-        'When enabled, capture pauses while a previous utterance is being transcribed. Disable to keep capturing — utterances queue in order and the session stops if the queue saturates.',
-      )
-      .addToggle((toggle) => {
-        toggle.setValue(settings.pauseWhileProcessing);
-        toggle.onChange(async (value) => {
-          await this.persistSettings({
-            ...this.dependencies.getSettings(),
-            pauseWhileProcessing: value,
+            listeningMode: value === 'always_on' || value === 'one_sentence' ? value : 'always_on',
           });
         });
       });

--- a/src/sidecar/protocol.ts
+++ b/src/sidecar/protocol.ts
@@ -49,7 +49,6 @@ export const SESSION_STATES = [
   'error',
   'idle',
   'listening',
-  'paused',
   'speech_detected',
   'speech_ending',
   'transcribing',
@@ -134,7 +133,6 @@ export interface StartSessionCommand extends EnvelopeBase<'start_session'> {
   mode: ListeningMode;
   modelSelection: SelectedModel;
   modelStorePathOverride?: string;
-  pauseWhileProcessing: boolean;
   sessionStartUnixMs: number;
   sessionId: string;
   speakingStyle: SpeakingStyle;

--- a/src/ui/dictation-ribbon.ts
+++ b/src/ui/dictation-ribbon.ts
@@ -73,7 +73,6 @@ function buildRibbonState(
       return { icon: 'audio-lines', label: 'Local Transcript: Hearing speech' };
 
     case 'transcribing':
-    case 'paused':
       return queueTier === 'catching_up'
         ? { icon: 'loader', label: 'Local Transcript: Catching up...' }
         : { icon: 'loader', label: 'Local Transcript: Transcribing...' };
@@ -92,7 +91,6 @@ function toVisualState(state: DictationControllerState): RibbonVisualState {
     case 'listening':
       return 'listening';
     case 'transcribing':
-    case 'paused':
       return 'working';
     case 'speech_detected':
     case 'speech_ending':

--- a/test/dictation-ribbon.test.ts
+++ b/test/dictation-ribbon.test.ts
@@ -34,7 +34,6 @@ describe('DictationRibbonController', () => {
     { state: 'speech_detected', icon: 'audio-lines', visual: 'speech_detected' },
     { state: 'speech_ending', icon: 'audio-lines', visual: 'speech_detected' },
     { state: 'transcribing', icon: 'loader', visual: 'working' },
-    { state: 'paused', icon: 'loader', visual: 'working' },
     { state: 'error', icon: 'mic-off', visual: 'error' },
   ] as const)('maps $state → icon=$icon, dataset=$visual', async ({ state, icon, visual }) => {
     const { setIcon } = await import('obsidian');
@@ -48,14 +47,11 @@ describe('DictationRibbonController', () => {
     expect(dataset.localSttState).toBe(visual);
   });
 
-  it('maps transcribing and paused to the working ribbon dataset', () => {
+  it('maps transcribing to the working ribbon dataset', () => {
     const { element, dataset } = createFakeElement();
     const controller = new DictationRibbonController(element);
 
     controller.setState('transcribing');
-    expect(dataset.localSttState).toBe('working');
-
-    controller.setState('paused');
     expect(dataset.localSttState).toBe('working');
   });
 
@@ -64,10 +60,6 @@ describe('DictationRibbonController', () => {
     const controller = new DictationRibbonController(element);
 
     controller.setState('transcribing');
-    expect(setAttribute).toHaveBeenCalledWith('aria-label', 'Local Transcript: Transcribing...');
-    expect(element.title).toBe('Local Transcript: Transcribing...');
-
-    controller.setState('paused');
     expect(setAttribute).toHaveBeenCalledWith('aria-label', 'Local Transcript: Transcribing...');
     expect(element.title).toBe('Local Transcript: Transcribing...');
 

--- a/test/plugin-settings.test.ts
+++ b/test/plugin-settings.test.ts
@@ -15,7 +15,6 @@ describe('resolvePluginSettings', () => {
         dictationAnchor: 'end_of_note',
         listeningMode: 'always_on',
         modelStorePathOverride: ' /tmp/models ',
-        pauseWhileProcessing: false,
         phraseSeparator: 'new_paragraph',
         selectedModel: {
           familyId: 'whisper',
@@ -36,7 +35,6 @@ describe('resolvePluginSettings', () => {
       dictationAnchor: 'end_of_note',
       listeningMode: 'always_on',
       modelStorePathOverride: '/tmp/models',
-      pauseWhileProcessing: false,
       phraseSeparator: 'new_paragraph',
       selectedModel: {
         familyId: 'whisper',
@@ -81,7 +79,6 @@ describe('resolvePluginSettings', () => {
         dictationAnchor: 'at_end',
         listeningMode: 'unsupported',
         modelStorePathOverride: 42,
-        pauseWhileProcessing: 'sometimes',
         phraseSeparator: 'tab',
         sidecarPathOverride: 12,
         sidecarRequestTimeoutMs: -1,

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -45,7 +45,6 @@ describe('sidecar protocol', () => {
         kind: 'external_file',
         runtimeId: 'whisper_cpp',
       },
-      pauseWhileProcessing: true,
       sessionStartUnixMs: 1_700_000_000_000,
       sessionId: 'session-gpu',
       speakingStyle: 'balanced',

--- a/timeline.md
+++ b/timeline.md
@@ -232,9 +232,8 @@ that processes in order and never drops audio:
 | 10+ | Visible warning: "Transcription is falling behind — pause to let it catch up." |
 | 30 (hard cap) | Stop session with a clear error. Save what's already transcribed. |
 
-`pause_while_processing` is an independent user setting; it is not
-repurposed as the emergency brake. Hard cap = stop session is the only
-no-audio-drop outcome at saturation.
+There is no pause-while-processing mode. The hard cap stops the session instead
+of silently dropping audio during normal processing.
 
 **Pause metadata (PR 5 / PR 6 prerequisite).**
 


### PR DESCRIPTION
## Summary

- The queue + hard-cap path from #69 supersedes pause-while-processing as the backpressure mechanism, so the setting and the `Paused` session state become dead weight.
- Drop pause-while-processing end-to-end (plugin, sidecar, wire protocol, settings UI, tests, docs) and flip the `listeningMode` default to `always_on` to match the always-listening posture.

## Key changes

- **Plugin (`src/`)**: drop `pauseWhileProcessing` from `PluginSettings`, the settings-tab toggle, the controller's `ActiveSessionSnapshot`, and the ribbon's `paused` mapping. `resolvePluginSettings` silently drops the legacy field for upgrading vaults.
- **Sidecar (`native/`)**: remove `pause_while_processing` from `Command::StartSession` and `ActiveSession`, drop the audio-frame short-circuit in `handle_audio_frame`, and remove the `pause_while_processing` parameter from `derive_session_state`. Remove `SessionState::Paused`. Frames now flow into the session normally during inference; the queue absorbs them and the existing hard cap (`MAX_QUEUED_UTTERANCES = 30`) stops the session if it saturates.
- **Wire protocol**: `pauseWhileProcessing` removed from the `start_session` command on both sides; `paused` removed from `SESSION_STATES` and the Rust `SessionState` enum.
- **Defaults**: `listeningMode: 'one_sentence' → 'always_on'`.
- **Docs**: `docs/system-architecture.md` settings table and state list updated; `timeline.md` PR 4 prose now states there is no pause-while-processing mode.

## Notes

### Wire protocol

Breaking change to `start_session`. A pre-upgrade plugin paired with a post-upgrade sidecar will still work because Rust deserializes `start_session` with `#[serde(default)]` on the unrelated optional fields and ignores unknown keys; the dropped `pauseWhileProcessing` key is simply discarded. The reverse pairing (post-upgrade plugin, pre-upgrade sidecar) means the sidecar runs without the pause behavior — desirable, since the sidecar will fall back to its old default. Plugin and sidecar ship together, so this is informational.

### Settings migration

Saved vaults carrying `pauseWhileProcessing: true` from prior versions are silently dropped by `resolvePluginSettings` (same shape as the documented `insertionMode` legacy-drop) — no migration code needed.

## Test plan

- [x] `npm run typecheck` (clean)
- [x] `npm run lint` (clean)
- [x] `npm run test` (vitest 296/296 pass)
- [x] `npm run build:frontend` (esbuild produces 118kb `main.js`)
- [x] `cargo test --lib` (154/154 pass)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [ ] Manual: start a long always-on session, generate continuous utterances faster than inference can drain — verify the queue fills, the catching-up tier surfaces in the ribbon, and the session stops cleanly at the hard cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)