### PR TITLE
feat(ux): setup wizard, settings audit, Manage Models guard

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "files": {
     "includes": [
       "**",

--- a/src/commands/register-commands.ts
+++ b/src/commands/register-commands.ts
@@ -18,7 +18,7 @@ interface CommandDependencies {
 export function registerCommands(dependencies: CommandDependencies): void {
   dependencies.plugin.addCommand({
     id: TOGGLE_DICTATION_COMMAND_ID,
-    name: 'Toggle dictation session',
+    name: 'Toggle dictation',
     callback: async () => {
       await dependencies.toggleDictation();
     },
@@ -26,7 +26,7 @@ export function registerCommands(dependencies: CommandDependencies): void {
 
   dependencies.plugin.addCommand({
     id: START_DICTATION_COMMAND_ID,
-    name: 'Start dictation session',
+    name: 'Start dictation',
     callback: async () => {
       await dependencies.startDictation();
     },
@@ -34,7 +34,7 @@ export function registerCommands(dependencies: CommandDependencies): void {
 
   dependencies.plugin.addCommand({
     id: STOP_DICTATION_COMMAND_ID,
-    name: 'Stop dictation session',
+    name: 'Stop dictation',
     callback: async () => {
       await dependencies.stopDictation();
     },
@@ -42,7 +42,7 @@ export function registerCommands(dependencies: CommandDependencies): void {
 
   dependencies.plugin.addCommand({
     id: CANCEL_DICTATION_COMMAND_ID,
-    name: 'Cancel dictation session',
+    name: 'Cancel dictation',
     callback: async () => {
       await dependencies.cancelDictation();
     },

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -84,6 +84,7 @@ interface DictationSessionControllerDependencies {
   logger?: PluginLogger;
   notice: (message: string) => void;
   ollamaClient: Pick<OllamaClient, 'cleanup'>;
+  onModelMissing?: () => void;
   onSidecarMissing?: () => void;
   setRibbonQueueTier: (tier: QueueBackpressureTier) => void;
   setRibbonState: (state: DictationControllerState) => void;
@@ -209,13 +210,13 @@ export class DictationSessionController {
     }
 
     const settings = this.dependencies.getSettings();
-    let selectedModel: NonNullable<PluginSettings['selectedModel']>;
-    try {
-      selectedModel = this.requireSelectedModel(settings);
-    } catch (error) {
-      this.handleError('Failed to start the dictation session', error);
+    if (settings.selectedModel === null) {
+      this.dependencies.logger?.debug('session', 'no model selected — prompting model picker');
+      this.applyUiState('idle');
+      this.dependencies.onModelMissing?.();
       return;
     }
+    const selectedModel = settings.selectedModel;
     const effectiveGeneration = resolveActiveGenerationDefaults(settings);
     const sessionStartUnixMs = Date.now();
     const snapshot: ActiveSessionSnapshot = {
@@ -841,15 +842,6 @@ export class DictationSessionController {
     }
   }
 
-  private requireSelectedModel(
-    settings: PluginSettings,
-  ): NonNullable<PluginSettings['selectedModel']> {
-    if (settings.selectedModel !== null) {
-      return settings.selectedModel;
-    }
-
-    throw new Error('Select a Local Dictation model before starting dictation.');
-  }
 }
 
 function createSessionId(): string {

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -841,7 +841,6 @@ export class DictationSessionController {
       }
     }
   }
-
 }
 
 function createSessionId(): string {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { dictationAnchorExtension } from './editor/dictation-anchor-extension';
 import { noteSurfaceUpdateListenerExtension } from './editor/note-surface';
 import { sessionProcessingExtension } from './editor/session-processing-extension';
 import { createOllamaClient } from './llm/ollama-client';
+import { ManageModelsModal } from './models/manage-models-modal';
 import { ModelInstallManager } from './models/model-install-manager';
 import { Session } from './session/session';
 import { logAccelerationFallbacks } from './settings/acceleration-info';
@@ -18,7 +19,6 @@ import {
   resolvePluginSettings,
 } from './settings/plugin-settings';
 import { LocalSttSettingTab } from './settings/settings-tab';
-import { ManageModelsModal } from './models/manage-models-modal';
 import { SetupWizardModal } from './setup/setup-wizard-modal';
 import { formatErrorMessage } from './shared/format-utils';
 import { createPluginLogger, type PluginLogger } from './shared/plugin-logger';

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,7 +107,7 @@ export default class LocalSttPlugin extends Plugin {
       },
       ollamaClient,
       onModelMissing: () => {
-        this.openModelPicker();
+        void this.openModelPicker();
       },
       onSidecarMissing: () => {
         void this.openSetupWizard();
@@ -127,6 +127,7 @@ export default class LocalSttPlugin extends Plugin {
         isDictationBusy: () => this.dictationController?.isBusy() ?? false,
         logger: this.logger,
         modelInstallManager: this.requireModelInstallManager(),
+        openModelPicker: (options) => this.openModelPicker(options),
         openSetupWizard: () => this.openSetupWizard(),
         pluginVersion: this.manifest.version,
         resolvePluginDirectory: () => this.resolvePluginDirectoryPath(),
@@ -234,17 +235,7 @@ export default class LocalSttPlugin extends Plugin {
     const modal = new SetupWizardModal({
       app: this.app,
       hasSelectedModel: () => this.settings.selectedModel !== null,
-      isSidecarInstalled: async () => {
-        try {
-          await this.resolveSidecarExecutablePath();
-          return true;
-        } catch (error) {
-          if (error instanceof SidecarNotInstalledError) {
-            return false;
-          }
-          throw error;
-        }
-      },
+      isSidecarInstalled: () => this.isSidecarInstalled(),
       logger: this.logger,
       modelInstallManager: this.requireModelInstallManager(),
       onCompleted: async () => {
@@ -270,14 +261,30 @@ export default class LocalSttPlugin extends Plugin {
     modal.open();
   }
 
-  private openModelPicker(): void {
+  async openModelPicker(options: { onChanged?: () => void } = {}): Promise<void> {
+    if (!(await this.isSidecarInstalled())) {
+      await this.openSetupWizard();
+      return;
+    }
     new ManageModelsModal(this.app, {
       manager: this.requireModelInstallManager(),
-      onChanged: () => {
-        // Selection or install state changed; nothing more to do here —
-        // ModelInstallManager handles auto-select-on-install.
+      onChanged: options.onChanged ?? (() => {}),
+      onRunSetup: () => {
+        void this.openSetupWizard();
       },
     }).open();
+  }
+
+  private async isSidecarInstalled(): Promise<boolean> {
+    try {
+      await this.resolveSidecarExecutablePath();
+      return true;
+    } catch (error) {
+      if (error instanceof SidecarNotInstalledError) {
+        return false;
+      }
+      throw error;
+    }
   }
 
   override async onunload(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,8 +18,8 @@ import {
   resolvePluginSettings,
 } from './settings/plugin-settings';
 import { LocalSttSettingTab } from './settings/settings-tab';
-import { getInstallCopy } from './setup/sidecar-install-copy';
-import { SidecarInstallModal } from './setup/sidecar-install-modal';
+import { ManageModelsModal } from './models/manage-models-modal';
+import { SetupWizardModal } from './setup/setup-wizard-modal';
 import { formatErrorMessage } from './shared/format-utils';
 import { createPluginLogger, type PluginLogger } from './shared/plugin-logger';
 import { assertSidecarExecutableIsFresh } from './sidecar/sidecar-build-state';
@@ -86,7 +86,7 @@ export default class LocalSttPlugin extends Plugin {
         }),
     );
 
-    const ribbonElement = this.addRibbonIcon('mic', 'Local Dictation: Click to start', () => {
+    const ribbonElement = this.addRibbonIcon('mic', 'Local Dictation — start dictation', () => {
       void this.requireDictationController().toggleDictation();
     });
     this.ribbonController = new DictationRibbonController(ribbonElement);
@@ -106,8 +106,11 @@ export default class LocalSttPlugin extends Plugin {
         new Notice(message);
       },
       ollamaClient,
+      onModelMissing: () => {
+        this.openModelPicker();
+      },
       onSidecarMissing: () => {
-        void this.openFirstRunSetup();
+        void this.openSetupWizard();
       },
       setRibbonState: (state) => {
         this.ribbonController?.setState(state);
@@ -124,6 +127,7 @@ export default class LocalSttPlugin extends Plugin {
         isDictationBusy: () => this.dictationController?.isBusy() ?? false,
         logger: this.logger,
         modelInstallManager: this.requireModelInstallManager(),
+        openSetupWizard: () => this.openSetupWizard(),
         pluginVersion: this.manifest.version,
         resolvePluginDirectory: () => this.resolvePluginDirectoryPath(),
         restartSidecar: async () => {
@@ -172,7 +176,7 @@ export default class LocalSttPlugin extends Plugin {
     } catch (error) {
       if (error instanceof SidecarNotInstalledError) {
         this.logger.debug('sidecar', 'sidecar not installed on startup');
-        await this.openFirstRunSetup();
+        await this.openSetupWizard();
         return;
       }
       this.logger.error('sidecar', 'initial startup check failed', error);
@@ -217,24 +221,41 @@ export default class LocalSttPlugin extends Plugin {
     await this.ensureLocalDictationSidebar();
   }
 
-  private async openFirstRunSetup(): Promise<void> {
+  async openSetupWizard(): Promise<void> {
     let pluginDirectory: string;
 
     try {
       pluginDirectory = await this.resolvePluginDirectoryPath();
     } catch (error) {
-      this.logger.error(
-        'installer',
-        'unable to resolve plugin directory for first-run setup',
-        error,
-      );
+      this.logger.error('installer', 'unable to resolve plugin directory for setup wizard', error);
       return;
     }
 
-    new SidecarInstallModal(this.app, {
-      copy: getInstallCopy('cpu', 'first-run'),
-      manager: this.requireSidecarInstallManager(),
-      onInstalled: async () => {
+    const modal = new SetupWizardModal({
+      app: this.app,
+      hasSelectedModel: () => this.settings.selectedModel !== null,
+      isSidecarInstalled: async () => {
+        try {
+          await this.resolveSidecarExecutablePath();
+          return true;
+        } catch (error) {
+          if (error instanceof SidecarNotInstalledError) {
+            return false;
+          }
+          throw error;
+        }
+      },
+      logger: this.logger,
+      modelInstallManager: this.requireModelInstallManager(),
+      onCompleted: async () => {
+        await this.updateSettings({
+          ...this.settings,
+          setupCompletedAt: new Date().toISOString(),
+        });
+      },
+      pluginDirectory,
+      pluginVersion: this.manifest.version,
+      postSidecarInstalled: async () => {
         await this.requireSidecarConnection().restart(
           this.settings.sidecarStartupTimeoutSeconds * 1000,
         );
@@ -242,9 +263,20 @@ export default class LocalSttPlugin extends Plugin {
         logAccelerationFallbacks(systemInfo, this.settings.accelerationPreference, this.logger);
         await this.requireModelInstallManager().init();
       },
-      pluginDirectory,
-      variant: 'cpu',
-      version: this.manifest.version,
+      sidecarConnection: this.requireSidecarConnection(),
+      sidecarInstallManager: this.requireSidecarInstallManager(),
+      sidecarStartupTimeoutMs: this.settings.sidecarStartupTimeoutSeconds * 1000,
+    });
+    modal.open();
+  }
+
+  private openModelPicker(): void {
+    new ManageModelsModal(this.app, {
+      manager: this.requireModelInstallManager(),
+      onChanged: () => {
+        // Selection or install state changed; nothing more to do here —
+        // ModelInstallManager handles auto-select-on-install.
+      },
     }).open();
   }
 

--- a/src/models/manage-models-modal.ts
+++ b/src/models/manage-models-modal.ts
@@ -77,7 +77,7 @@ export class ManageModelsModal extends Modal {
 
     const state = this.deps.manager.getState();
     if (state.loadStatus === 'error' && this.deps.onRunSetup !== undefined) {
-      this.renderSidecarRequired(state.loadError);
+      this.renderLoadErrorPanel(state.loadError);
       return;
     }
 
@@ -88,13 +88,13 @@ export class ManageModelsModal extends Modal {
     this.renderModelList();
   }
 
-  private renderSidecarRequired(loadError: string | null): void {
+  private renderLoadErrorPanel(loadError: string | null): void {
     const panel = this.contentEl.createDiv({ cls: 'local-stt-empty-panel' });
     const iconWrap = panel.createDiv({ cls: 'local-stt-empty-panel__icon' });
     setIcon(iconWrap, 'download-cloud');
-    panel.createEl('h3', { text: 'Sidecar required to manage models' });
+    panel.createEl('h3', { text: "Couldn't load models" });
     panel.createEl('p', {
-      text: 'Local Dictation needs the native sidecar to download, verify, and run speech-to-text models.',
+      text: 'The speech engine may not be installed or may not be responding. Re-run setup to reinstall it, or try again.',
     });
     if (loadError !== null && loadError.length > 0) {
       panel.createEl('p', { cls: 'local-stt-empty-panel__detail', text: loadError });

--- a/src/models/manage-models-modal.ts
+++ b/src/models/manage-models-modal.ts
@@ -1,5 +1,5 @@
 import type { App } from 'obsidian';
-import { Modal, Notice, Setting } from 'obsidian';
+import { Modal, Notice, Setting, setIcon } from 'obsidian';
 
 import { formatBytes, formatErrorMessage } from '../shared/format-utils';
 import { resolveEngineCapabilities } from './capability-view';
@@ -26,6 +26,7 @@ import { deriveModelRowStates, type ModelRowState } from './model-row-state';
 interface ManageModelsModalDependencies {
   manager: ModelInstallManager;
   onChanged: () => void;
+  onRunSetup?: () => void;
 }
 
 interface AdapterTabKey {
@@ -60,19 +61,53 @@ export class ManageModelsModal extends Modal {
   override onOpen(): void {
     this.modalEl.addClass('local-stt-manage-models');
     this.titleEl.setText('Manage models');
-    this.contentEl.empty();
-
-    // Tab bar (no search)
-    const toolbar = this.contentEl.createDiv({ cls: 'local-stt-toolbar' });
-    this.tabBarEl = toolbar.createDiv({ cls: 'local-stt-tab-bar' });
-
-    this.listContainer = this.contentEl.createDiv({ cls: 'local-stt-model-list' });
-
-    this.renderTabs();
-    this.renderModelList();
+    this.renderContent();
 
     this.releaseSubscription = this.deps.manager.subscribe(() => {
       this.handleStateChange();
+    });
+  }
+
+  private renderContent(): void {
+    this.contentEl.empty();
+    this.progressElements.clear();
+    this.tabBarEl = null;
+    this.listContainer = null;
+    this.tabButtons.clear();
+
+    const state = this.deps.manager.getState();
+    if (state.loadStatus === 'error' && this.deps.onRunSetup !== undefined) {
+      this.renderSidecarRequired(state.loadError);
+      return;
+    }
+
+    const toolbar = this.contentEl.createDiv({ cls: 'local-stt-toolbar' });
+    this.tabBarEl = toolbar.createDiv({ cls: 'local-stt-tab-bar' });
+    this.listContainer = this.contentEl.createDiv({ cls: 'local-stt-model-list' });
+    this.renderTabs();
+    this.renderModelList();
+  }
+
+  private renderSidecarRequired(loadError: string | null): void {
+    const panel = this.contentEl.createDiv({ cls: 'local-stt-empty-panel' });
+    const iconWrap = panel.createDiv({ cls: 'local-stt-empty-panel__icon' });
+    setIcon(iconWrap, 'download-cloud');
+    panel.createEl('h3', { text: 'Sidecar required to manage models' });
+    panel.createEl('p', {
+      text: 'Local Dictation needs the native sidecar to download, verify, and run speech-to-text models.',
+    });
+    if (loadError !== null && loadError.length > 0) {
+      panel.createEl('p', { cls: 'local-stt-empty-panel__detail', text: loadError });
+    }
+    const actions = panel.createDiv({ cls: 'local-stt-empty-panel__actions' });
+    actions
+      .createEl('button', { cls: 'mod-cta', text: 'Run setup' })
+      .addEventListener('click', () => {
+        this.close();
+        this.deps.onRunSetup?.();
+      });
+    actions.createEl('button', { text: 'Try again' }).addEventListener('click', () => {
+      void this.deps.manager.init();
     });
   }
 
@@ -351,6 +386,18 @@ export class ManageModelsModal extends Modal {
 
   private handleStateChange(): void {
     const state = this.deps.manager.getState();
+
+    // If we're currently in the sidecar-required panel (listContainer === null)
+    // or the state has just transitioned into error mode, do a full re-render
+    // so the layout matches the load status.
+    if (
+      this.listContainer === null ||
+      (state.loadStatus === 'error' && this.deps.onRunSetup !== undefined)
+    ) {
+      this.renderContent();
+      return;
+    }
+
     const { activeInstall } = state;
 
     // Fast path: if an install is active for a visible row, try in-place

--- a/src/models/model-install-manager.ts
+++ b/src/models/model-install-manager.ts
@@ -528,14 +528,19 @@ export class ModelInstallManager {
     // On completed installs, refresh the installed models list so the UI
     // reflects the new model without requiring a restart.
     if (event.state === 'completed') {
-      void this.refreshAfterInstall();
+      void this.refreshAfterInstall({
+        familyId: event.familyId,
+        kind: 'catalog_model',
+        modelId: event.modelId,
+        runtimeId: event.runtimeId,
+      });
       return;
     }
 
     this.notify();
   }
 
-  private async refreshAfterInstall(): Promise<void> {
+  private async refreshAfterInstall(completed?: CatalogModelSelection): Promise<void> {
     try {
       const overridePayload = createModelStoreOverridePayload(
         this.deps.getSettings().modelStorePathOverride,
@@ -550,6 +555,20 @@ export class ModelInstallManager {
         `failed to refresh installed models after install: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
+
+    // Auto-select on install when nothing is currently selected — new users
+    // shouldn't have to figure out a second "Use" click after installing.
+    if (completed !== undefined && this.deps.getSettings().selectedModel === null) {
+      try {
+        await this.select(completed);
+      } catch (error) {
+        this.deps.logger?.warn(
+          'model',
+          `auto-select after install failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
     this.notify();
   }
 

--- a/src/settings/plugin-settings.ts
+++ b/src/settings/plugin-settings.ts
@@ -95,6 +95,7 @@ export interface PluginSettings {
   localTranscriptSidebarBootstrapped: boolean;
   modelStorePathOverride: string;
   selectedModel: SelectedModel | null;
+  setupCompletedAt: string | null;
   sidecarPathOverride: string;
   sidecarRequestTimeoutSeconds: number;
   sidecarStartupTimeoutSeconds: number;
@@ -129,6 +130,7 @@ export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
   localTranscriptSidebarBootstrapped: false,
   modelStorePathOverride: '',
   selectedModel: null,
+  setupCompletedAt: null,
   sidecarPathOverride: '',
   sidecarRequestTimeoutSeconds: 300,
   sidecarStartupTimeoutSeconds: 4,
@@ -215,6 +217,7 @@ export function resolvePluginSettings(data: unknown): PluginSettings {
       DEFAULT_PLUGIN_SETTINGS.modelStorePathOverride,
     ),
     selectedModel: readSelectedModel(raw.selectedModel),
+    setupCompletedAt: typeof raw.setupCompletedAt === 'string' ? raw.setupCompletedAt : null,
     sidecarPathOverride: readString(
       raw.sidecarPathOverride,
       DEFAULT_PLUGIN_SETTINGS.sidecarPathOverride,

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -1,11 +1,12 @@
 import type { App, Plugin } from 'obsidian';
-import { Platform, PluginSettingTab, Setting } from 'obsidian';
+import { Notice, Platform, PluginSettingTab, Setting } from 'obsidian';
 
 import { resolveEngineCapabilities } from '../models/capability-view';
 import type { ModelInstallManager } from '../models/model-install-manager';
 import { updateInstallProgressElement } from '../models/model-install-progress';
 import { ExternalModelFileModal, ModelDetailsModal } from '../models/model-management-modals';
 import { matchesModelTriple } from '../models/model-management-types';
+import { formatErrorMessage } from '../shared/format-utils';
 import type { PluginLogger } from '../shared/plugin-logger';
 import type { SpeakingStyle } from '../sidecar/protocol';
 import type { SidecarConnection } from '../sidecar/sidecar-connection';
@@ -391,9 +392,7 @@ export class LocalSttSettingTab extends PluginSettingTab {
         : (state.compiledRuntimes.find((r) => r.runtimeId === sel.runtimeId) ?? null);
 
     containerEl.empty();
-    heading.setName(
-      selectedAdapter === null ? 'Engine' : `${selectedAdapter.displayName} engine`,
-    );
+    heading.setName(selectedAdapter === null ? 'Engine' : `${selectedAdapter.displayName} engine`);
 
     let rendered = 0;
 
@@ -410,7 +409,18 @@ export class LocalSttSettingTab extends PluginSettingTab {
         .addToggle((toggle) => {
           toggle.setValue(settings.accelerationPreference === 'auto');
           toggle.onChange(async (value) => {
+            if (this.dependencies.isDictationBusy()) {
+              new Notice('Cannot change hardware acceleration while dictating.');
+              toggle.setValue(!value);
+              return;
+            }
             await this.access.persistOne('accelerationPreference', value ? 'auto' : 'cpu_only');
+            try {
+              await this.dependencies.restartSidecar();
+              new Notice(value ? 'Hardware acceleration on.' : 'Hardware acceleration off.');
+            } catch (error) {
+              new Notice(`Failed to apply hardware acceleration: ${formatErrorMessage(error)}`);
+            }
           });
         });
       rendered += 1;
@@ -471,7 +481,9 @@ export class LocalSttSettingTab extends PluginSettingTab {
 
       const setting = new Setting(items)
         .setName('Set up Local Dictation')
-        .setDesc("Local Dictation isn't ready yet. Run the setup wizard to install the speech engine and a model.");
+        .setDesc(
+          "Local Dictation isn't ready yet. Run the setup wizard to install the speech engine and a model.",
+        );
       setting.addButton((button) => {
         button
           .setCta()

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -36,13 +36,11 @@ import {
   addEnumSetting,
   addTextSetting,
   addToggleSetting,
-  appendInfoTooltip,
   createSettingGroup,
   type DropdownOption,
   type SettingAccess,
 } from './setting-helpers';
 import {
-  openSidecarInstallModal,
   resolvePluginDirectorySafe,
   type SidecarInstallActionDeps,
   SidecarSettingsSection,
@@ -53,6 +51,7 @@ interface SettingsTabDependencies {
   isDictationBusy: () => boolean;
   logger?: PluginLogger | undefined;
   modelInstallManager: ModelInstallManager;
+  openSetupWizard: () => Promise<void>;
   pluginVersion: string;
   resolvePluginDirectory: () => Promise<string>;
   restartSidecar: () => Promise<void>;
@@ -164,7 +163,7 @@ export class LocalSttSettingTab extends PluginSettingTab {
 
     addEnumSetting(transcriptionCard, this.access, {
       name: 'Listening mode',
-      desc: 'Continuous or single-phrase capture.',
+      desc: 'Continuous, or stop after one sentence.',
       key: 'listeningMode',
       options: LISTENING_MODE_OPTIONS,
       isValid: isListeningMode,
@@ -172,9 +171,9 @@ export class LocalSttSettingTab extends PluginSettingTab {
 
     addEnumSetting(transcriptionCard, this.access, {
       name: 'Speaking style',
-      desc: 'Pause detection speed.',
+      desc: "How quickly the engine decides you've stopped speaking.",
       tooltip:
-        "How quickly the engine decides you've stopped speaking. Responsive — ends quickly. Balanced — standard detection (default). Patient — waits longer through pauses.",
+        'Responsive ends quickly. Balanced uses standard detection (default). Patient waits longer through pauses.',
       key: 'speakingStyle',
       options: SPEAKING_STYLE_OPTIONS,
       isValid: isSpeakingStyle,
@@ -190,9 +189,8 @@ export class LocalSttSettingTab extends PluginSettingTab {
 
     addEnumSetting(transcriptionCard, this.access, {
       name: 'Transcript formatting',
-      desc: 'How speech is joined.',
-      tooltip:
-        'How dictated speech is joined within one session. Smart paragraphs use longer pauses as paragraph breaks.',
+      desc: 'How phrases are joined together.',
+      tooltip: 'Smart paragraphs use longer pauses as paragraph breaks.',
       key: 'transcriptFormatting',
       options: TRANSCRIPT_FORMATTING_OPTIONS,
       isValid: isTranscriptFormattingMode,
@@ -206,7 +204,7 @@ export class LocalSttSettingTab extends PluginSettingTab {
     // can hide the whole card when no rows apply (e.g. macOS + a model with
     // no initial-prompt support).
     const engineGroup = containerEl.createDiv({ cls: 'setting-group' });
-    const engineHeading = new Setting(engineGroup).setName('Engine options').setHeading();
+    const engineHeading = new Setting(engineGroup).setName('Engine').setHeading();
     const engineSection = engineGroup.createDiv({ cls: 'setting-items' });
     const renderEngine = (): void => {
       this.renderEngineOptions(engineGroup, engineHeading, engineSection);
@@ -229,16 +227,14 @@ export class LocalSttSettingTab extends PluginSettingTab {
 
     addTextSetting(advancedSection, this.access, {
       name: 'Model store folder override',
-      desc: 'Custom managed-model folder.',
-      tooltip:
-        'Optional absolute folder path for managed downloads. Leave blank to use the shared default model store.',
+      desc: 'Custom folder for managed model downloads.',
       key: 'modelStorePathOverride',
       placeholder: 'Use the shared default model store',
     });
 
     const disableLlmSetting = new Setting(advancedSection)
       .setName('Disable LLM features')
-      .setDesc('Turn off the Ollama LLM transform and remove the LLM transformation sidebar.');
+      .setDesc('Hide the LLM transformation sidebar.');
     disableLlmSetting.addToggle((toggle) => {
       toggle.setValue(!this.dependencies.getSettings().llmFeaturesEnabled);
       toggle.onChange(async (value) => {
@@ -247,9 +243,18 @@ export class LocalSttSettingTab extends PluginSettingTab {
       });
     });
 
+    new Setting(advancedSection)
+      .setName('Run setup')
+      .setDesc('Re-run the first-time setup wizard.')
+      .addButton((button) => {
+        button.setButtonText('Run setup').onClick(() => {
+          void this.dependencies.openSetupWizard();
+        });
+      });
+
     const developerModeSetting = new Setting(advancedSection)
       .setName('Developer mode')
-      .setDesc('Verbose console diagnostics.');
+      .setDesc('Show verbose diagnostics and developer-only settings.');
     developerModeSetting.addToggle((toggle) => {
       toggle.setValue(this.dependencies.getSettings().developerMode);
       toggle.onChange(async (value) => {
@@ -276,9 +281,9 @@ export class LocalSttSettingTab extends PluginSettingTab {
   }
 
   private renderTimestampSettings(parent: HTMLElement, settings: PluginSettings): void {
-    const enableSetting = new Setting(parent)
+    new Setting(parent)
       .setName('Use timestamps')
-      .setDesc('Stamp phrase boundaries with the time they were spoken.')
+      .setDesc('Stamp each phrase with the time it was spoken.')
       .addToggle((toggle) => {
         toggle.setValue(settings.timestampsEnabled);
         toggle.onChange(async (value) => {
@@ -286,22 +291,18 @@ export class LocalSttSettingTab extends PluginSettingTab {
           this.display();
         });
       });
-    appendInfoTooltip(
-      enableSetting,
-      'Inserts a boundary timestamp at each phrase break (when the voice-activity detector decides one phrase has ended and another begins), plus an optional session header at the top. A long session reads like a timed log.',
-    );
 
     if (!settings.timestampsEnabled) return;
 
     addToggleSetting(parent, this.access, {
       name: 'Session header',
-      desc: 'Emit [YYYY-MM-DD HH:MM] before the first phrase.',
+      desc: 'Insert [YYYY-MM-DD HH:MM] at the top of the session.',
       key: 'timestampSessionHeader',
     });
 
     addEnumSetting(parent, this.access, {
       name: 'Reference clock',
-      desc: 'Elapsed since session start, or wall-clock time.',
+      desc: 'Elapsed time, or wall-clock time.',
       key: 'timestampClock',
       options: TIMESTAMP_CLOCK_OPTIONS,
       isValid: isTimestampClock,
@@ -309,19 +310,17 @@ export class LocalSttSettingTab extends PluginSettingTab {
 
     addEnumSetting(parent, this.access, {
       name: 'Density',
-      desc: 'Sparse: landmarks at fixed intervals. Every phrase: one per phrase.',
+      desc: 'Stamp every phrase, or at fixed intervals.',
       key: 'timestampDensity',
       options: TIMESTAMP_DENSITY_OPTIONS,
       isValid: isTimestampDensity,
-      tooltip:
-        'Sparse keeps the transcript clean by emitting one landmark per interval. Every phrase stamps every utterance — useful for meeting notes or precise references.',
     });
 
     const minSeconds = MIN_TIMESTAMP_SPARSE_INTERVAL_MS / 1000;
     const maxSeconds = MAX_TIMESTAMP_SPARSE_INTERVAL_MS / 1000;
     new Setting(parent)
       .setName('Sparse interval')
-      .setDesc(`Seconds between sparse landmarks (${minSeconds}-${maxSeconds}).`)
+      .setDesc(`Seconds between landmarks (${minSeconds}-${maxSeconds}).`)
       .addText((text) => {
         text.inputEl.type = 'number';
         text.inputEl.min = String(minSeconds);
@@ -394,7 +393,7 @@ export class LocalSttSettingTab extends PluginSettingTab {
 
     containerEl.empty();
     heading.setName(
-      selectedAdapter === null ? 'Engine options' : `${selectedAdapter.displayName} engine`,
+      selectedAdapter === null ? 'Engine' : `${selectedAdapter.displayName} engine`,
     );
 
     let rendered = 0;
@@ -406,19 +405,15 @@ export class LocalSttSettingTab extends PluginSettingTab {
     if (!Platform.isMacOS && hasNonCpuAccelerator) {
       // accelerationPreference is a string enum mapped onto a boolean toggle, so
       // the addEnumSetting / addToggleSetting helpers don't fit.
-      const accelSetting = new Setting(containerEl)
+      new Setting(containerEl)
         .setName('Hardware acceleration')
-        .setDesc('GPU when available.');
-      accelSetting.addToggle((toggle) => {
-        toggle.setValue(settings.accelerationPreference === 'auto');
-        toggle.onChange(async (value) => {
-          await this.access.persistOne('accelerationPreference', value ? 'auto' : 'cpu_only');
+        .setDesc('Run inference on the GPU when available.')
+        .addToggle((toggle) => {
+          toggle.setValue(settings.accelerationPreference === 'auto');
+          toggle.onChange(async (value) => {
+            await this.access.persistOne('accelerationPreference', value ? 'auto' : 'cpu_only');
+          });
         });
-      });
-      appendInfoTooltip(
-        accelSetting,
-        'Run inference on the GPU when supported. Disable to force CPU on every engine.',
-      );
       rendered += 1;
     }
 
@@ -426,9 +421,9 @@ export class LocalSttSettingTab extends PluginSettingTab {
     if (caps.status === 'ready' && caps.capabilities.family.supportsInitialPrompt) {
       addToggleSetting(containerEl, this.access, {
         name: 'Use note as context',
-        desc: 'Glossary prompt for supported engines.',
+        desc: 'Send distinctive terms from the open note to help spelling.',
         tooltip:
-          'Send a glossary of distinctive terms from the note as the engine’s prompt. Helps spell proper nouns and technical terms. Only used by engines that support initial prompts.',
+          'Sends a glossary of proper nouns and technical terms as the engine’s initial prompt. Only used by engines that support initial prompts.',
         key: 'useNoteAsContext',
       });
       rendered += 1;
@@ -476,20 +471,14 @@ export class LocalSttSettingTab extends PluginSettingTab {
       }
 
       const setting = new Setting(items)
-        .setName('Sidecar required')
-        .setDesc(
-          'Local Dictation needs the speech-to-text sidecar to work. Install it to enable dictation.',
-        );
+        .setName('Set up Local Dictation')
+        .setDesc("Local Dictation isn't ready yet. Run the setup wizard to install the speech engine and a model.");
       setting.addButton((button) => {
         button
           .setCta()
-          .setButtonText('Install sidecar')
+          .setButtonText('Run setup')
           .onClick(() => {
-            openSidecarInstallModal(this.buildSidecarInstallActionDeps(), {
-              intent: 'install',
-              pluginDirectory,
-              variant: 'cpu',
-            });
+            void this.dependencies.openSetupWizard();
           });
       });
     };

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -2,7 +2,6 @@ import type { App, Plugin } from 'obsidian';
 import { Platform, PluginSettingTab, Setting } from 'obsidian';
 
 import { resolveEngineCapabilities } from '../models/capability-view';
-import { ManageModelsModal } from '../models/manage-models-modal';
 import type { ModelInstallManager } from '../models/model-install-manager';
 import { updateInstallProgressElement } from '../models/model-install-progress';
 import { ExternalModelFileModal, ModelDetailsModal } from '../models/model-management-modals';
@@ -51,6 +50,7 @@ interface SettingsTabDependencies {
   isDictationBusy: () => boolean;
   logger?: PluginLogger | undefined;
   modelInstallManager: ModelInstallManager;
+  openModelPicker: (options?: { onChanged?: () => void }) => Promise<void>;
   openSetupWizard: () => Promise<void>;
   pluginVersion: string;
   resolvePluginDirectory: () => Promise<string>;
@@ -135,12 +135,11 @@ export class LocalSttSettingTab extends PluginSettingTab {
     const manager = this.dependencies.modelInstallManager;
     this.disposeModelSection = renderModelSection(modelSection, manager, {
       onManageModels: () => {
-        new ManageModelsModal(this.app, {
-          manager,
+        void this.dependencies.openModelPicker({
           onChanged: () => {
             this.display();
           },
-        }).open();
+        });
       },
       onExternalFile: () => {
         const selectedModel = this.dependencies.getSettings().selectedModel;

--- a/src/settings/sidecar-settings-section.ts
+++ b/src/settings/sidecar-settings-section.ts
@@ -22,12 +22,7 @@ import {
 } from '../sidecar/sidecar-installer';
 import { SidecarNotInstalledError } from '../sidecar/sidecar-paths';
 import { renderActiveInstallCard } from './install-progress-row';
-import {
-  addPositiveIntSetting,
-  addTextSetting,
-  appendInfoTooltip,
-  type SettingAccess,
-} from './setting-helpers';
+import { addPositiveIntSetting, addTextSetting, type SettingAccess } from './setting-helpers';
 
 export interface SidecarInstallActionDeps {
   app: App;
@@ -116,7 +111,6 @@ export class SidecarSettingsSection {
         manifest: cpuManifest,
         name: 'Sidecar',
         pluginDirectory,
-        tooltipExtra: 'Includes Metal acceleration on Apple Silicon and Intel Macs.',
         variant: 'cpu',
       });
       if (activeInstall !== null) renderActiveCard(activeInstall);
@@ -141,9 +135,7 @@ export class SidecarSettingsSection {
     if (Platform.isLinux) {
       addTextSetting(this.container, this.deps.access, {
         name: 'CUDA library path',
-        desc: 'Sidecar-only CUDA search path.',
-        tooltip:
-          'Optional colon-separated library search path for the sidecar process only. Use this for Flatpak or custom CUDA installs without changing Obsidian’s global environment.',
+        desc: 'Optional library search path for the sidecar (Flatpak, custom CUDA installs).',
         key: 'cudaLibraryPath',
         placeholder: '/run/host/usr/local/cuda-12.9/targets/x86_64-linux/lib:/run/host/usr/lib64',
       });
@@ -152,27 +144,28 @@ export class SidecarSettingsSection {
     if (this.deps.access.getSettings().developerMode) {
       addTextSetting(this.container, this.deps.access, {
         name: 'Sidecar path override',
-        desc: 'Custom sidecar executable.',
-        tooltip: 'Optional absolute path to an installed or dev sidecar executable file.',
+        desc: 'Custom sidecar executable path.',
         key: 'sidecarPathOverride',
         placeholder: 'Auto-detect from bin/cpu, bin/cuda, or native/target debug builds',
       });
 
       addPositiveIntSetting(this.container, this.deps.access, {
         name: 'Startup timeout (s)',
-        desc: 'Startup health-check limit.',
-        tooltip: 'Maximum time allowed for the startup health handshake.',
+        desc: 'Seconds allowed for the startup handshake.',
         key: 'sidecarStartupTimeoutSeconds',
       });
 
       addPositiveIntSetting(this.container, this.deps.access, {
         name: 'Request timeout (s)',
-        desc: 'Sidecar request limit.',
-        tooltip:
-          'Maximum time allowed for start, stop, cancel, health, and model-management requests before failing them.',
+        desc: 'Seconds allowed for sidecar requests.',
         key: 'sidecarRequestTimeoutSeconds',
       });
     }
+
+    // Sentinel keeps Obsidian's `.setting-item:last-child` padding-stripping
+    // rule from matching the last sidecar row, so its spacing stays consistent
+    // with the rows that follow this wrapper in the Advanced section.
+    this.container.createSpan({ attr: { 'aria-hidden': 'true', style: 'display: none;' } });
   }
 
   private handleStateChange(): void {
@@ -191,10 +184,10 @@ export class SidecarSettingsSection {
     manifest: InstallManifest | null;
     name: string;
     pluginDirectory: string;
-    tooltipExtra?: string;
     variant: SidecarInstallVariant;
   }): void {
     const setting = new Setting(this.container).setName(opts.name).setDesc(opts.desc);
+    appendVersionChip(setting, opts.manifest);
     addInstallButtons(setting, opts.manifest !== null, {
       onInstall: () => {
         openSidecarInstallModal(this.deps, {
@@ -214,7 +207,6 @@ export class SidecarSettingsSection {
         void uninstallSidecarVariantWithUx(this.deps, opts.pluginDirectory, opts.variant);
       },
     });
-    appendInfoTooltip(setting, formatSidecarTooltip(opts.manifest, opts.tooltipExtra));
   }
 
   private renderGpuRow(
@@ -227,7 +219,8 @@ export class SidecarSettingsSection {
 
     const setting = new Setting(this.container)
       .setName('GPU sidecar')
-      .setDesc(isInstalled ? 'NVIDIA CUDA acceleration.' : driverReason.label);
+      .setDesc(isInstalled ? 'CUDA acceleration active.' : driverReason.label);
+    appendVersionChip(setting, manifest);
 
     addInstallButtons(setting, isInstalled, {
       installCta: driverStatus === 'present',
@@ -256,13 +249,6 @@ export class SidecarSettingsSection {
         });
       });
     }
-
-    appendInfoTooltip(
-      setting,
-      isInstalled
-        ? formatSidecarTooltip(manifest, 'NVIDIA CUDA backend.')
-        : formatSidecarTooltip(null, driverReason.tooltip),
-    );
   }
 
   private openCudaInstallModal(pluginDirectory: string): void {
@@ -407,27 +393,30 @@ function addInstallButtons(
   });
 }
 
-function formatSidecarTooltip(manifest: InstallManifest | null, extra?: string): string {
-  const base = manifest === null ? 'Not installed.' : `Installed: ${manifest.version}.`;
-  return extra === undefined ? base : `${base} ${extra}`;
+function appendVersionChip(setting: Setting, manifest: InstallManifest | null): void {
+  if (manifest === null) return;
+  setting.nameEl.createSpan({
+    cls: 'local-stt-version-chip',
+    text: `v${manifest.version}`,
+  });
 }
 
 function describeDriverStatus(status: NvidiaDriverStatus): { label: string; tooltip: string } {
   switch (status) {
     case 'present':
       return {
-        label: 'NVIDIA driver detected.',
+        label: 'NVIDIA GPU detected — faster transcription.',
         tooltip: 'Downloads the CUDA sidecar archive from GitHub releases.',
       };
     case 'absent':
       return {
-        label: 'No NVIDIA driver detected.',
+        label: 'Requires an NVIDIA GPU. Install anyway if you know yours is supported.',
         tooltip:
           'nvidia-smi was not found on PATH. Use "Install anyway" if you are certain your system supports CUDA.',
       };
     case 'unknown':
       return {
-        label: 'NVIDIA driver status unknown.',
+        label: "Couldn't probe for NVIDIA — install only if you're sure.",
         tooltip:
           'Unable to probe for an NVIDIA driver. Proceed only if you know your GPU supports CUDA.',
       };

--- a/src/setup/setup-wizard-modal.ts
+++ b/src/setup/setup-wizard-modal.ts
@@ -10,7 +10,6 @@ import { SidecarInstallModal } from './sidecar-install-modal';
 
 interface WizardDependencies {
   app: App;
-  getInitialStep?: () => WizardStepId;
   hasSelectedModel: () => boolean;
   isSidecarInstalled: () => Promise<boolean>;
   logger?: PluginLogger;
@@ -43,10 +42,7 @@ export class SetupWizardModal extends Modal {
     this.sidecarReady = await this.deps.isSidecarInstalled();
     this.modelReady = this.deps.hasSelectedModel();
 
-    const initial = this.deps.getInitialStep?.();
-    if (initial !== undefined) {
-      this.currentStep = initial;
-    } else if (!this.sidecarReady) {
+    if (!this.sidecarReady) {
       this.currentStep = 'sidecar';
     } else if (!this.modelReady) {
       this.currentStep = 'model';
@@ -161,9 +157,8 @@ export class SetupWizardModal extends Modal {
   }
 
   private openSidecarInstall(): void {
-    const variant: 'cpu' | 'cuda' = 'cpu';
     const modal = new SidecarInstallModal(this.deps.app, {
-      copy: getInstallCopy(variant, 'first-run'),
+      copy: getInstallCopy('cpu', 'first-run'),
       manager: this.deps.sidecarInstallManager,
       onInstalled: async () => {
         await this.deps.postSidecarInstalled();
@@ -171,7 +166,7 @@ export class SetupWizardModal extends Modal {
         this.goNext();
       },
       pluginDirectory: this.deps.pluginDirectory,
-      variant,
+      variant: 'cpu',
       version: this.deps.pluginVersion,
     });
     modal.open();

--- a/src/setup/setup-wizard-modal.ts
+++ b/src/setup/setup-wizard-modal.ts
@@ -1,13 +1,12 @@
 import type { App } from 'obsidian';
 import { Modal, Notice, Platform, setIcon } from 'obsidian';
-
-import type { ModelInstallManager } from '../models/model-install-manager';
 import { ManageModelsModal } from '../models/manage-models-modal';
+import type { ModelInstallManager } from '../models/model-install-manager';
 import type { PluginLogger } from '../shared/plugin-logger';
 import type { SidecarConnection } from '../sidecar/sidecar-connection';
 import type { SidecarInstallManager } from '../sidecar/sidecar-install-manager';
-import { SidecarInstallModal } from './sidecar-install-modal';
 import { getInstallCopy } from './sidecar-install-copy';
+import { SidecarInstallModal } from './sidecar-install-modal';
 
 interface WizardDependencies {
   app: App;
@@ -285,16 +284,20 @@ export class SetupWizardModal extends Modal {
   // ---------------- Navigation ----------------
   private goNext(): void {
     const idx = STEP_ORDER.indexOf(this.currentStep);
-    if (idx >= 0 && idx < STEP_ORDER.length - 1) {
-      this.currentStep = STEP_ORDER[idx + 1]!;
+    if (idx < 0) return;
+    const next = STEP_ORDER[idx + 1];
+    if (next !== undefined) {
+      this.currentStep = next;
       this.render();
     }
   }
 
   private goBack(): void {
     const idx = STEP_ORDER.indexOf(this.currentStep);
-    if (idx > 0) {
-      this.currentStep = STEP_ORDER[idx - 1]!;
+    if (idx <= 0) return;
+    const prev = STEP_ORDER[idx - 1];
+    if (prev !== undefined) {
+      this.currentStep = prev;
       this.render();
     }
   }

--- a/src/setup/setup-wizard-modal.ts
+++ b/src/setup/setup-wizard-modal.ts
@@ -1,0 +1,301 @@
+import type { App } from 'obsidian';
+import { Modal, Notice, Platform, setIcon } from 'obsidian';
+
+import type { ModelInstallManager } from '../models/model-install-manager';
+import { ManageModelsModal } from '../models/manage-models-modal';
+import type { PluginLogger } from '../shared/plugin-logger';
+import type { SidecarConnection } from '../sidecar/sidecar-connection';
+import type { SidecarInstallManager } from '../sidecar/sidecar-install-manager';
+import { SidecarInstallModal } from './sidecar-install-modal';
+import { getInstallCopy } from './sidecar-install-copy';
+
+interface WizardDependencies {
+  app: App;
+  getInitialStep?: () => WizardStepId;
+  hasSelectedModel: () => boolean;
+  isSidecarInstalled: () => Promise<boolean>;
+  logger?: PluginLogger;
+  modelInstallManager: ModelInstallManager;
+  onCompleted: () => Promise<void>;
+  pluginDirectory: string;
+  postSidecarInstalled: () => Promise<void>;
+  pluginVersion: string;
+  sidecarConnection: Pick<SidecarConnection, 'restart'>;
+  sidecarInstallManager: SidecarInstallManager;
+  sidecarStartupTimeoutMs: number;
+}
+
+type WizardStepId = 'sidecar' | 'model' | 'ready';
+
+const STEP_ORDER: readonly WizardStepId[] = ['sidecar', 'model', 'ready'];
+
+export class SetupWizardModal extends Modal {
+  private currentStep: WizardStepId = 'sidecar';
+  private sidecarReady = false;
+  private modelReady = false;
+  private modelManagerUnsub: (() => void) | null = null;
+
+  constructor(private readonly deps: WizardDependencies) {
+    super(deps.app);
+  }
+
+  override async onOpen(): Promise<void> {
+    this.modalEl.addClass('local-stt-setup-wizard');
+    this.sidecarReady = await this.deps.isSidecarInstalled();
+    this.modelReady = this.deps.hasSelectedModel();
+
+    const initial = this.deps.getInitialStep?.();
+    if (initial !== undefined) {
+      this.currentStep = initial;
+    } else if (!this.sidecarReady) {
+      this.currentStep = 'sidecar';
+    } else if (!this.modelReady) {
+      this.currentStep = 'model';
+    } else {
+      this.currentStep = 'ready';
+    }
+
+    this.modelManagerUnsub = this.deps.modelInstallManager.subscribe(() => {
+      const next = this.deps.hasSelectedModel();
+      if (next !== this.modelReady) {
+        this.modelReady = next;
+        if (this.currentStep === 'model') {
+          this.render();
+        }
+      }
+    });
+
+    this.render();
+  }
+
+  override onClose(): void {
+    this.modelManagerUnsub?.();
+    this.modelManagerUnsub = null;
+    this.contentEl.empty();
+  }
+
+  private render(): void {
+    this.contentEl.empty();
+    this.titleEl.setText('Set up Local Dictation');
+
+    this.renderProgress();
+
+    switch (this.currentStep) {
+      case 'sidecar':
+        this.renderSidecarStep();
+        break;
+      case 'model':
+        this.renderModelStep();
+        break;
+      case 'ready':
+        this.renderReadyStep();
+        break;
+    }
+  }
+
+  private renderProgress(): void {
+    const bar = this.contentEl.createDiv({ cls: 'local-stt-wizard-progress' });
+    STEP_ORDER.forEach((step, index) => {
+      const dot = bar.createDiv({
+        cls: 'local-stt-wizard-progress__dot',
+      });
+      if (step === this.currentStep) {
+        dot.addClass('is-active');
+      }
+      if (this.isStepComplete(step)) {
+        dot.addClass('is-complete');
+      }
+      dot.setText(String(index + 1));
+    });
+  }
+
+  private isStepComplete(step: WizardStepId): boolean {
+    if (step === 'sidecar') return this.sidecarReady;
+    if (step === 'model') return this.modelReady;
+    return false;
+  }
+
+  // ---------------- Step 1: Sidecar ----------------
+  private renderSidecarStep(): void {
+    const body = this.contentEl.createDiv({ cls: 'local-stt-wizard-step' });
+    body.createEl('h2', {
+      cls: 'local-stt-wizard-step__title',
+      text: this.sidecarReady ? 'Speech engine ready' : 'Install the speech engine',
+    });
+
+    if (this.sidecarReady) {
+      body.createEl('p', {
+        text: 'The local speech-to-text engine is installed and ready.',
+      });
+    } else {
+      body.createEl('p', {
+        text: Platform.isMacOS
+          ? 'Local Dictation needs a one-time download of its speech-to-text engine. Transcription runs entirely on your Mac — audio never leaves your machine.'
+          : 'Local Dictation needs a one-time download of its speech-to-text engine. Transcription runs locally on your machine after this completes.',
+      });
+      body.createEl('p', {
+        cls: 'local-stt-wizard-step__muted',
+        text: Platform.isMacOS
+          ? 'Includes Metal acceleration on Apple Silicon and Intel Macs.'
+          : 'CPU build first. You can install CUDA acceleration later in Settings → Advanced.',
+      });
+    }
+
+    const actions = this.contentEl.createDiv({ cls: 'local-stt-wizard-actions' });
+    actions.createEl('button', { text: 'Cancel' }).addEventListener('click', () => {
+      this.close();
+    });
+
+    if (this.sidecarReady) {
+      const next = actions.createEl('button', {
+        cls: 'mod-cta',
+        text: 'Next',
+      });
+      next.addEventListener('click', () => this.goNext());
+    } else {
+      const installBtn = actions.createEl('button', {
+        cls: 'mod-cta',
+        text: 'Download engine',
+      });
+      installBtn.addEventListener('click', () => this.openSidecarInstall());
+    }
+  }
+
+  private openSidecarInstall(): void {
+    const variant: 'cpu' | 'cuda' = 'cpu';
+    const modal = new SidecarInstallModal(this.deps.app, {
+      copy: getInstallCopy(variant, 'first-run'),
+      manager: this.deps.sidecarInstallManager,
+      onInstalled: async () => {
+        await this.deps.postSidecarInstalled();
+        this.sidecarReady = true;
+        this.goNext();
+      },
+      pluginDirectory: this.deps.pluginDirectory,
+      variant,
+      version: this.deps.pluginVersion,
+    });
+    modal.open();
+  }
+
+  // ---------------- Step 2: Model ----------------
+  private renderModelStep(): void {
+    const body = this.contentEl.createDiv({ cls: 'local-stt-wizard-step' });
+    body.createEl('h2', {
+      cls: 'local-stt-wizard-step__title',
+      text: this.modelReady ? 'Model selected' : 'Pick a transcription model',
+    });
+
+    if (this.modelReady) {
+      body.createEl('p', {
+        text: 'A transcription model is installed and selected. You can install more or switch later from Settings.',
+      });
+    } else {
+      body.createEl('p', {
+        text: 'Install a transcription model to enable dictation. You can install more later — smaller models are faster, larger models are more accurate.',
+      });
+    }
+
+    const actions = this.contentEl.createDiv({ cls: 'local-stt-wizard-actions' });
+    actions.createEl('button', { text: 'Back' }).addEventListener('click', () => this.goBack());
+
+    if (this.modelReady) {
+      const next = actions.createEl('button', { cls: 'mod-cta', text: 'Next' });
+      next.addEventListener('click', () => this.goNext());
+    } else {
+      const openPicker = actions.createEl('button', {
+        cls: 'mod-cta',
+        text: 'Open model picker',
+      });
+      openPicker.addEventListener('click', () => this.openModelPicker());
+    }
+  }
+
+  private openModelPicker(): void {
+    const modal = new ManageModelsModal(this.deps.app, {
+      manager: this.deps.modelInstallManager,
+      onChanged: () => {
+        // Re-check on any change so the wizard advances as soon as a model is selected.
+        this.modelReady = this.deps.hasSelectedModel();
+        if (this.modelReady) {
+          this.render();
+        }
+      },
+    });
+    modal.open();
+  }
+
+  // ---------------- Step 3: Ready ----------------
+  private renderReadyStep(): void {
+    const body = this.contentEl.createDiv({ cls: 'local-stt-wizard-step' });
+    body.createEl('h2', {
+      cls: 'local-stt-wizard-step__title',
+      text: "You're ready to dictate",
+    });
+
+    const cardRibbon = body.createDiv({ cls: 'local-stt-wizard-card' });
+    const ribbonIcon = cardRibbon.createSpan({ cls: 'local-stt-wizard-card__icon' });
+    setIcon(ribbonIcon, 'audio-lines');
+    const ribbonText = cardRibbon.createDiv({ cls: 'local-stt-wizard-card__text' });
+    ribbonText.createEl('strong', { text: 'Use the ribbon mic' });
+    ribbonText.createEl('p', {
+      text: 'Look for this icon in the Obsidian ribbon. Click it to start dictating; click again to stop.',
+    });
+
+    const cardHotkey = body.createDiv({ cls: 'local-stt-wizard-card' });
+    const hotkeyIcon = cardHotkey.createSpan({ cls: 'local-stt-wizard-card__icon' });
+    setIcon(hotkeyIcon, 'keyboard');
+    const hotkeyText = cardHotkey.createDiv({ cls: 'local-stt-wizard-card__text' });
+    hotkeyText.createEl('strong', { text: 'Or bind a hotkey' });
+    hotkeyText.createEl('p', {
+      text: 'Set a keyboard shortcut to toggle dictation from anywhere in Obsidian.',
+    });
+    const hotkeyBtn = cardHotkey.createEl('button', { text: 'Open hotkey settings' });
+    hotkeyBtn.addEventListener('click', () => this.openHotkeySettings());
+
+    const actions = this.contentEl.createDiv({ cls: 'local-stt-wizard-actions' });
+    actions.createEl('button', { text: 'Back' }).addEventListener('click', () => this.goBack());
+    const done = actions.createEl('button', { cls: 'mod-cta', text: 'Done' });
+    done.addEventListener('click', async () => {
+      await this.deps.onCompleted();
+      this.close();
+    });
+  }
+
+  private openHotkeySettings(): void {
+    // Obsidian's documented setting-open API: opens the hotkeys tab and filters by command name.
+    type SettingHost = {
+      setting?: { open?: () => void; openTabById?: (id: string) => unknown };
+    };
+    type HotkeysTab = { searchInputEl?: HTMLInputElement; updateHotkeyVisibility?: () => void };
+    const host = this.deps.app as unknown as SettingHost;
+    try {
+      host.setting?.open?.();
+      const tab = host.setting?.openTabById?.('hotkeys') as HotkeysTab | undefined;
+      if (tab !== undefined && tab.searchInputEl !== undefined) {
+        tab.searchInputEl.value = 'Local Dictation';
+        tab.searchInputEl.dispatchEvent(new Event('input'));
+      }
+    } catch (error) {
+      this.deps.logger?.warn('setup', 'failed to open hotkey settings', error);
+      new Notice('Open Settings → Hotkeys and search for "Local Dictation".');
+    }
+  }
+
+  // ---------------- Navigation ----------------
+  private goNext(): void {
+    const idx = STEP_ORDER.indexOf(this.currentStep);
+    if (idx >= 0 && idx < STEP_ORDER.length - 1) {
+      this.currentStep = STEP_ORDER[idx + 1]!;
+      this.render();
+    }
+  }
+
+  private goBack(): void {
+    const idx = STEP_ORDER.indexOf(this.currentStep);
+    if (idx > 0) {
+      this.currentStep = STEP_ORDER[idx - 1]!;
+      this.render();
+    }
+  }
+}

--- a/src/setup/sidecar-install-modal.ts
+++ b/src/setup/sidecar-install-modal.ts
@@ -106,9 +106,14 @@ export class SidecarInstallModal extends Modal {
 
     this.contentEl.createEl('p', { text: this.options.copy.bodyText });
 
-    const details = this.contentEl.createEl('ul', { cls: 'local-stt-sidecar-install__details' });
-    details.createEl('li', { text: `Archive: ${asset}` });
-    details.createEl('li', { text: `Release: ${this.options.version}` });
+    const details = this.contentEl.createEl('dl', { cls: 'local-stt-details-grid' });
+    const appendRow = (label: string, value: string): void => {
+      details.createEl('dt', { text: label });
+      details.createEl('dd', { text: value });
+    };
+    appendRow('Download', asset);
+    appendRow('Version', this.options.version);
+    appendRow('Privacy', 'Runs locally — audio never leaves your device.');
 
     const buttons = this.contentEl.createDiv({ cls: 'local-stt-sidecar-install__buttons' });
     buttons.createEl('button', { text: 'Later' }).addEventListener('click', () => {
@@ -148,6 +153,12 @@ export class SidecarInstallModal extends Modal {
     });
 
     const buttons = this.contentEl.createDiv({ cls: 'local-stt-sidecar-install__buttons' });
+    buttons.createEl('button', { text: 'Copy error' }).addEventListener('click', () => {
+      void navigator.clipboard?.writeText(errorMessage).then(
+        () => new Notice('Error message copied to clipboard.'),
+        () => new Notice('Could not copy to clipboard.'),
+      );
+    });
     buttons
       .createEl('button', {
         cls: 'mod-cta',

--- a/src/sidecar/sidecar-connection.ts
+++ b/src/sidecar/sidecar-connection.ts
@@ -73,14 +73,25 @@ export class SidecarConnection {
   private readonly frameParser = new FramedMessageParser(parseEventFrame);
   private readonly pendingWaiters = new Set<PendingEventWaiter>();
   private readonly process: SidecarProcessLike;
+  // Set true whenever the plugin itself initiates a stop (shutdown/restart),
+  // so the onExit handler can distinguish clean swaps from real crashes.
+  private expectedStop = false;
 
   constructor(private readonly options: SidecarConnectionOptions) {
     const handlers = {
       onExit: (code: number | null, signal: NodeJS.Signals | null) => {
-        this.options.logger?.warn(
-          'sidecar',
-          `sidecar process exited (code: ${String(code)}, signal: ${String(signal)})`,
-        );
+        if (this.expectedStop) {
+          this.options.logger?.debug(
+            'sidecar',
+            `sidecar stopped (code: ${String(code)}, signal: ${String(signal)})`,
+          );
+        } else {
+          this.options.logger?.warn(
+            'sidecar',
+            `sidecar process exited unexpectedly (code: ${String(code)}, signal: ${String(signal)})`,
+          );
+        }
+        this.expectedStop = false;
         this.frameParser.reset();
         this.rejectPendingWaiters(
           new Error(
@@ -269,6 +280,7 @@ export class SidecarConnection {
       return;
     }
 
+    this.expectedStop = true;
     try {
       this.process.write(encodeJsonFrame(createShutdownCommand()));
     } finally {

--- a/src/ui/dictation-ribbon.ts
+++ b/src/ui/dictation-ribbon.ts
@@ -64,27 +64,25 @@ function buildRibbonState(
 } {
   switch (state) {
     case 'idle':
-      return { icon: 'mic', label: 'Local Dictation: Click to start' };
+      return { icon: 'mic', label: 'Local Dictation — start dictation' };
 
     case 'starting':
-      return { icon: 'loader', label: 'Local Dictation: Starting...' };
+      return { icon: 'loader', label: 'Local Dictation — starting…' };
 
     case 'listening':
-      return { icon: 'audio-lines', label: 'Local Dictation: Listening' };
+      return { icon: 'audio-lines', label: 'Local Dictation — listening' };
 
     case 'speech_detected':
-      return { icon: 'audio-lines', label: 'Local Dictation: Hearing speech' };
-
     case 'speech_ending':
-      return { icon: 'audio-lines', label: 'Local Dictation: Hearing speech' };
+      return { icon: 'audio-lines', label: 'Local Dictation — hearing speech' };
 
     case 'transcribing':
       return queueTier === 'catching_up'
-        ? { icon: 'loader', label: 'Local Dictation: Catching up...' }
-        : { icon: 'loader', label: 'Local Dictation: Transcribing...' };
+        ? { icon: 'loader', label: 'Local Dictation — catching up…' }
+        : { icon: 'loader', label: 'Local Dictation — transcribing…' };
 
     case 'error':
-      return { icon: 'mic-off', label: 'Local Dictation: Error' };
+      return { icon: 'mic-off', label: 'Local Dictation — error' };
   }
 }
 

--- a/src/ui/local-dictation-view.ts
+++ b/src/ui/local-dictation-view.ts
@@ -62,6 +62,7 @@ export class LocalDictationView extends ItemView {
   private advancedOpen = false;
   private focusedInput: HTMLElement | null = null;
   private models: OllamaModelOption[] = [];
+  private narrowObserver: ResizeObserver | null = null;
   private ollamaStatus = 'Ollama status unknown.';
   private lastEnabledMode: LlmPresetMode = DEFAULT_ENABLED_CLEANUP_MODE;
   private promptBlurRenderPending = false;
@@ -89,13 +90,29 @@ export class LocalDictationView extends ItemView {
 
   override async onOpen(): Promise<void> {
     this.render();
+    this.attachWidthObserver();
     if (this.dependencies.getSettings().llmFeaturesEnabled) {
       void this.refreshModels({ silent: true });
     }
   }
 
   override async onClose(): Promise<void> {
+    this.narrowObserver?.disconnect();
+    this.narrowObserver = null;
     await this.flushPendingPromptSave();
+  }
+
+  private attachWidthObserver(): void {
+    if (this.narrowObserver !== null) return;
+    const target = this.contentEl;
+    if (typeof ResizeObserver === 'undefined') return;
+    this.narrowObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const width = entry.contentRect.width;
+        target.toggleClass('local-dictation-sidebar--narrow', width > 0 && width < 360);
+      }
+    });
+    this.narrowObserver.observe(target);
   }
 
   private render(): void {
@@ -145,7 +162,7 @@ export class LocalDictationView extends ItemView {
     const enabled = settings.llmPostprocessMode !== 'off';
     new Setting(parent)
       .setName('Transform')
-      .setDesc(enabled ? 'LLM transform is on.' : 'Raw Whisper text is inserted directly.')
+      .setDesc(enabled ? '' : 'Raw Whisper text is inserted directly.')
       .addToggle((toggle) => {
         toggle.setValue(enabled);
         toggle.onChange(async (value) => {
@@ -181,9 +198,9 @@ export class LocalDictationView extends ItemView {
       return;
     }
 
-    const setting = new Setting(parent)
+    new Setting(parent)
       .setName('Mode')
-      .setDesc('Choose when the LLM transform runs.')
+      .setDesc('Run after each phrase, or all at once when you stop.')
       .addDropdown((dropdown) => {
         for (const option of CLEANUP_MODE_OPTIONS) {
           dropdown.addOption(option.value, option.label);
@@ -197,11 +214,6 @@ export class LocalDictationView extends ItemView {
           await this.saveField('llmPostprocessMode', value);
         });
       });
-
-    appendInfoTooltip(
-      setting,
-      'When the LLM transform runs. "After each phrase" (per-utterance) — every spoken phrase is sent to the model as soon as Whisper finishes transcribing it, and the transformed version replaces the raw text in-line. Best for prompts that operate on one phrase at a time (filler cleanup, punctuation). "All at once on stop" (batch) — raw Whisper text is inserted while you talk, then on stop the whole session is sent to the model and replaced with the transformed result. Required for prompts that need the full context (summary, reformatting, markdown structure, brain-dump organization).',
-    );
   }
 
   private renderStylePicker(parent: HTMLElement, settings: PluginSettings): void {
@@ -214,7 +226,7 @@ export class LocalDictationView extends ItemView {
     const activeRef = activeOption?.ref ?? CUSTOM_STYLE_VALUE;
 
     const description = isCustom
-      ? 'Custom - current prompt does not match any saved preset.'
+      ? 'Custom — prompt does not match a saved preset.'
       : `${activeOption.description}${describeMode(activeOption.mode)}`;
 
     const setting = new Setting(parent)
@@ -289,8 +301,8 @@ export class LocalDictationView extends ItemView {
       selectedModel.length > 0 && this.models.some((model) => model.id === selectedModel);
 
     const setting = new Setting(parent)
-      .setName('Model')
-      .setDesc('The Ollama model used to clean transcripts.')
+      .setName('Ollama model')
+      .setDesc('Pick a local Ollama chat model.')
       .addDropdown((dropdown) => {
         dropdown.addOption('', 'Select a model');
         if (selectedModel.length > 0 && !hasSelectedModel) {
@@ -320,15 +332,10 @@ export class LocalDictationView extends ItemView {
         button.extraSettingsEl.setAttribute('aria-label', 'Refresh Ollama models');
       });
 
-    appendInfoTooltip(
-      setting,
-      'Refresh re-queries Ollama for installed chat models. Smaller models are faster but less reliable.',
-    );
-
     if (selectedModel.length === 0) {
       parent.createEl('p', {
         cls: 'local-dictation-muted',
-        text: 'Pick an Ollama model to enable LLM transform. Until then, raw Whisper text is inserted directly.',
+        text: 'Pick an Ollama model above to enable the transform.',
       });
     }
   }
@@ -477,15 +484,11 @@ export class LocalDictationView extends ItemView {
   }
 
   private renderCustomizeStyleSection(parent: HTMLElement, settings: PluginSettings): void {
-    const items = createSettingGroup(
-      parent,
-      'Prompt',
-      'Edit the prompt for the current preset. Any change switches the preset picker to Custom.',
-    );
+    const items = createSettingGroup(parent, 'Prompt');
     this.addTextAreaSetting(
       items,
       'Prompt',
-      'LLM transform instructions',
+      'System prompt sent to the model.',
       settings.llmPostprocessPrompt,
       10,
       (value) => {
@@ -507,7 +510,7 @@ export class LocalDictationView extends ItemView {
       'Min words',
       override !== null
         ? `Set by preset "${override.label}". Delete and re-save the preset to change.`
-        : 'Skip below N words',
+        : 'Skip the transform under N words.',
       override?.value ?? settings.llmPostprocessSkipMinWords,
       (value) => this.saveField('llmPostprocessSkipMinWords', value, { rerender: false }),
       'Skip the LLM transform when the utterance has fewer words than this.',
@@ -516,11 +519,7 @@ export class LocalDictationView extends ItemView {
   }
 
   private renderGenerationSection(parent: HTMLElement, settings: PluginSettings): void {
-    const items = createSettingGroup(
-      parent,
-      'Generation',
-      'Ollama sampling parameters controlling output randomness.',
-    );
+    const items = createSettingGroup(parent, 'Generation');
     const override = activePresetOverride(settings, 'temperature');
     this.addNumberSetting(
       items,
@@ -545,19 +544,15 @@ export class LocalDictationView extends ItemView {
       });
     }
 
-    const showRawSetting = new Setting(items)
+    new Setting(items)
       .setName('Show raw beneath LLM output')
-      .setDesc('Keep the original Whisper transcript visible in a collapsible callout.')
+      .setDesc('Keep the Whisper transcript in a collapsible callout under each result.')
       .addToggle((toggle) => {
         toggle.setValue(settings.llmPostprocessShowRawBelow);
         toggle.onChange(async (value) => {
           await this.saveField('llmPostprocessShowRawBelow', value, { rerender: false });
         });
       });
-    appendInfoTooltip(
-      showRawSetting,
-      'Inserts the raw Whisper text below the transformed text inside a collapsible "raw" callout. After each phrase: a small raw callout is appended under every transformed phrase. All at once on stop: one combined raw callout is appended below the transformed session text. Useful while iterating on an LLM transform prompt so you can compare the model output against what was actually said.',
-    );
 
     new Setting(items).setName('Ollama status').setDesc(this.ollamaStatus);
 
@@ -716,12 +711,12 @@ export class LocalDictationView extends ItemView {
       this.models = await this.dependencies.ollamaClient.listOllamaModels();
       this.ollamaStatus =
         this.models.length === 0
-          ? 'Ollama is running. No chat models found.'
-          : 'Ollama is running.';
+          ? 'Running, but no chat models installed.'
+          : `Ready (${this.models.length} chat model${this.models.length === 1 ? '' : 's'}).`;
       this.render();
     } catch (error) {
       this.models = [];
-      this.ollamaStatus = 'Ollama is unavailable.';
+      this.ollamaStatus = 'Not running.';
       this.dependencies.logger?.warn('llm', 'Ollama refresh failed', error);
       if (options.silent !== true) {
         this.notice('Local Dictation: Ollama is unavailable.');

--- a/src/ui/local-dictation-view.ts
+++ b/src/ui/local-dictation-view.ts
@@ -300,7 +300,7 @@ export class LocalDictationView extends ItemView {
     const hasSelectedModel =
       selectedModel.length > 0 && this.models.some((model) => model.id === selectedModel);
 
-    const setting = new Setting(parent)
+    new Setting(parent)
       .setName('Ollama model')
       .setDesc('Pick a local Ollama chat model.')
       .addDropdown((dropdown) => {

--- a/styles.css
+++ b/styles.css
@@ -579,6 +579,40 @@
   }
 }
 
+/* --- LLM sidebar narrow-width --------------------------------------
+   When the sidebar is dragged narrow, stack setting rows vertically so
+   labels and controls don't get squeezed onto a single short line. */
+
+.local-dictation-sidebar--narrow .setting-item {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.local-dictation-sidebar--narrow .setting-item-info {
+  margin-right: 0;
+  margin-bottom: 6px;
+}
+
+.local-dictation-sidebar--narrow .setting-item-control {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.local-dictation-sidebar--narrow .setting-item-control select,
+.local-dictation-sidebar--narrow .setting-item-control input[type="text"],
+.local-dictation-sidebar--narrow .setting-item-control input[type="number"] {
+  width: 100%;
+  min-width: 0;
+}
+
+/* Truncate preset description to one line; full text in title attr on hover. */
+.local-dictation-sidebar .setting-item-description {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 /* --- LLM sidebar Advanced disclosure ------------------------------ */
 
 .local-dictation-advanced {
@@ -595,4 +629,110 @@
 
 .local-stt-hidden {
   display: none;
+}
+
+.local-stt-version-chip {
+  margin-left: 0.55em;
+  color: var(--text-muted);
+  font-size: 0.82em;
+  font-weight: normal;
+  font-variant-numeric: tabular-nums;
+}
+
+/* --- Setup wizard ------------------------------------------------- */
+
+.local-stt-setup-wizard {
+  width: min(560px, 92vw);
+}
+
+.local-stt-wizard-progress {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin: 4px 0 18px;
+}
+
+.local-stt-wizard-progress__dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: var(--background-modifier-border, rgba(128, 128, 128, 0.18));
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+  font-weight: 600;
+}
+
+.local-stt-wizard-progress__dot.is-active {
+  background: var(--interactive-accent);
+  color: var(--text-on-accent);
+}
+
+.local-stt-wizard-progress__dot.is-complete {
+  background: var(--background-modifier-success, rgba(0, 160, 0, 0.18));
+  color: var(--text-success, var(--text-normal));
+}
+
+.local-stt-wizard-step {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.local-stt-wizard-step__title {
+  margin: 0 0 4px;
+  font-size: var(--font-ui-large, 1.1em);
+}
+
+.local-stt-wizard-step__muted {
+  color: var(--text-muted);
+  font-size: var(--font-ui-small);
+  margin: 0;
+}
+
+.local-stt-wizard-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px 14px;
+  padding: 12px 14px;
+  margin-top: 8px;
+  border: 1px solid var(--background-modifier-border, rgba(128, 128, 128, 0.18));
+  border-radius: var(--radius-m, 8px);
+  background: var(--background-secondary-alt, rgba(128, 128, 128, 0.05));
+}
+
+.local-stt-wizard-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  color: var(--interactive-accent);
+}
+
+.local-stt-wizard-card__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.local-stt-wizard-card__text p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--font-ui-small);
+}
+
+.local-stt-wizard-card > button {
+  grid-column: 1 / -1;
+  justify-self: start;
+  margin-top: 4px;
+}
+
+.local-stt-wizard-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 18px;
 }

--- a/styles.css
+++ b/styles.css
@@ -188,6 +188,48 @@
   padding: 24px 0;
 }
 
+.local-stt-empty-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 32px 16px;
+  text-align: center;
+}
+
+.local-stt-empty-panel__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+}
+
+.local-stt-empty-panel__icon svg {
+  width: 40px;
+  height: 40px;
+}
+
+.local-stt-empty-panel h3 {
+  margin: 0;
+}
+
+.local-stt-empty-panel p {
+  margin: 0;
+  max-width: 36em;
+  color: var(--text-muted);
+}
+
+.local-stt-empty-panel__detail {
+  font-size: var(--font-ui-small);
+  color: var(--text-faint);
+}
+
+.local-stt-empty-panel__actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
 /* --- Details grid (dt/dd pairs) ----------------------------------- */
 
 .local-stt-details-grid {

--- a/test/register-commands.test.ts
+++ b/test/register-commands.test.ts
@@ -29,10 +29,10 @@ describe('registerCommands', () => {
     registerCommands(dependencies);
 
     expect(commands.map((command) => [command.id, command.name])).toEqual([
-      ['toggle-dictation-session', 'Toggle dictation session'],
-      ['start-dictation-session', 'Start dictation session'],
-      ['stop-dictation-session', 'Stop dictation session'],
-      ['cancel-dictation-session', 'Cancel dictation session'],
+      ['toggle-dictation-session', 'Toggle dictation'],
+      ['start-dictation-session', 'Start dictation'],
+      ['stop-dictation-session', 'Stop dictation'],
+      ['cancel-dictation-session', 'Cancel dictation'],
       ['check-sidecar-health', 'Check sidecar health'],
       ['restart-sidecar', 'Restart sidecar'],
     ]);


### PR DESCRIPTION
## Summary

A first-run experience aimed at a brand-new user, plus the dead-end fix for Manage Models with no sidecar.

**Setup Wizard** — `SetupWizardModal` walks Sidecar → Model → Ready in one flow, composing the existing install modals. `setupCompletedAt` persists completion so the wizard only auto-opens on a fresh install; a "Run setup" row in Advanced re-runs it.

**Manage Models guard** — `openModelPicker` is the single canonical entry point. It checks `isSidecarInstalled` and reroutes to the wizard when missing. Settings-tab now delegates to it instead of duplicating the guard. As defense in depth, `ManageModelsModal` renders a native-styled "Sidecar required" empty panel (with `download-cloud` icon and Run setup / Try again actions) if it ever opens without a sidecar.

**No-model dictation** — clicking the ribbon with no model selected used to throw an error notice. It now opens Manage Models directly. Installing a model auto-selects it when nothing was selected.

**Sidecar swap-vs-crash** (closes #88) — `SidecarConnection` tracks an `expectedStop` flag set by `shutdown()`. Plugin-initiated stops (CPU↔CUDA swap, plugin teardown) log at `debug` ("sidecar stopped") instead of `warn` ("sidecar process exited unexpectedly"). Real crashes still warn.

**Settings copy / tooltip audit** — drops self-explanatory tooltips on ~10 rows, replaces install-info tooltips with an inline muted version chip, rewrites the GPU acceleration row value-first, renames "Engine options" → "Engine" and the LLM sidebar's "Model" → "Ollama model".

**LLM sidebar narrow-width mode** — `ResizeObserver` toggles a `--narrow` class below 360px so setting rows stack vertically; preset description clamped to 2 lines.

**Sidecar install modal** — bullet list replaced with a Download / Version / Privacy info grid; failure panel adds a Copy error button.

**Ribbon & command palette** — drop the redundant " session" suffix; ribbon labels use an em-dash state style ("Local Dictation — listening").

Closes #88

## Test plan

- [ ] Fresh install (no sidecar, no model): plugin loads, wizard auto-opens, walks sidecar → model → ready, ribbon and hotkey CTAs work.
- [ ] Reopen Obsidian after completing setup: wizard does not re-open.
- [ ] Advanced → Run setup: wizard re-opens.
- [ ] Uninstall sidecar in Advanced, click Manage models: routed to the wizard (not the broken modal).
- [ ] Click the ribbon with no model selected: Manage Models opens directly.
- [ ] Install a model: it auto-selects without a separate "Use" click.
- [ ] Switch CPU ↔ CUDA in Engine: developer console shows debug "sidecar stopped", not warn "exited unexpectedly".
- [ ] Resize the LLM sidebar below 360px: setting rows stack vertically.
- [ ] Sidecar install modal: info grid renders, Copy error appears on a failed install.
- [ ] All 326 tests pass; typecheck and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)