### PR TITLE
Unify sidecar download UX with plugin-owned install manager

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -1,0 +1,314 @@
+# Unify download UX (closes #74 and #54)
+
+## Context
+
+Today, the sidecar install lives entirely inside `SidecarInstallModal`: the
+modal owns the `AbortController`, and `onClose()` aborts the download — so an
+accidental dismiss kills a multi-megabyte fetch. Progress only renders inside
+the modal, so there is no persistent surface to monitor or cancel from.
+
+Model installs already follow the right pattern: a long-lived plugin-owned
+`ModelInstallManager` owns active install state, the manage-models modal and
+the inline settings section both subscribe, and closing the modal does NOT
+abort. The Rust sidecar runs the model download, so the lifecycle is naturally
+decoupled from the UI.
+
+This plan unifies sidecar install with the model pattern (closes #74) and
+addresses the rest of #54: a prominent install card on the settings page when
+sidecar is missing, and gating the rarely-used Sidecar path override behind
+Developer mode.
+
+The intended outcome:
+- Closing the install modal never kills the download.
+- Both download surfaces (model + sidecar) follow the same shape, so a future
+  "thing to download" can copy the established pattern.
+- A user who lands on the settings page without a sidecar sees one obvious
+  CTA at the top.
+- The Advanced section drops noise that the typical user can't act on.
+
+CUDA library path was already Linux-gated; no change needed there.
+
+## Branch
+
+`feat/unify-download-ux` from `main`.
+
+## File-by-file changes
+
+### 1. NEW — `src/sidecar/sidecar-install-manager.ts`
+
+Mirrors `ModelInstallManager` shape. Long-lived, plugin-owned.
+
+```ts
+type SidecarInstallPhase = 'installing' | 'canceling';
+
+interface ActiveSidecarInstall {
+  variant: SidecarInstallVariant;       // 'cpu' | 'cuda'
+  intent: InstallIntent;                // 'first-run' | 'install' | 'reinstall'
+  copy: InstallCopy;                    // for display + success notice
+  progress: {
+    phase: 'download' | 'verify' | 'extract';
+    bytesDownloaded: number;
+    totalBytes: number | null;
+  };
+  phase: SidecarInstallPhase;
+  lastError: string | null;
+}
+
+interface SidecarInstallManagerState {
+  activeInstall: ActiveSidecarInstall | null;
+}
+```
+
+Public API: `subscribe(listener)`, `getState()`, `install(opts)`, `cancel()`,
+`dispose()`.
+
+`install(opts)`:
+- Throws if `activeInstall !== null`.
+- Sets initial active state, creates `AbortController`, notifies.
+- Spawns `void this.runInstall(opts, controller.signal)` — fire-and-forget.
+- Returns after kickoff (so the modal can transition to in-progress state).
+
+`runInstall(opts, signal)`:
+- Calls `installSidecar({ ...opts, signal, onProgress: (p) => updateProgress(p) })`.
+- On success: invokes `opts.onInstalled()`, fires `notice(opts.copy.successNotice)`,
+  clears `activeInstall`, notifies.
+- On failure (non-abort): sets `lastError`, fires error notice, clears
+  `activeInstall`, notifies.
+- On abort: fires `notice('Sidecar install cancelled.')`, clears
+  `activeInstall`, notifies.
+
+`cancel()`:
+- No-op unless `phase === 'installing'`.
+- Sets `phase: 'canceling'`, notifies.
+- Calls `controller.abort()` (synchronous; in-process). No `cancelStuck` state
+  needed — the model manager needed it because cancel goes over IPC; the
+  sidecar AbortController acts immediately.
+
+`dispose()`: aborts in-flight install, clears listeners.
+
+Constructor deps: `{ notice: (msg: string) => void; logger?: PluginLogger }`.
+
+`install(opts)` parameter shape:
+```ts
+{ variant, intent, copy, version, pluginDirectory,
+  beforeReplace?: () => Promise<void>, onInstalled: () => Promise<void> }
+```
+
+Per-install callbacks (not constructor-level) because CUDA install also persists
+`accelerationPreference='auto'` via `onInstalled`, while CPU does not.
+
+Helper (also in this file):
+```ts
+function buildSidecarProgressState(active: ActiveSidecarInstall): InstallProgressState
+```
+Maps sidecar `progress.phase` → a non-null `message` string ("Downloading",
+"Verifying checksum…", "Extracting archive…") and supplies a plausible `state`
+value (e.g. `'downloading'`). The progress renderer uses `message` first and
+falls back to `state` only when `message` is null, so this works without
+touching the existing renderer.
+
+### 2. `src/setup/sidecar-install-modal.ts` — slim down + live progress mode
+
+Remove: `abortController`, `installInProgress`, all of `progressLabelEl` /
+`progressBarEl` / `statusEl`, `updateProgress`, `setProgressPercent`,
+`setStatus`. Drop `installSidecar` import.
+
+Constructor now takes `manager: SidecarInstallManager` instead of the install
+plumbing. Still takes `variant`, `intent`, `copy`, `version`, `pluginDirectory`,
+`beforeReplace`, `onInstalled` — these are forwarded to `manager.install(...)`.
+
+`onOpen()`: subscribe to manager. Render the modal contents based on current
+state. `onClose()`: unsubscribe. **Never abort.**
+
+Render states (the modal re-renders content on subscription ticks; in-place
+progress updates use `updateInstallProgressElement` for low-churn ticks):
+
+| State | Body | Primary | Secondary |
+|---|---|---|---|
+| Pre-install (no active) | Body text + asset + version | `copy.primaryButtonText` → `manager.install(...)` | "Later" → close |
+| In-progress | Inline `createInstallProgressElement` | "Downloading…" disabled | "Close" → close, no abort |
+| Failed (lastError captured locally before activeInstall clears) | Error message | "Retry download" → kick off again | "Close" |
+
+On terminal events: success → modal auto-closes (Notice fires from manager).
+Cancellation → modal auto-closes (Notice fires from manager). Failure → modal
+stays open with Retry. Catch the kickoff promise to show a Notice if
+`manager.install()` itself rejects (e.g. concurrent install).
+
+### 3. `src/setup/first-run-setup-modal.ts` — passthrough manager
+
+Add `manager: SidecarInstallManager` to `FirstRunSetupOptions`. Pass it into
+the `SidecarInstallModal` constructor.
+
+### 4. NEW — `src/settings/install-progress-row.ts` — small shared helper
+
+Two consumers (model + sidecar settings sections). Justified shared helper.
+
+```ts
+export interface ActiveInstallCardOptions {
+  name: string;                       // e.g. "Installing: tiny.en"
+  progressState: InstallProgressState;
+  isCancelling: boolean;
+  onCancel: () => void;
+}
+
+export function renderActiveInstallCard(
+  container: HTMLElement,
+  opts: ActiveInstallCardOptions,
+): { progressEl: HTMLDivElement }
+```
+
+Builds a `Setting` row: `name` in name slot, `createInstallProgressElement` in
+desc slot, single button "Cancel" / "Cancelling…" (disabled when cancelling)
+calling `onCancel`. Returns `progressEl` so callers can update it in place
+between renders.
+
+### 5. `src/models/model-settings-section.ts` — use shared helper + add Cancel
+
+Replace lines ~104-124 (the inline "Installing: X" Setting construction) with
+`renderActiveInstallCard(container, { name: 'Installing: ' + displayName,
+progressState, isCancelling, onCancel: () => void manager.cancel() })`. Store
+the returned `progressEl` for the existing in-place fast-update path in
+`handleStateChange`.
+
+### 6. `src/settings/settings-tab.ts` — three changes
+
+**a. Subscribe to sidecar manager + inline card.**
+Add `sidecarInstallManager: SidecarInstallManager` to `SettingsTabDependencies`.
+In `renderSidecarSection`, after the existing rows, if
+`manager.getState().activeInstall !== null`, append an inline card via
+`renderActiveInstallCard(...)`. Subscribe to manager state changes; track the
+dispose function in a new `disposeSidecarSection` field, cleared in
+`tearDown()`. Pass `manager` to `openInstallModal` / `openCudaInstallModal`.
+
+**b. Banner install card at the top when sidecar missing (issue #54).**
+At the very top of `display()`, before the Model section: detect whether the
+sidecar is installed by reading both manifests
+(`readInstallManifest(variantDirectoryPath(pluginDirectory, 'cpu'|'cuda'))`).
+If both are null, render a `setting-group` with a single Setting row:
+- name: "Sidecar required"
+- desc: "Local Dictation needs the speech-to-text sidecar to work. Install it
+  to enable dictation."
+- primary button (CTA): "Install sidecar" → opens the CPU install modal (same
+  path as the existing Sidecar section button).
+The banner subscribes to the sidecar manager too, so when an install becomes
+active, the banner can show inline progress (reusing
+`renderActiveInstallCard`) and disappears on completion. Use the existing
+`disposeSidecarSection` subscription so banner + sidecar section share
+re-render triggers, or add a sibling subscription with separate dispose.
+
+Implementation: extract a small helper
+`renderMissingSidecarBanner(container, deps): () => void` co-located with the
+settings tab (private method). It returns a disposer.
+
+**c. Gate dev-only sidecar fields behind Developer mode (issue #54).**
+In `renderSidecarSection`, wrap each of these in
+`if (this.dependencies.getSettings().developerMode) { ... }`:
+- `sidecarPathOverride` (text)
+- `sidecarStartupTimeoutSeconds` (positive int)
+- `sidecarRequestTimeoutSeconds` (positive int)
+
+`cudaLibraryPath` stays as-is (Linux-only — useful for Flatpak end users).
+
+In the Developer mode toggle's `addToggleSetting`, add a follow-up that calls
+`this.display()` after persisting, so the gated fields appear/disappear
+immediately when the toggle flips. Easiest path: inline the toggle (not via
+`addToggleSetting`) in the Advanced section so the change handler can call
+both `persistOne` and `this.display()`.
+
+### 7. `src/main.ts` — instantiate, wire, dispose
+
+After existing managers in `onload`:
+
+```ts
+this.sidecarInstallManager = new SidecarInstallManager({
+  logger: this.logger,
+  notice: (message) => { new Notice(message); },
+});
+```
+
+Pass into:
+- `LocalSttSettingTab` deps.
+- `openFirstRunSetupModal` options (add `manager` field).
+
+`onunload`: `this.sidecarInstallManager?.dispose()` (aborts any in-flight install).
+
+## Edge cases handled
+
+- **Modal closed mid-install**: download keeps running on the manager.
+  Reopening the modal renders live progress immediately because the modal
+  subscribes to current state.
+- **Plugin unloaded mid-install**: `dispose()` aborts the AbortController.
+  `installSidecar`'s catch block already cleans the staging dir.
+- **Concurrent install**: `install()` throws; modal click handler shows Notice.
+- **Cancel after completion**: `cancel()` checks `phase === 'installing'`;
+  no-op otherwise.
+- **CUDA `accelerationPreference` side effect**: still fires via the
+  per-install `onInstalled` callback that the manager invokes on success.
+- **Windows DLL handle on sidecar replace**: still fires via `beforeReplace`
+  callback, invoked inside `installSidecar` before the rename.
+- **Banner during install**: banner shows progress while installing; remains
+  visible until the install completes and the manifest exists.
+- **Developer mode toggle**: re-renders settings so the gated dev fields
+  (path override + both timeouts) appear/disappear without requiring a
+  settings-tab close/reopen.
+
+## Critical files
+
+- `src/sidecar/sidecar-install-manager.ts` (new)
+- `src/setup/sidecar-install-modal.ts`
+- `src/setup/first-run-setup-modal.ts`
+- `src/settings/install-progress-row.ts` (new)
+- `src/settings/settings-tab.ts`
+- `src/models/model-settings-section.ts`
+- `src/main.ts`
+
+## Reused functions (no changes)
+
+- `installSidecar` — `src/sidecar/sidecar-installer.ts`
+- `createInstallProgressElement` / `updateInstallProgressElement` —
+  `src/models/model-install-progress.ts`
+- `getInstallCopy` — `src/setup/sidecar-install-copy.ts`
+- `formatErrorMessage` — `src/shared/format-utils.ts`
+- `readInstallManifest` / `variantDirectoryPath` —
+  `src/sidecar/sidecar-installer.ts`
+- `ModelInstallManager.cancel()` (consumed from new model card Cancel button)
+
+## Verification
+
+1. **Build & types**: `npm run typecheck` and `npm run build` — no errors.
+2. **Lint** (if present in package.json) — clean.
+3. **Manual UI test (desktop Obsidian, dev vault)**:
+   - Delete `bin/cpu` and `bin/cuda` directories, restart plugin →
+     first-run modal opens AND the settings page shows the banner. Click
+     Download in modal. Confirm: progress bar appears in the modal AND in the
+     banner / Sidecar section. Close modal. Confirm settings still updates and
+     the download continues to completion. Success Notice fires. Sidecar
+     restarts. Banner disappears.
+   - Trigger CUDA install from settings (with NVIDIA driver present). Same flow.
+     Confirm `accelerationPreference` flips to `'auto'` after success.
+   - Trigger a CPU reinstall, then click Cancel from the settings card while
+     in-progress. Confirm the download aborts (staging dir cleaned, no
+     leftover archive in `bin/.cpu-staging/`), Notice
+     "Sidecar install cancelled." fires.
+   - Open Manage Models modal, start an install, close the manage-models modal,
+     then click Cancel on the Settings → Model "Installing: X" card. Confirm
+     the model install actually cancels.
+   - Toggle Developer mode off → Sidecar path override, startup timeout, and
+     request timeout all disappear. Toggle on → they reappear. Confirm
+     `cudaLibraryPath` (Linux only) remains unaffected by this gating.
+4. **Regression checks**:
+   - Sidecar install/uninstall buttons in settings still behave when no install
+     is active.
+   - `isDictationBusy()` guard still prevents installs during active dictation.
+   - When sidecar IS installed, the banner does NOT appear.
+   - `developerMode = true` users still see the path override and timeouts;
+     existing values in `data.json` continue to take effect regardless of UI
+     visibility.
+
+## Distillation after merge
+
+Per AGENTS.md: this PLANS.md is temporary. After merge:
+- Add a one-paragraph entry to `docs/decisions.md` if a load-bearing
+  architectural shape was confirmed (e.g. "long-lived install manager owns
+  download lifecycle; UI subscribes").
+- Delete this file.

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import { createPluginLogger, type PluginLogger } from './shared/plugin-logger';
 import { assertSidecarExecutableIsFresh } from './sidecar/sidecar-build-state';
 import { SidecarConnection } from './sidecar/sidecar-connection';
 import { formatSidecarExecutableName } from './sidecar/sidecar-executable';
+import { SidecarInstallManager } from './sidecar/sidecar-install-manager';
 import { resolveSidecarExecutablePath, SidecarNotInstalledError } from './sidecar/sidecar-paths';
 import type { SidecarLaunchSpec } from './sidecar/sidecar-process';
 import { DictationRibbonController } from './ui/dictation-ribbon';
@@ -34,6 +35,7 @@ export default class LocalSttPlugin extends Plugin {
   private ribbonController: DictationRibbonController | null = null;
   private settings: PluginSettings = DEFAULT_PLUGIN_SETTINGS;
   private sidecarConnection: SidecarConnection | null = null;
+  private sidecarInstallManager: SidecarInstallManager | null = null;
 
   override async onload(): Promise<void> {
     this.settings = resolvePluginSettings(await this.loadData());
@@ -55,6 +57,12 @@ export default class LocalSttPlugin extends Plugin {
         await this.updateSettings(nextSettings);
       },
       sidecarConnection: this.sidecarConnection,
+    });
+    this.sidecarInstallManager = new SidecarInstallManager({
+      logger: this.logger,
+      notice: (message) => {
+        new Notice(message);
+      },
     });
 
     const ribbonElement = this.addRibbonIcon('mic', 'Local Dictation: Click to start', () => {
@@ -105,6 +113,7 @@ export default class LocalSttPlugin extends Plugin {
           await this.updateSettings(nextSettings);
         },
         sidecarConnection: this.requireSidecarConnection(),
+        sidecarInstallManager: this.requireSidecarInstallManager(),
       }),
     );
 
@@ -160,7 +169,7 @@ export default class LocalSttPlugin extends Plugin {
     }
 
     openFirstRunSetupModal(this.app, {
-      logger: this.logger,
+      manager: this.requireSidecarInstallManager(),
       onInstalled: async () => {
         await this.requireSidecarConnection().restart(
           this.settings.sidecarStartupTimeoutSeconds * 1000,
@@ -179,6 +188,12 @@ export default class LocalSttPlugin extends Plugin {
       this.modelInstallManager?.dispose();
     } catch (error) {
       this.logger.error('model', 'failed to dispose model install manager cleanly', error);
+    }
+
+    try {
+      this.sidecarInstallManager?.dispose();
+    } catch (error) {
+      this.logger.error('installer', 'failed to dispose sidecar install manager cleanly', error);
     }
 
     try {
@@ -267,6 +282,14 @@ export default class LocalSttPlugin extends Plugin {
     }
 
     return this.modelInstallManager;
+  }
+
+  private requireSidecarInstallManager(): SidecarInstallManager {
+    if (this.sidecarInstallManager === null) {
+      throw new Error('Sidecar install manager has not been initialized.');
+    }
+
+    return this.sidecarInstallManager;
   }
 
   private async resolveSidecarLaunchSpec(): Promise<SidecarLaunchSpec> {

--- a/src/settings/install-progress-row.ts
+++ b/src/settings/install-progress-row.ts
@@ -1,0 +1,32 @@
+import { Setting } from 'obsidian';
+
+import {
+  createInstallProgressElement,
+  type InstallProgressState,
+} from '../models/model-install-progress';
+
+export interface ActiveInstallCardOptions {
+  isCancelling: boolean;
+  name: string;
+  onCancel: () => void;
+  progressState: InstallProgressState;
+}
+
+export function renderActiveInstallCard(
+  container: HTMLElement,
+  opts: ActiveInstallCardOptions,
+): { progressEl: HTMLDivElement } {
+  const progressEl = createInstallProgressElement(opts.progressState);
+  const fragment = document.createDocumentFragment();
+  fragment.append(progressEl);
+
+  const setting = new Setting(container).setName(opts.name).setDesc(fragment);
+  setting.addButton((button) => {
+    button
+      .setButtonText(opts.isCancelling ? 'Cancelling...' : 'Cancel')
+      .setDisabled(opts.isCancelling)
+      .onClick(opts.onCancel);
+  });
+
+  return { progressEl };
+}

--- a/src/settings/model-settings-section.ts
+++ b/src/settings/model-settings-section.ts
@@ -1,11 +1,9 @@
 import { Setting } from 'obsidian';
 
 import { isCancellingPhase, type ModelInstallManager } from '../models/model-install-manager';
-import {
-  createInstallProgressElement,
-  updateInstallProgressElement,
-} from '../models/model-install-progress';
+import { updateInstallProgressElement } from '../models/model-install-progress';
 import { deriveCurrentModelDisplay } from '../models/model-row-state';
+import { renderActiveInstallCard } from './install-progress-row';
 
 // ---------------------------------------------------------------------------
 // Badge helper (maps installedLabel -> CSS modifier + display text)
@@ -107,9 +105,6 @@ export function renderModelSection(
         ...activeInstall.installUpdate,
         isCancelling: isCancellingPhase(activeInstall.phase),
       };
-      const progressEl = createInstallProgressElement(progressState);
-      installProgressEl = progressEl;
-
       const activeInstallDisplayName =
         state.catalog.models.find(
           (m) =>
@@ -118,9 +113,16 @@ export function renderModelSection(
             m.modelId === activeInstall.installUpdate.modelId,
         )?.displayName ?? activeInstall.installUpdate.modelId;
 
-      const fragment = document.createDocumentFragment();
-      fragment.append(progressEl);
-      new Setting(container).setName(`Installing: ${activeInstallDisplayName}`).setDesc(fragment);
+      const isCancelling = isCancellingPhase(activeInstall.phase);
+      const { progressEl } = renderActiveInstallCard(container, {
+        isCancelling,
+        name: `Installing: ${activeInstallDisplayName}`,
+        onCancel: () => {
+          void manager.cancel();
+        },
+        progressState,
+      });
+      installProgressEl = progressEl;
     }
   }
 

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -3,6 +3,7 @@ import { Notice, Platform, PluginSettingTab, Setting } from 'obsidian';
 import { resolveEngineCapabilities } from '../models/capability-view';
 import { ManageModelsModal } from '../models/manage-models-modal';
 import type { ModelInstallManager } from '../models/model-install-manager';
+import { updateInstallProgressElement } from '../models/model-install-progress';
 import { ExternalModelFileModal, ModelDetailsModal } from '../models/model-management-modals';
 import { matchesModelTriple } from '../models/model-management-types';
 import { getInstallCopy, type InstallIntent } from '../setup/sidecar-install-copy';
@@ -13,12 +14,17 @@ import { detectNvidiaDriver, type NvidiaDriverStatus } from '../sidecar/gpu-prec
 import type { SpeakingStyle } from '../sidecar/protocol';
 import type { SidecarConnection } from '../sidecar/sidecar-connection';
 import {
+  buildSidecarProgressState,
+  type SidecarInstallManager,
+} from '../sidecar/sidecar-install-manager';
+import {
   type InstallManifest,
   readInstallManifest,
   type SidecarInstallVariant,
   uninstallSidecarVariant,
   variantDirectoryPath,
 } from '../sidecar/sidecar-installer';
+import { renderActiveInstallCard } from './install-progress-row';
 import { renderModelSection } from './model-settings-section';
 import {
   type DictationAnchor,
@@ -40,6 +46,7 @@ interface SettingsTabDependencies {
   restartSidecar: () => Promise<void>;
   saveSettings: (settings: PluginSettings) => Promise<void>;
   sidecarConnection: Pick<SidecarConnection, 'shutdown'>;
+  sidecarInstallManager: SidecarInstallManager;
 }
 
 // Filters PluginSettings keys whose value type is exactly T (not just assignable
@@ -90,8 +97,12 @@ const SPEAKING_STYLE_OPTIONS: ReadonlyArray<DropdownOption<SpeakingStyle>> = [
 
 export class LocalSttSettingTab extends PluginSettingTab {
   private disposeEngineSection: (() => void) | null = null;
+  private disposeMissingSidecarBanner: (() => void) | null = null;
   private disposeModelSection: (() => void) | null = null;
+  private disposeSidecarSection: (() => void) | null = null;
+  private missingSidecarProgressEl: HTMLDivElement | null = null;
   private nvidiaDriverStatus: Promise<NvidiaDriverStatus> | null = null;
+  private sidecarProgressEl: HTMLDivElement | null = null;
 
   constructor(
     app: App,
@@ -109,6 +120,9 @@ export class LocalSttSettingTab extends PluginSettingTab {
 
     containerEl.empty();
     containerEl.createEl('h2', { text: 'Local Dictation' });
+
+    const missingSidecarGroup = containerEl.createDiv({ cls: 'setting-group' });
+    this.disposeMissingSidecarBanner = this.renderMissingSidecarBanner(missingSidecarGroup);
 
     // --- Model ---
     const modelSection = this.createSettingGroup(containerEl, 'Model');
@@ -201,6 +215,9 @@ export class LocalSttSettingTab extends PluginSettingTab {
     // --- Sidecar ---
     const sidecarSection = this.createSettingGroup(containerEl, 'Sidecar');
     void this.renderSidecarSection(sidecarSection);
+    this.disposeSidecarSection = this.dependencies.sidecarInstallManager.subscribe(() => {
+      this.handleSidecarSectionChange(sidecarSection);
+    });
 
     // --- Advanced ---
     const advancedSection = this.createSettingGroup(containerEl, 'Advanced');
@@ -214,10 +231,15 @@ export class LocalSttSettingTab extends PluginSettingTab {
       placeholder: 'Use the shared default model store',
     });
 
-    this.addToggleSetting(advancedSection, {
-      name: 'Developer mode',
-      desc: 'Verbose console diagnostics.',
-      key: 'developerMode',
+    const developerModeSetting = new Setting(advancedSection)
+      .setName('Developer mode')
+      .setDesc('Verbose console diagnostics.');
+    developerModeSetting.addToggle((toggle) => {
+      toggle.setValue(this.dependencies.getSettings().developerMode);
+      toggle.onChange(async (value) => {
+        await this.persistOne('developerMode', value);
+        this.display();
+      });
     });
   }
 
@@ -230,6 +252,12 @@ export class LocalSttSettingTab extends PluginSettingTab {
     this.disposeModelSection = null;
     this.disposeEngineSection?.();
     this.disposeEngineSection = null;
+    this.disposeSidecarSection?.();
+    this.disposeSidecarSection = null;
+    this.disposeMissingSidecarBanner?.();
+    this.disposeMissingSidecarBanner = null;
+    this.sidecarProgressEl = null;
+    this.missingSidecarProgressEl = null;
     this.nvidiaDriverStatus = null;
   }
 
@@ -334,6 +362,9 @@ export class LocalSttSettingTab extends PluginSettingTab {
   }
 
   private async renderSidecarSection(section: HTMLDivElement): Promise<void> {
+    section.empty();
+    this.sidecarProgressEl = null;
+
     const pluginDirectory = await this.resolvePluginDirectorySafe();
     if (pluginDirectory === null || !section.isConnected) return;
 
@@ -365,14 +396,6 @@ export class LocalSttSettingTab extends PluginSettingTab {
       if (!section.isConnected) return;
     }
 
-    this.addTextSetting(section, {
-      name: 'Sidecar path override',
-      desc: 'Custom sidecar executable.',
-      tooltip: 'Optional absolute path to an installed or dev sidecar executable file.',
-      key: 'sidecarPathOverride',
-      placeholder: 'Auto-detect from bin/cpu, bin/cuda, or native/target debug builds',
-    });
-
     if (Platform.isLinux) {
       this.addTextSetting(section, {
         name: 'CUDA library path',
@@ -384,20 +407,133 @@ export class LocalSttSettingTab extends PluginSettingTab {
       });
     }
 
-    this.addPositiveIntSetting(section, {
-      name: 'Startup timeout (s)',
-      desc: 'Startup health-check limit.',
-      tooltip: 'Maximum time allowed for the startup health handshake.',
-      key: 'sidecarStartupTimeoutSeconds',
-    });
+    if (this.dependencies.getSettings().developerMode) {
+      this.addTextSetting(section, {
+        name: 'Sidecar path override',
+        desc: 'Custom sidecar executable.',
+        tooltip: 'Optional absolute path to an installed or dev sidecar executable file.',
+        key: 'sidecarPathOverride',
+        placeholder: 'Auto-detect from bin/cpu, bin/cuda, or native/target debug builds',
+      });
 
-    this.addPositiveIntSetting(section, {
-      name: 'Request timeout (s)',
-      desc: 'Sidecar request limit.',
-      tooltip:
-        'Maximum time allowed for start, stop, cancel, health, and model-management requests before failing them.',
-      key: 'sidecarRequestTimeoutSeconds',
-    });
+      this.addPositiveIntSetting(section, {
+        name: 'Startup timeout (s)',
+        desc: 'Startup health-check limit.',
+        tooltip: 'Maximum time allowed for the startup health handshake.',
+        key: 'sidecarStartupTimeoutSeconds',
+      });
+
+      this.addPositiveIntSetting(section, {
+        name: 'Request timeout (s)',
+        desc: 'Sidecar request limit.',
+        tooltip:
+          'Maximum time allowed for start, stop, cancel, health, and model-management requests before failing them.',
+        key: 'sidecarRequestTimeoutSeconds',
+      });
+    }
+
+    const activeInstall = this.dependencies.sidecarInstallManager.getState().activeInstall;
+    if (activeInstall !== null) {
+      const { progressEl } = renderActiveInstallCard(section, {
+        isCancelling: activeInstall.phase === 'canceling',
+        name: `Installing: ${activeInstall.variant.toUpperCase()} sidecar`,
+        onCancel: () => {
+          this.dependencies.sidecarInstallManager.cancel();
+        },
+        progressState: buildSidecarProgressState(activeInstall),
+      });
+      this.sidecarProgressEl = progressEl;
+    }
+  }
+
+  private handleSidecarSectionChange(section: HTMLDivElement): void {
+    const activeInstall = this.dependencies.sidecarInstallManager.getState().activeInstall;
+
+    if (activeInstall !== null && this.sidecarProgressEl !== null) {
+      updateInstallProgressElement(
+        this.sidecarProgressEl,
+        buildSidecarProgressState(activeInstall),
+      );
+      return;
+    }
+
+    void this.renderSidecarSection(section);
+  }
+
+  private renderMissingSidecarBanner(group: HTMLDivElement): () => void {
+    let disposed = false;
+
+    const render = async (): Promise<void> => {
+      this.missingSidecarProgressEl = null;
+      group.empty();
+
+      const pluginDirectory = await this.resolvePluginDirectorySafe();
+      if (disposed || pluginDirectory === null || !group.isConnected) return;
+
+      const [cpuManifest, cudaManifest] = await Promise.all([
+        readInstallManifest(variantDirectoryPath(pluginDirectory, 'cpu')),
+        readInstallManifest(variantDirectoryPath(pluginDirectory, 'cuda')),
+      ]);
+      if (disposed || !group.isConnected) return;
+
+      const activeInstall = this.dependencies.sidecarInstallManager.getState().activeInstall;
+      if (cpuManifest !== null || cudaManifest !== null) {
+        group.style.display = 'none';
+        return;
+      }
+
+      group.style.display = '';
+      const items = group.createDiv({ cls: 'setting-items' });
+
+      if (activeInstall !== null) {
+        const { progressEl } = renderActiveInstallCard(items, {
+          isCancelling: activeInstall.phase === 'canceling',
+          name: `Installing: ${activeInstall.variant.toUpperCase()} sidecar`,
+          onCancel: () => {
+            this.dependencies.sidecarInstallManager.cancel();
+          },
+          progressState: buildSidecarProgressState(activeInstall),
+        });
+        this.missingSidecarProgressEl = progressEl;
+        return;
+      }
+
+      const setting = new Setting(items)
+        .setName('Sidecar required')
+        .setDesc(
+          'Local Dictation needs the speech-to-text sidecar to work. Install it to enable dictation.',
+        );
+      setting.addButton((button) => {
+        button
+          .setCta()
+          .setButtonText('Install sidecar')
+          .onClick(() => {
+            this.openInstallModal(pluginDirectory, 'cpu', 'install');
+          });
+      });
+    };
+
+    const handleChange = (): void => {
+      const activeInstall = this.dependencies.sidecarInstallManager.getState().activeInstall;
+
+      if (activeInstall !== null && this.missingSidecarProgressEl !== null) {
+        updateInstallProgressElement(
+          this.missingSidecarProgressEl,
+          buildSidecarProgressState(activeInstall),
+        );
+        return;
+      }
+
+      void render();
+    };
+
+    void render();
+    const unsubscribe = this.dependencies.sidecarInstallManager.subscribe(handleChange);
+
+    return () => {
+      disposed = true;
+      unsubscribe();
+    };
   }
 
   private renderSidecarInstallRow(
@@ -614,7 +750,7 @@ export class LocalSttSettingTab extends PluginSettingTab {
         await this.shutdownSidecarBeforeFileMutation(`${variant} install`);
       },
       copy: getInstallCopy(variant, intent),
-      logger: this.dependencies.logger,
+      manager: this.dependencies.sidecarInstallManager,
       onInstalled: async () => {
         await onInstalled?.();
         await this.dependencies.restartSidecar();

--- a/src/setup/first-run-setup-modal.ts
+++ b/src/setup/first-run-setup-modal.ts
@@ -1,11 +1,11 @@
 import type { App } from 'obsidian';
 
-import type { PluginLogger } from '../shared/plugin-logger';
+import type { SidecarInstallManager } from '../sidecar/sidecar-install-manager';
 import { getInstallCopy } from './sidecar-install-copy';
 import { SidecarInstallModal } from './sidecar-install-modal';
 
 export interface FirstRunSetupOptions {
-  logger?: PluginLogger | undefined;
+  manager: SidecarInstallManager;
   onInstalled: () => Promise<void>;
   pluginDirectory: string;
   version: string;
@@ -14,7 +14,7 @@ export interface FirstRunSetupOptions {
 export function openFirstRunSetupModal(app: App, options: FirstRunSetupOptions): void {
   new SidecarInstallModal(app, {
     copy: getInstallCopy('cpu', 'first-run'),
-    logger: options.logger,
+    manager: options.manager,
     onInstalled: options.onInstalled,
     pluginDirectory: options.pluginDirectory,
     variant: 'cpu',

--- a/src/setup/sidecar-install-modal.ts
+++ b/src/setup/sidecar-install-modal.ts
@@ -1,12 +1,18 @@
 import type { App } from 'obsidian';
 import { Modal, Notice } from 'obsidian';
 
-import { formatBytes, formatErrorMessage } from '../shared/format-utils';
-import type { PluginLogger } from '../shared/plugin-logger';
+import {
+  createInstallProgressElement,
+  updateInstallProgressElement,
+} from '../models/model-install-progress';
+import { formatErrorMessage } from '../shared/format-utils';
+import {
+  type ActiveSidecarInstall,
+  buildSidecarProgressState,
+  type SidecarInstallManager,
+} from '../sidecar/sidecar-install-manager';
 import {
   detectPlatformAssetForCurrentEnv,
-  type InstallProgress,
-  installSidecar,
   type SidecarInstallVariant,
 } from '../sidecar/sidecar-installer';
 import type { InstallCopy } from './sidecar-install-copy';
@@ -14,24 +20,17 @@ import type { InstallCopy } from './sidecar-install-copy';
 export interface SidecarInstallModalOptions {
   beforeReplace?: (() => Promise<void>) | undefined;
   copy: InstallCopy;
-  logger?: PluginLogger | undefined;
+  manager: SidecarInstallManager;
   onInstalled: () => Promise<void>;
   pluginDirectory: string;
   variant: SidecarInstallVariant;
   version: string;
 }
 
-const STATUS_TONES = ['info', 'success', 'error'] as const;
-type StatusTone = (typeof STATUS_TONES)[number];
-
 export class SidecarInstallModal extends Modal {
-  private abortController: AbortController | null = null;
-  private installInProgress = false;
-  private progressLabelEl: HTMLDivElement | null = null;
-  private progressBarEl: HTMLDivElement | null = null;
-  private primaryButtonEl: HTMLButtonElement | null = null;
-  private secondaryButtonEl: HTMLButtonElement | null = null;
-  private statusEl: HTMLDivElement | null = null;
+  private installProgressEl: HTMLDivElement | null = null;
+  private unsubscribe: (() => void) | null = null;
+  private wasActive = false;
 
   constructor(
     app: App,
@@ -43,8 +42,66 @@ export class SidecarInstallModal extends Modal {
   override onOpen(): void {
     this.modalEl.addClass('local-stt-sidecar-install');
     this.titleEl.setText(this.options.copy.title);
-    this.contentEl.empty();
+    this.unsubscribe = this.options.manager.subscribe(() => {
+      this.handleManagerChange();
+    });
+    this.render();
+  }
 
+  override onClose(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.contentEl.empty();
+  }
+
+  private handleManagerChange(): void {
+    const state = this.options.manager.getState();
+
+    if (state.activeInstall !== null) {
+      this.wasActive = true;
+
+      if (this.installProgressEl !== null) {
+        updateInstallProgressElement(
+          this.installProgressEl,
+          buildSidecarProgressState(state.activeInstall),
+        );
+        return;
+      }
+
+      this.render();
+      return;
+    }
+
+    if (this.wasActive && state.lastError === null) {
+      this.close();
+      return;
+    }
+
+    this.wasActive = false;
+    this.render();
+  }
+
+  private render(): void {
+    this.contentEl.empty();
+    this.installProgressEl = null;
+
+    const state = this.options.manager.getState();
+
+    if (state.activeInstall !== null) {
+      this.wasActive = true;
+      this.renderProgress(state.activeInstall);
+      return;
+    }
+
+    if (state.lastError !== null) {
+      this.renderFailure(state.lastError);
+      return;
+    }
+
+    this.renderPreInstall();
+  }
+
+  private renderPreInstall(): void {
     const asset = detectPlatformAssetForCurrentEnv(this.options.variant);
 
     this.contentEl.createEl('p', { text: this.options.copy.bodyText });
@@ -53,152 +110,69 @@ export class SidecarInstallModal extends Modal {
     details.createEl('li', { text: `Archive: ${asset.assetName}` });
     details.createEl('li', { text: `Release: ${this.options.version}` });
 
-    this.statusEl = this.contentEl.createDiv({ cls: 'local-stt-sidecar-install__status' });
-    this.progressLabelEl = this.contentEl.createDiv({
-      cls: 'local-stt-sidecar-install__progress-label',
+    const buttons = this.contentEl.createDiv({ cls: 'local-stt-sidecar-install__buttons' });
+    buttons.createEl('button', { text: 'Later' }).addEventListener('click', () => {
+      this.close();
     });
-    const progressTrack = this.contentEl.createDiv({
-      cls: 'local-stt-sidecar-install__progress',
-    });
-    this.progressBarEl = progressTrack.createDiv({
-      cls: 'local-stt-sidecar-install__progress-bar',
-    });
-    this.progressBarEl.style.width = '0%';
+    buttons
+      .createEl('button', {
+        cls: 'mod-cta',
+        text: this.options.copy.primaryButtonText,
+      })
+      .addEventListener('click', () => {
+        this.startInstall();
+      });
+  }
+
+  private renderProgress(active: ActiveSidecarInstall): void {
+    const progressState = buildSidecarProgressState(active);
+    const fragment = document.createDocumentFragment();
+    this.installProgressEl = createInstallProgressElement(progressState);
+    fragment.append(this.installProgressEl);
+    this.contentEl.append(fragment);
 
     const buttons = this.contentEl.createDiv({ cls: 'local-stt-sidecar-install__buttons' });
-    this.secondaryButtonEl = buttons.createEl('button', { text: 'Later' });
-    this.primaryButtonEl = buttons.createEl('button', {
+    buttons.createEl('button', {
       cls: 'mod-cta',
-      text: this.options.copy.primaryButtonText,
-    });
-
-    this.secondaryButtonEl.addEventListener('click', () => {
-      this.handleSecondaryClick();
-    });
-    this.primaryButtonEl.addEventListener('click', () => {
-      void this.handlePrimaryClick();
+      text: active.phase === 'canceling' ? 'Cancelling...' : 'Downloading...',
+    }).disabled = true;
+    buttons.createEl('button', { text: 'Close' }).addEventListener('click', () => {
+      this.close();
     });
   }
 
-  override onClose(): void {
-    this.abortController?.abort();
-    this.contentEl.empty();
+  private renderFailure(errorMessage: string): void {
+    this.contentEl.createEl('p', {
+      cls: 'local-stt-sidecar-install__status local-stt-sidecar-install__status--error',
+      text: `Install failed: ${errorMessage}`,
+    });
+
+    const buttons = this.contentEl.createDiv({ cls: 'local-stt-sidecar-install__buttons' });
+    buttons
+      .createEl('button', {
+        cls: 'mod-cta',
+        text: 'Retry download',
+      })
+      .addEventListener('click', () => {
+        this.startInstall();
+      });
+    buttons.createEl('button', { text: 'Close' }).addEventListener('click', () => {
+      this.close();
+    });
   }
 
-  private handleSecondaryClick(): void {
-    if (this.installInProgress) {
-      this.abortController?.abort();
-      return;
-    }
-
-    this.close();
-  }
-
-  private async handlePrimaryClick(): Promise<void> {
-    if (this.installInProgress) return;
-
-    this.installInProgress = true;
-    this.abortController = new AbortController();
-
-    if (this.primaryButtonEl !== null) {
-      this.primaryButtonEl.disabled = true;
-      this.primaryButtonEl.setText('Downloading…');
-    }
-
-    if (this.secondaryButtonEl !== null) {
-      this.secondaryButtonEl.setText('Cancel');
-    }
-
-    this.setStatus('Fetching release metadata…', 'info');
-
+  private startInstall(): void {
     try {
-      await installSidecar({
+      this.options.manager.install({
         beforeReplace: this.options.beforeReplace,
-        logger: this.options.logger,
-        onProgress: (progress) => {
-          this.updateProgress(progress);
-        },
+        onInstalled: this.options.onInstalled,
         pluginDirectory: this.options.pluginDirectory,
-        signal: this.abortController.signal,
+        successNotice: this.options.copy.successNotice,
         variant: this.options.variant,
         version: this.options.version,
       });
-
-      this.setStatus('Sidecar installed. Starting…', 'success');
-      await this.options.onInstalled();
-      new Notice(this.options.copy.successNotice);
-      this.close();
     } catch (error) {
-      this.options.logger?.error('installer', 'sidecar install failed', error);
-      this.setStatus(`Install failed: ${formatErrorMessage(error)}`, 'error');
-
-      if (this.primaryButtonEl !== null) {
-        this.primaryButtonEl.disabled = false;
-        this.primaryButtonEl.setText('Retry download');
-      }
-
-      if (this.secondaryButtonEl !== null) {
-        this.secondaryButtonEl.setText('Later');
-      }
-    } finally {
-      this.installInProgress = false;
-      this.abortController = null;
-    }
-  }
-
-  private updateProgress(progress: InstallProgress): void {
-    if (progress.phase === 'verify') {
-      this.setStatus('Verifying checksum…', 'info');
-      this.progressLabelEl?.setText('');
-      this.setProgressPercent(null);
-      return;
-    }
-
-    if (progress.phase === 'extract') {
-      this.setStatus('Extracting archive…', 'info');
-      this.progressLabelEl?.setText('');
-      this.setProgressPercent(null);
-      return;
-    }
-
-    const percent =
-      progress.totalBytes !== null && progress.totalBytes > 0
-        ? (progress.bytesDownloaded / progress.totalBytes) * 100
-        : null;
-
-    const label =
-      progress.totalBytes !== null
-        ? `${formatBytes(progress.bytesDownloaded)} of ${formatBytes(progress.totalBytes)}`
-        : formatBytes(progress.bytesDownloaded);
-
-    if (this.progressLabelEl !== null) {
-      this.progressLabelEl.setText(label);
-    }
-
-    this.setProgressPercent(percent);
-  }
-
-  private setProgressPercent(percent: number | null): void {
-    if (this.progressBarEl === null) return;
-
-    if (percent === null) {
-      this.progressBarEl.style.width = '100%';
-      this.progressBarEl.classList.add('local-stt-sidecar-install__progress-bar--indeterminate');
-      return;
-    }
-
-    this.progressBarEl.classList.remove('local-stt-sidecar-install__progress-bar--indeterminate');
-    this.progressBarEl.style.width = `${Math.max(0, Math.min(100, percent))}%`;
-  }
-
-  private setStatus(message: string, tone: StatusTone): void {
-    if (this.statusEl === null) return;
-    this.statusEl.setText(message);
-    for (const candidate of STATUS_TONES) {
-      this.statusEl.classList.toggle(
-        `local-stt-sidecar-install__status--${candidate}`,
-        candidate === tone,
-      );
+      new Notice(formatErrorMessage(error));
     }
   }
 }

--- a/src/sidecar/sidecar-install-manager.ts
+++ b/src/sidecar/sidecar-install-manager.ts
@@ -1,0 +1,179 @@
+import type { InstallProgressState } from '../models/model-install-progress';
+import { formatErrorMessage } from '../shared/format-utils';
+import type { PluginLogger } from '../shared/plugin-logger';
+import {
+  type InstallProgress,
+  installSidecar,
+  type SidecarInstallVariant,
+} from './sidecar-installer';
+
+export type SidecarInstallPhase = 'canceling' | 'installing';
+
+export interface ActiveSidecarInstall {
+  phase: SidecarInstallPhase;
+  progress: InstallProgress;
+  variant: SidecarInstallVariant;
+}
+
+export interface SidecarInstallManagerState {
+  activeInstall: ActiveSidecarInstall | null;
+  lastError: string | null;
+}
+
+export interface SidecarInstallOptions {
+  beforeReplace?: (() => Promise<void>) | undefined;
+  onInstalled: () => Promise<void>;
+  pluginDirectory: string;
+  successNotice: string;
+  variant: SidecarInstallVariant;
+  version: string;
+}
+
+interface SidecarInstallManagerDependencies {
+  logger?: PluginLogger | undefined;
+  notice: (message: string) => void;
+}
+
+const INITIAL_PROGRESS: InstallProgress = {
+  bytesDownloaded: 0,
+  phase: 'download',
+  totalBytes: null,
+};
+
+export class SidecarInstallManager {
+  private abortController: AbortController | null = null;
+  private activeInstall: ActiveSidecarInstall | null = null;
+  private lastError: string | null = null;
+  private readonly listeners = new Set<() => void>();
+
+  constructor(private readonly deps: SidecarInstallManagerDependencies) {}
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  getState(): Readonly<SidecarInstallManagerState> {
+    return {
+      activeInstall: this.activeInstall,
+      lastError: this.lastError,
+    };
+  }
+
+  install(options: SidecarInstallOptions): void {
+    if (this.activeInstall !== null) {
+      throw new Error('Another sidecar is already being installed.');
+    }
+
+    const controller = new AbortController();
+    this.abortController = controller;
+    this.lastError = null;
+    this.activeInstall = {
+      phase: 'installing',
+      progress: INITIAL_PROGRESS,
+      variant: options.variant,
+    };
+    this.notify();
+
+    void this.runInstall(options, controller.signal);
+  }
+
+  cancel(): void {
+    const current = this.activeInstall;
+
+    if (current === null || current.phase !== 'installing') {
+      return;
+    }
+
+    this.activeInstall = { ...current, phase: 'canceling' };
+    this.notify();
+    this.abortController?.abort();
+  }
+
+  dispose(): void {
+    this.abortController?.abort();
+    this.abortController = null;
+    this.activeInstall = null;
+    this.listeners.clear();
+  }
+
+  private async runInstall(options: SidecarInstallOptions, signal: AbortSignal): Promise<void> {
+    try {
+      await installSidecar({
+        beforeReplace: options.beforeReplace,
+        logger: this.deps.logger,
+        onProgress: (progress) => {
+          this.updateProgress(progress);
+        },
+        pluginDirectory: options.pluginDirectory,
+        signal,
+        variant: options.variant,
+        version: options.version,
+      });
+
+      await options.onInstalled();
+      this.deps.notice(options.successNotice);
+      this.lastError = null;
+    } catch (error) {
+      if (isAbortError(error)) {
+        this.deps.notice('Sidecar install cancelled.');
+        this.lastError = null;
+      } else {
+        const message = formatErrorMessage(error);
+        this.deps.logger?.error('installer', 'sidecar install failed', error);
+        this.lastError = message;
+        this.deps.notice(`Sidecar install failed: ${message}`);
+      }
+    } finally {
+      if (this.abortController?.signal === signal) {
+        this.abortController = null;
+      }
+      this.activeInstall = null;
+      this.notify();
+    }
+  }
+
+  private updateProgress(progress: InstallProgress): void {
+    if (this.activeInstall === null) return;
+
+    this.activeInstall = {
+      ...this.activeInstall,
+      progress,
+    };
+    this.notify();
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
+export function buildSidecarProgressState(active: ActiveSidecarInstall): InstallProgressState {
+  return {
+    details: null,
+    downloadedBytes: active.progress.bytesDownloaded,
+    isCancelling: active.phase === 'canceling',
+    message: formatProgressMessage(active.progress.phase),
+    state: 'downloading',
+    totalBytes: active.progress.totalBytes,
+  };
+}
+
+function formatProgressMessage(phase: InstallProgress['phase']): string {
+  switch (phase) {
+    case 'download':
+      return 'Downloading';
+    case 'verify':
+      return 'Verifying checksum...';
+    case 'extract':
+      return 'Extracting archive...';
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}

--- a/test/sidecar-install-manager.test.ts
+++ b/test/sidecar-install-manager.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { installSidecarMock } = vi.hoisted(() => ({
+  installSidecarMock: vi.fn(),
+}));
+
+vi.mock('../src/sidecar/sidecar-installer', async () => {
+  const actual = await vi.importActual<typeof import('../src/sidecar/sidecar-installer')>(
+    '../src/sidecar/sidecar-installer',
+  );
+
+  return {
+    ...actual,
+    installSidecar: installSidecarMock,
+  };
+});
+
+import {
+  buildSidecarProgressState,
+  SidecarInstallManager,
+} from '../src/sidecar/sidecar-install-manager';
+import type { InstallSidecarOptions } from '../src/sidecar/sidecar-installer';
+
+beforeEach(() => {
+  installSidecarMock.mockReset();
+});
+
+function createInstallOptions(
+  overrides?: Partial<Parameters<SidecarInstallManager['install']>[0]>,
+) {
+  return {
+    onInstalled: vi.fn(async () => {}),
+    pluginDirectory: '/plugin',
+    successNotice: 'Installed.',
+    variant: 'cpu' as const,
+    version: '2026.5.3',
+    ...overrides,
+  };
+}
+
+describe('SidecarInstallManager', () => {
+  it('tracks active install progress and exposes shared progress state', () => {
+    installSidecarMock.mockImplementationOnce(() => new Promise(() => {}));
+    const manager = new SidecarInstallManager({ notice: vi.fn() });
+    const listener = vi.fn();
+    manager.subscribe(listener);
+
+    manager.install(createInstallOptions());
+    const capturedOptions = installSidecarMock.mock.calls[0]?.[0] as
+      | InstallSidecarOptions
+      | undefined;
+    capturedOptions?.onProgress?.({
+      bytesDownloaded: 50,
+      phase: 'download',
+      totalBytes: 100,
+    });
+
+    const activeInstall = manager.getState().activeInstall;
+    expect(activeInstall).not.toBeNull();
+    expect(activeInstall?.progress.bytesDownloaded).toBe(50);
+    expect(activeInstall ? buildSidecarProgressState(activeInstall) : null).toMatchObject({
+      downloadedBytes: 50,
+      isCancelling: false,
+      message: 'Downloading',
+      totalBytes: 100,
+    });
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects concurrent installs', () => {
+    installSidecarMock.mockImplementationOnce(() => new Promise(() => {}));
+    const manager = new SidecarInstallManager({ notice: vi.fn() });
+
+    manager.install(createInstallOptions());
+
+    expect(() => {
+      manager.install(createInstallOptions());
+    }).toThrow('Another sidecar is already being installed.');
+  });
+
+  it('cancels the active AbortController', () => {
+    installSidecarMock.mockImplementationOnce(() => new Promise(() => {}));
+    const manager = new SidecarInstallManager({ notice: vi.fn() });
+
+    manager.install(createInstallOptions());
+    const capturedOptions = installSidecarMock.mock.calls[0]?.[0] as
+      | InstallSidecarOptions
+      | undefined;
+    manager.cancel();
+
+    expect(manager.getState().activeInstall?.phase).toBe('canceling');
+    expect(capturedOptions?.signal?.aborted).toBe(true);
+  });
+
+  it('clears active state and shows success notice after install completes', async () => {
+    installSidecarMock.mockResolvedValueOnce({
+      manifest: {
+        installedAt: '2026-05-03T00:00:00.000Z',
+        sha256: 'abc',
+        variant: 'cpu',
+        version: '2026.5.3',
+      },
+      variantDirectory: '/plugin/bin/cpu',
+    });
+    const notice = vi.fn();
+    const onInstalled = vi.fn(async () => {});
+    const manager = new SidecarInstallManager({ notice });
+
+    manager.install(createInstallOptions({ onInstalled }));
+    await vi.waitFor(() => {
+      expect(manager.getState().activeInstall).toBeNull();
+    });
+
+    expect(onInstalled).toHaveBeenCalledOnce();
+    expect(notice).toHaveBeenCalledWith('Installed.');
+    expect(manager.getState().lastError).toBeNull();
+  });
+
+  it('records failed install errors after clearing active state', async () => {
+    installSidecarMock.mockRejectedValueOnce(new Error('network failed'));
+    const notice = vi.fn();
+    const manager = new SidecarInstallManager({ notice });
+
+    manager.install(createInstallOptions());
+    await vi.waitFor(() => {
+      expect(manager.getState().activeInstall).toBeNull();
+    });
+
+    expect(manager.getState().lastError).toBe('network failed');
+    expect(notice).toHaveBeenCalledWith('Sidecar install failed: network failed');
+  });
+
+  it('clears state and notifies on abort error', async () => {
+    const abortError = new Error('aborted');
+    abortError.name = 'AbortError';
+    installSidecarMock.mockRejectedValueOnce(abortError);
+    const notice = vi.fn();
+    const manager = new SidecarInstallManager({ notice });
+
+    manager.install(createInstallOptions());
+    await vi.waitFor(() => {
+      expect(manager.getState().activeInstall).toBeNull();
+    });
+
+    expect(notice).toHaveBeenCalledWith('Sidecar install cancelled.');
+    expect(manager.getState().lastError).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #74 — closing the install modal no longer aborts the download. The new `SidecarInstallManager` (mirrors `ModelInstallManager`) is plugin-owned and survives modal lifecycles.
- Addresses #54 — adds a missing-sidecar banner at the top of settings with a single CTA, and gates dev-only sidecar fields (path override, both timeouts) behind Developer mode.
- Extracts a shared `renderActiveInstallCard` helper used by both the model and sidecar settings sections so the two download surfaces are visually and behaviorally consistent.

## Test plan
- [ ] `npm run typecheck` clean
- [ ] `npm run lint` clean
- [ ] `npx vitest run` — full suite (315 tests) passing
- [ ] Delete `bin/cpu` + `bin/cuda`, restart plugin → first-run modal opens AND settings page shows the banner. Click Download. Close modal mid-install. Confirm download continues; settings reflects progress; success Notice fires; banner disappears.
- [ ] Trigger CUDA install (with NVIDIA driver). Confirm `accelerationPreference` flips to `'auto'` after success.
- [ ] CPU reinstall, click Cancel from the settings card mid-install. Confirm staging dir is cleaned and "Sidecar install cancelled." Notice fires.
- [ ] Toggle Developer mode → dev-only sidecar fields appear/disappear without reopening settings. `cudaLibraryPath` (Linux) remains visible regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)