### PR TITLE
Stabilize Whisper live partials

### DIFF
--- a/native/src/adapters/whisper.rs
+++ b/native/src/adapters/whisper.rs
@@ -83,6 +83,17 @@ impl LoadedModel for LoadedWhisperModel {
         params.set_print_realtime(false);
         params.set_print_timestamps(false);
 
+        if request.is_partial {
+            // Partial-only tuning: deterministic, single-segment, narrow
+            // encoder context, no carry-over from prior partial. Final decode
+            // keeps Whisper's default behavior so the canonical revision is
+            // unaffected.
+            params.set_no_context(true);
+            params.set_temperature(0.0);
+            params.set_single_segment(true);
+            params.set_audio_ctx(768);
+        }
+
         if let Some(context) = request.context.as_ref() {
             params.set_initial_prompt(&context.text);
         }

--- a/native/src/app.rs
+++ b/native/src/app.rs
@@ -12,17 +12,19 @@ use crate::model_store::{
     remove_installed_model, resolve_catalog_model_runtime_path, resolve_model_store_info,
     scan_installed_models,
 };
+use crate::partial_stabilizer::PartialStabilizer;
 use crate::protocol::{
     AccelerationPreference, Command, CompiledAdapterInfo, CompiledRuntimeInfo, ContextWindow,
     Event, HealthStatus, ListeningMode, LivePartialMode, ModelInstallState, ModelProbeStatus,
-    QueueBackpressureTier, SelectedModel, SessionState, SessionStopReason, system_info_string,
+    QueueBackpressureTier, SelectedModel, SessionState, SessionStopReason, TimestampGranularity,
+    TimestampSource, TranscriptSegment, system_info_string,
 };
 use crate::session::{
     FinalizedUtterance, ListeningSession, SessionAction, SessionBaseState, SessionConfig,
     SessionInitError,
 };
 use crate::stages::{StageEnablement, any_registered_stage_needs_context};
-use crate::transcription::GpuConfig;
+use crate::transcription::{GpuConfig, Transcript};
 use crate::worker::{SessionMetadata, TranscriptionWorker, WorkerCommand, WorkerEvent};
 
 /// Hard cap on waiting utterances behind the active worker item. Reaching
@@ -69,6 +71,7 @@ struct ActiveSession {
     last_reported_state: Option<SessionState>,
     overload_draining: bool,
     partial_in_flight: bool,
+    partial_stabilizer: PartialStabilizer,
     pending_context_requests: Vec<PendingContextRequest>,
     queued_utterances: usize,
     session: ListeningSession,
@@ -511,6 +514,7 @@ impl AppState {
                             last_reported_state: None,
                             overload_draining: false,
                             partial_in_flight: false,
+                            partial_stabilizer: PartialStabilizer::new(),
                             pending_context_requests: Vec::new(),
                             queued_utterances: 0,
                             session,
@@ -796,7 +800,7 @@ impl AppState {
             } => {
                 let is_final = transcript.is_final();
 
-                {
+                let emitted_transcript: Option<Transcript> = {
                     let Some(active_session) = self.active_session.as_mut() else {
                         return;
                     };
@@ -808,10 +812,23 @@ impl AppState {
                     if is_final {
                         advance_transcription_queue(active_session);
                         emit_queue_tier_if_changed(active_session, events);
+                        active_session.partial_stabilizer.clear();
+                        Some(transcript)
                     } else {
                         active_session.partial_in_flight = false;
+                        let raw_text = transcript.joined_text();
+                        active_session
+                            .partial_stabilizer
+                            .apply(transcript.utterance_id, &raw_text)
+                            .map(|stable_text| {
+                                stabilize_partial_transcript(&transcript, stable_text)
+                            })
                     }
-                }
+                };
+
+                let Some(transcript) = emitted_transcript else {
+                    return;
+                };
 
                 let text = transcript.joined_text();
                 events.push(Event::TranscriptReady {
@@ -1225,6 +1242,34 @@ fn advance_transcription_queue(active_session: &mut ActiveSession) {
     }
 }
 
+fn stabilize_partial_transcript(transcript: &Transcript, stable_text: String) -> Transcript {
+    let (start_ms, end_ms, granularity, source) = transcript
+        .segments
+        .first()
+        .map(|seg| {
+            (
+                seg.start_ms,
+                seg.end_ms,
+                seg.timestamp_granularity,
+                seg.timestamp_source,
+            )
+        })
+        .unwrap_or((0, 0, TimestampGranularity::Segment, TimestampSource::Engine));
+
+    Transcript {
+        utterance_id: transcript.utterance_id,
+        revision: transcript.revision,
+        segments: vec![TranscriptSegment {
+            start_ms,
+            end_ms,
+            text: stable_text,
+            timestamp_granularity: granularity,
+            timestamp_source: source,
+        }],
+        stage_history: transcript.stage_history.clone(),
+    }
+}
+
 fn queue_backpressure_tier(queued_utterances: usize) -> QueueBackpressureTier {
     match queued_utterances {
         0..=2 => QueueBackpressureTier::Normal,
@@ -1389,7 +1434,8 @@ mod tests {
     use crate::protocol::{
         AccelerationPreference, Command, ContextWindow, ContextWindowSource, Event, HealthStatus,
         ListeningMode, LivePartialMode, ModelProbeStatus, QueueBackpressureTier, SelectedModel,
-        SessionState, SessionStopReason, StageId, StageOutcome, StageStatus,
+        SessionState, SessionStopReason, StageId, StageOutcome, StageStatus, TimestampGranularity,
+        TimestampSource, TranscriptSegment,
     };
     use crate::session::{FinalizedUtterance, ListeningSession, SessionInitError, SpeakingStyle};
     use crate::transcription::{
@@ -2417,6 +2463,245 @@ mod tests {
             events.is_empty(),
             "worker events for a cancelled session must be dropped silently: {events:?}"
         );
+    }
+
+    #[test]
+    fn first_partial_emits_no_transcript_ready_event() {
+        let model_file_path = create_model_file();
+        let mut app = test_app();
+        let _ = app.handle_command(start_session_command("session-1", &model_file_path));
+
+        let utterance_id = Uuid::new_v4();
+        let mut events = Vec::new();
+        app.handle_worker_event(
+            partial_event(
+                make_partial_transcript(utterance_id, 0, "the cat"),
+                "session-1",
+            ),
+            &mut events,
+        );
+
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, Event::TranscriptReady { .. })),
+            "first partial has no previous decode to agree with"
+        );
+    }
+
+    #[test]
+    fn second_partial_emits_word_aligned_committed_prefix() {
+        let model_file_path = create_model_file();
+        let mut app = test_app();
+        let _ = app.handle_command(start_session_command("session-1", &model_file_path));
+
+        let utterance_id = Uuid::new_v4();
+        let mut events = Vec::new();
+        app.handle_worker_event(
+            partial_event(
+                make_partial_transcript(utterance_id, 0, "the cat"),
+                "session-1",
+            ),
+            &mut events,
+        );
+        events.clear();
+        app.handle_worker_event(
+            partial_event(
+                make_partial_transcript(utterance_id, 1, "the cat sat"),
+                "session-1",
+            ),
+            &mut events,
+        );
+
+        let emitted = events
+            .iter()
+            .find_map(|e| match e {
+                Event::TranscriptReady { text, is_final, .. } if !is_final => Some(text.clone()),
+                _ => None,
+            })
+            .expect("stabilized partial should be emitted");
+        assert_eq!(emitted, "the cat");
+    }
+
+    #[test]
+    fn partial_with_no_new_agreement_is_suppressed() {
+        let model_file_path = create_model_file();
+        let mut app = test_app();
+        let _ = app.handle_command(start_session_command("session-1", &model_file_path));
+
+        let utterance_id = Uuid::new_v4();
+        let mut events = Vec::new();
+        app.handle_worker_event(
+            partial_event(
+                make_partial_transcript(utterance_id, 0, "the cat"),
+                "session-1",
+            ),
+            &mut events,
+        );
+        app.handle_worker_event(
+            partial_event(
+                make_partial_transcript(utterance_id, 1, "the cat sat"),
+                "session-1",
+            ),
+            &mut events,
+        );
+        app.handle_worker_event(
+            partial_event(
+                make_partial_transcript(utterance_id, 2, "the cat sat around"),
+                "session-1",
+            ),
+            &mut events,
+        );
+        events.clear();
+        app.handle_worker_event(
+            partial_event(
+                make_partial_transcript(utterance_id, 3, "the cat sat beside"),
+                "session-1",
+            ),
+            &mut events,
+        );
+
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, Event::TranscriptReady { .. })),
+            "no-op partial must be suppressed"
+        );
+    }
+
+    #[test]
+    fn final_transcript_bypasses_stabilizer_and_emits_full_text() {
+        let model_file_path = create_model_file();
+        let mut app = test_app();
+        let _ = app.handle_command(start_session_command("session-1", &model_file_path));
+
+        let utterance_id = Uuid::new_v4();
+        let mut events = Vec::new();
+        app.handle_worker_event(
+            partial_event(
+                make_partial_transcript(utterance_id, 0, "the cat"),
+                "session-1",
+            ),
+            &mut events,
+        );
+        events.clear();
+        app.handle_worker_event(
+            partial_event(
+                make_final_transcript(utterance_id, 1, "the cat sat down"),
+                "session-1",
+            ),
+            &mut events,
+        );
+
+        let emitted = events
+            .iter()
+            .find_map(|e| match e {
+                Event::TranscriptReady { text, is_final, .. } if *is_final => Some(text.clone()),
+                _ => None,
+            })
+            .expect("final must emit");
+        assert_eq!(emitted, "the cat sat down", "finals are unstabilized");
+    }
+
+    #[test]
+    fn new_utterance_after_final_starts_stabilizer_fresh() {
+        let model_file_path = create_model_file();
+        let mut app = test_app();
+        let _ = app.handle_command(start_session_command("session-1", &model_file_path));
+
+        let u1 = Uuid::new_v4();
+        let u2 = Uuid::new_v4();
+        let mut events = Vec::new();
+
+        app.handle_worker_event(
+            partial_event(make_partial_transcript(u1, 0, "the cat"), "session-1"),
+            &mut events,
+        );
+        app.handle_worker_event(
+            partial_event(make_partial_transcript(u1, 1, "the cat sat"), "session-1"),
+            &mut events,
+        );
+        app.handle_worker_event(
+            partial_event(
+                make_final_transcript(u1, 2, "the cat sat down"),
+                "session-1",
+            ),
+            &mut events,
+        );
+        events.clear();
+
+        app.handle_worker_event(
+            partial_event(
+                make_partial_transcript(u2, 0, "another phrase"),
+                "session-1",
+            ),
+            &mut events,
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, Event::TranscriptReady { .. })),
+            "first partial of new utterance must not emit"
+        );
+
+        app.handle_worker_event(
+            partial_event(
+                make_partial_transcript(u2, 1, "another phrase here"),
+                "session-1",
+            ),
+            &mut events,
+        );
+        let emitted = events
+            .iter()
+            .find_map(|e| match e {
+                Event::TranscriptReady { text, is_final, .. } if !is_final => Some(text.clone()),
+                _ => None,
+            })
+            .expect("u2 partial should emit");
+        assert_eq!(emitted, "another phrase");
+    }
+
+    fn make_partial_transcript(utterance_id: Uuid, revision: u32, text: &str) -> Transcript {
+        Transcript {
+            utterance_id,
+            revision,
+            segments: vec![TranscriptSegment {
+                start_ms: 0,
+                end_ms: 1_000,
+                text: text.to_string(),
+                timestamp_granularity: TimestampGranularity::Segment,
+                timestamp_source: TimestampSource::Engine,
+            }],
+            stage_history: vec![StageOutcome {
+                duration_ms: 5,
+                is_final: false,
+                payload: None,
+                revision_in: revision,
+                revision_out: Some(revision),
+                stage_id: StageId::Engine,
+                status: StageStatus::Ok,
+            }],
+        }
+    }
+
+    fn make_final_transcript(utterance_id: Uuid, revision: u32, text: &str) -> Transcript {
+        let mut transcript = make_partial_transcript(utterance_id, revision, text);
+        transcript.stage_history[0].is_final = true;
+        transcript
+    }
+
+    fn partial_event(transcript: Transcript, session_id: &str) -> WorkerEvent {
+        WorkerEvent::TranscriptReady {
+            pause_ms_before_utterance: None,
+            processing_duration_ms: 5,
+            session_id: session_id.to_string(),
+            transcript,
+            utterance_duration_ms: 1_000,
+            utterance_end_ms_in_session: 1_000,
+            utterance_index: 0,
+            utterance_start_ms_in_session: 0,
+            warnings: Vec::new(),
+        }
     }
 
     fn start_session_command(session_id: &str, model_file_path: &std::path::Path) -> Command {

--- a/native/src/engine/registry.rs
+++ b/native/src/engine/registry.rs
@@ -365,6 +365,7 @@ mod tests {
         TranscriptionRequest {
             audio_samples: vec![0.0; 16_000],
             gpu_config: GpuConfig::default(),
+            is_partial: false,
             language: "en".to_string(),
             model_file_path: PathBuf::from("/tmp/model.bin"),
             context,

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -8,6 +8,7 @@ pub mod installer;
 pub mod mel;
 pub mod model_store;
 pub mod panic_util;
+pub mod partial_stabilizer;
 pub mod protocol;
 pub mod runtimes;
 pub mod session;

--- a/native/src/partial_stabilizer.rs
+++ b/native/src/partial_stabilizer.rs
@@ -1,0 +1,286 @@
+//! Per-utterance LocalAgreement-2 stabilizer for live partial transcripts.
+//!
+//! Whisper is a Snapshot-strategy backend: every partial re-decodes the
+//! rolling audio buffer from scratch, so consecutive partials disagree at
+//! the tail. The stabilizer keeps the committed prefix (monotonic,
+//! append-only within an utterance) and the previous raw decode; on each
+//! new partial it commits the longest word-aligned prefix that the previous
+//! and current decodes agree on, and only emits when that prefix strictly
+//! extends what was already committed.
+
+use uuid::Uuid;
+
+#[derive(Debug, Default)]
+pub struct PartialStabilizer {
+    current_utterance_id: Option<Uuid>,
+    committed_prefix: String,
+    previous_decode: String,
+}
+
+impl PartialStabilizer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Process a fresh partial decode. Returns `Some(stable_text)` when the
+    /// committed prefix has grown, or `None` when the new agreement does not
+    /// strictly extend the committed prefix.
+    pub fn apply(&mut self, utterance_id: Uuid, latest_decode: &str) -> Option<String> {
+        if self.current_utterance_id != Some(utterance_id) {
+            self.current_utterance_id = Some(utterance_id);
+            self.committed_prefix.clear();
+            self.previous_decode.clear();
+        }
+
+        let agreement = agreed_prefix(&self.previous_decode, latest_decode);
+        let candidate = word_aligned_prefix(latest_decode, agreement);
+
+        self.previous_decode.clear();
+        self.previous_decode.push_str(latest_decode);
+
+        if candidate.len() > self.committed_prefix.len()
+            && candidate.starts_with(&self.committed_prefix)
+        {
+            self.committed_prefix.clear();
+            self.committed_prefix.push_str(candidate);
+            Some(self.committed_prefix.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Forget the in-progress utterance. Call when a finalized transcript
+    /// arrives so the next utterance starts from a clean slate.
+    pub fn clear(&mut self) {
+        self.current_utterance_id = None;
+        self.committed_prefix.clear();
+        self.previous_decode.clear();
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Agreement {
+    latest_byte_len: usize,
+    previous_next_char: Option<char>,
+}
+
+fn agreed_prefix(previous: &str, latest: &str) -> Agreement {
+    let mut prev_iter = previous.char_indices().peekable();
+    let mut latest_iter = latest.char_indices().peekable();
+    let mut last_agreed_byte_end = 0;
+
+    loop {
+        let prev_is_ws = prev_iter
+            .peek()
+            .is_some_and(|&(_, c)| c.is_ascii_whitespace());
+        let latest_is_ws = latest_iter
+            .peek()
+            .is_some_and(|&(_, c)| c.is_ascii_whitespace());
+
+        if prev_is_ws && latest_is_ws {
+            while let Some(&(_, c)) = prev_iter.peek() {
+                if !c.is_ascii_whitespace() {
+                    break;
+                }
+                prev_iter.next();
+            }
+            while let Some(&(idx, c)) = latest_iter.peek() {
+                if !c.is_ascii_whitespace() {
+                    break;
+                }
+                last_agreed_byte_end = idx + c.len_utf8();
+                latest_iter.next();
+            }
+            continue;
+        }
+
+        if prev_is_ws != latest_is_ws {
+            break;
+        }
+
+        match (prev_iter.peek(), latest_iter.peek()) {
+            (Some(&(_, p)), Some(&(idx, l))) => {
+                if p.eq_ignore_ascii_case(&l) {
+                    last_agreed_byte_end = idx + l.len_utf8();
+                    prev_iter.next();
+                    latest_iter.next();
+                } else {
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+
+    Agreement {
+        latest_byte_len: last_agreed_byte_end,
+        previous_next_char: prev_iter.peek().map(|&(_, c)| c),
+    }
+}
+
+fn word_aligned_prefix(latest: &str, agreement: Agreement) -> &str {
+    if agreement.latest_byte_len == 0 {
+        return "";
+    }
+
+    if agreement.latest_byte_len >= latest.len()
+        && !agreement
+            .previous_next_char
+            .is_some_and(|c| c.is_alphanumeric())
+    {
+        return latest;
+    }
+
+    let mut candidate = &latest[..agreement.latest_byte_len];
+    candidate = candidate.trim_end();
+
+    let next_char = latest[candidate.len()..].chars().next();
+    if next_char.is_some_and(|c| c.is_alphanumeric())
+        || agreement
+            .previous_next_char
+            .is_some_and(|c| c.is_alphanumeric())
+    {
+        match candidate.rfind(char::is_whitespace) {
+            Some(pos) => candidate[..pos].trim_end(),
+            None => "",
+        }
+    } else {
+        candidate
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uid(byte: u8) -> Uuid {
+        Uuid::from_bytes([byte; 16])
+    }
+
+    #[test]
+    fn first_partial_emits_nothing_with_no_previous_decode() {
+        let mut s = PartialStabilizer::new();
+        assert_eq!(s.apply(uid(1), "the cat"), None);
+    }
+
+    #[test]
+    fn second_partial_commits_word_aligned_agreement() {
+        let mut s = PartialStabilizer::new();
+        s.apply(uid(1), "the cat");
+        assert_eq!(s.apply(uid(1), "the cat sat"), Some("the cat".to_string()));
+    }
+
+    #[test]
+    fn agreement_ending_mid_word_trims_back_to_previous_word_boundary() {
+        let mut s = PartialStabilizer::new();
+        s.apply(uid(1), "the cat sat");
+        assert_eq!(s.apply(uid(1), "the cat sa"), Some("the cat".to_string()));
+    }
+
+    #[test]
+    fn identical_partials_can_extend_once_then_no_growth_suppresses() {
+        let mut s = PartialStabilizer::new();
+        s.apply(uid(1), "the cat");
+        assert_eq!(s.apply(uid(1), "the cat sat"), Some("the cat".to_string()));
+        assert_eq!(
+            s.apply(uid(1), "the cat sat"),
+            Some("the cat sat".to_string())
+        );
+        assert_eq!(s.apply(uid(1), "the cat sat around"), None);
+    }
+
+    #[test]
+    fn agreement_shorter_than_committed_keeps_committed_and_suppresses() {
+        let mut s = PartialStabilizer::new();
+        s.apply(uid(1), "the cat sat on");
+        s.apply(uid(1), "the cat sat on the");
+        assert_eq!(s.apply(uid(1), "the cats sat on the"), None);
+    }
+
+    #[test]
+    fn agreement_not_starting_with_committed_keeps_committed() {
+        let mut s = PartialStabilizer::new();
+        s.apply(uid(1), "the cat sat on the");
+        s.apply(uid(1), "the cat sat on the wall");
+        assert_eq!(s.apply(uid(1), "the cats sat on the wall"), None);
+    }
+
+    #[test]
+    fn new_utterance_id_resets_state() {
+        let mut s = PartialStabilizer::new();
+        s.apply(uid(1), "the cat");
+        s.apply(uid(1), "the cat sat");
+
+        assert_eq!(s.apply(uid(2), "another sentence"), None);
+        assert_eq!(
+            s.apply(uid(2), "another sentence here"),
+            Some("another sentence".to_string())
+        );
+    }
+
+    #[test]
+    fn clear_resets_state_and_subsequent_apply_starts_fresh() {
+        let mut s = PartialStabilizer::new();
+        s.apply(uid(1), "the cat");
+        s.apply(uid(1), "the cat sat");
+        s.clear();
+        assert_eq!(s.apply(uid(1), "different start"), None);
+    }
+
+    #[test]
+    fn casefold_normalizes_for_comparison_but_emit_uses_raw_text() {
+        let mut s = PartialStabilizer::new();
+        s.apply(uid(1), "Hello world");
+        assert_eq!(
+            s.apply(uid(1), "hello world today"),
+            Some("hello world".to_string())
+        );
+    }
+
+    #[test]
+    fn collapsed_whitespace_normalizes_for_comparison() {
+        let mut s = PartialStabilizer::new();
+        s.apply(uid(1), "hello  world");
+        assert_eq!(
+            s.apply(uid(1), "hello world today"),
+            Some("hello world".to_string())
+        );
+    }
+
+    #[test]
+    fn internal_punctuation_difference_breaks_agreement() {
+        let mut s = PartialStabilizer::new();
+        s.apply(uid(1), "twenty five dollars");
+        assert_eq!(
+            s.apply(uid(1), "twenty-five dollars"),
+            Some("twenty".to_string())
+        );
+    }
+
+    #[test]
+    fn trailing_punctuation_does_not_appear_in_emit_when_partial_overlap() {
+        let mut s = PartialStabilizer::new();
+        s.apply(uid(1), "hello world");
+        assert_eq!(
+            s.apply(uid(1), "hello world,"),
+            Some("hello world".to_string())
+        );
+    }
+
+    #[test]
+    fn full_match_including_trailing_punctuation_emits_unchanged() {
+        let mut s = PartialStabilizer::new();
+        s.apply(uid(1), "hello world,");
+        assert_eq!(
+            s.apply(uid(1), "hello world,"),
+            Some("hello world,".to_string())
+        );
+    }
+
+    #[test]
+    fn agreement_falls_inside_first_word_emits_empty_and_suppresses() {
+        let mut s = PartialStabilizer::new();
+        s.apply(uid(1), "abcde");
+        assert_eq!(s.apply(uid(1), "abxyz"), None);
+    }
+}

--- a/native/src/transcription.rs
+++ b/native/src/transcription.rs
@@ -16,6 +16,11 @@ pub struct GpuConfig {
 pub struct TranscriptionRequest {
     pub audio_samples: Vec<f32>,
     pub gpu_config: GpuConfig,
+    /// True when this request is a live partial (interim) decode rather than
+    /// a finalized utterance. Adapters use this to swap to interim-tuned
+    /// decode params (faster, less context) without contaminating final
+    /// decode behavior.
+    pub is_partial: bool,
     pub language: String,
     pub model_file_path: PathBuf,
     /// Structured context window the plugin assembled for this utterance.

--- a/native/src/worker.rs
+++ b/native/src/worker.rs
@@ -311,6 +311,7 @@ fn run_transcription(
     let mut request = TranscriptionRequest {
         audio_samples,
         gpu_config: session.metadata.gpu_config,
+        is_partial: !is_final,
         language: session.metadata.language.clone(),
         model_file_path: session.metadata.model_file_path.clone(),
         context,


### PR DESCRIPTION
## Summary

- Stabilizes live Whisper partials so only text agreed by consecutive decodes is emitted.
- Tunes Whisper interim decode parameters for faster short-buffer partials while leaving final decode behavior canonical.
- Relates to live dictation partial flicker reduction.

## Key changes

- Sidecar: add `TranscriptionRequest.is_partial` and set it from the worker based on final vs. interim transcription.
- Sidecar: add a per-utterance `PartialStabilizer` that commits monotonic, word-aligned prefixes with ASCII casefold and whitespace-collapse comparison.
- Sidecar: wire the stabilizer into `ActiveSession` so first/no-growth partials are suppressed, stable partials emit as one segment, and finals bypass stabilization and clear state.
- Sidecar: tune Whisper partial-only decode with no context, greedy temperature, single segment output, and reduced audio context.

## Notes

### Expected behavior

Once a word appears in the live partial stream, it should not be rewritten by later unstable tails. The UI may show fewer interim updates than before because first partials and no-growth partials are intentionally suppressed. Final transcripts still pass through unchanged and should replace the stabilized partial cleanly.

### Verification limitation

`cargo test --all-features` is not representative on this local machine because enabling every feature pulls in CUDA and failed before crate compilation due to missing local CUDA compiler / C header setup. The repository check path avoids CUDA on Linux and passed.

## Test plan

- [x] `npm run check` (TS typecheck + lint + vitest + esbuild)
- [x] `cargo test` (+ `cargo clippy` if Rust changed)
- [x] `cargo build --release`
- [ ] Manual: live Obsidian dictation smoke with a 5-8 second multi-word utterance; confirm partials stop flickering, finals replace partials cleanly, and partial latency is acceptable.