### PR TITLE
fix(editor): keep batch LLM cleanup working across multi-utterance sessions

### DIFF
--- a/src/editor/note-surface.ts
+++ b/src/editor/note-surface.ts
@@ -444,7 +444,9 @@ export class NoteSurface {
     for (const span of this.spans.values()) {
       span.start = update.changes.mapPos(span.start, -1);
       span.textStart = update.changes.mapPos(span.textStart, -1);
-      span.textEnd = update.changes.mapPos(span.textEnd, 1);
+      // Text bias: insertions at textEnd land outside the span, so a sibling
+      // append at writingRegionTail() doesn't swallow the next utterance.
+      span.textEnd = update.changes.mapPos(span.textEnd, -1);
       span.end = update.changes.mapPos(span.end, 1);
     }
 

--- a/test/note-surface.test.ts
+++ b/test/note-surface.test.ts
@@ -356,6 +356,19 @@ describe('NoteSurface', () => {
     expect(surface.replaceAnchor('u2', 'SECOND', 'second').kind).toBe('replaced');
   });
 
+  it('rewrites a multi-utterance region without latching as span_mismatch', () => {
+    const { surface, view } = createSurface();
+
+    expect(append(surface, 'u1', 'first').kind).toBe('appended');
+    expect(append(surface, 'u2', 'second').kind).toBe('appended');
+
+    expect(surface.rewriteRegion({ from: 0, to: doc(view).length }, 'Cleaned.', [])).toEqual({
+      kind: 'rewritten',
+      range: { from: 0, to: 'first second'.length },
+    });
+    expect(doc(view)).toBe('Cleaned.');
+  });
+
   it('rewrites a changed region when the contained spans are allowed', () => {
     const { surface, view } = createSurface();
 


### PR DESCRIPTION
## Summary

- Multi-utterance batch LLM cleanup (TLDR, Markdown, Brain dump, Voice commands, any user batch preset) was being silently dropped whenever a session had more than one utterance — the warn line `[llm] batch cleanup replacement skipped — session range no longer available` fired and the raw transcript was left in the note.
- Root cause: `NoteSurface.mapSpans` mapped `span.textEnd` with `mapPos(..., 1)`. The next utterance's append happens at `writingRegionTail()` which equals the previous span's `textEnd`. The `+1` bias treated that boundary insertion as **inside** the span, so utterance 1's `textEnd` slid forward to swallow every later utterance. The integrity check in `rewriteRegion` (`doc.sliceString(textStart, textEnd) !== projectedText`) then denied with `span_mismatch`.
- Fix: flip the bias on `textEnd` to `-1` so boundary insertions land outside the span. `span.end` keeps `+1` (correctly absorbs adjacent inserts into the writing-region tail), and user-edit latching is unaffected since `changeIntersectsSpan` uses `[start, end]`, not `textEnd`.

## Test plan

- [x] `npm run -s typecheck`
- [x] `npx vitest run` — 339 tests, including new regression `rewrites a multi-utterance region without latching as span_mismatch` (note-surface.test.ts went 27 → 28)
- [x] `npm run build` — bundle builds (177.4 kb)
- [x] `npm run install:dev -- --vault "<dev vault>"` — installed
- [ ] Manual: in Obsidian, dictate ≥2 utterances with TLDR (or any batch preset). Cleaned output replaces the raw transcript with no `batch cleanup replacement skipped` warning.
- [ ] Manual: re-test a single-utterance batch session for no regression.
- [ ] Manual: re-test a per-utterance (non-batch) preset — different code path (`replaceAnchor`), should be unaffected.

## Adjacent findings (not in this PR)

Surfaced by audit; filing as out-of-scope so they don't get lost:

1. `src/editor/session-processing-extension.ts:28` — `mapPos(next.to, 1)` is the same bias class. Different semantics (short-lived; internal rewrites bypass via `bypassSessionProcessingLock`), so needs its own investigation before flipping.
2. Every `replaceSessionRangeWithCleaned` denial is console-warn-only — no user-facing notice. After this fix `span_mismatch` should be unreachable in normal flow, but `disposed` / `user_edited` / `range_invalid` / `range_partial` can still legitimately fire and the user has no signal.
3. No controller-level test for multi-utterance batch cleanup — the existing test in `test/dictation-session-controller.test.ts` stubs `replaceSessionRangeWithCleaned` to return `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)