### PR TITLE
Implement multi-session sidecar architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Private, on-device speech-to-text for Obsidian. Dictate notes with Whisper or Co
 
 CPU works everywhere with no extra dependencies. CUDA acceleration requires an RTX 20-series / GTX 16-series or newer GPU with a driver compatible with CUDA 12.9; Cohere on CUDA also needs cuDNN 9 (falls back to CPU without it). Full details in [Platform Runtime Dependencies](docs/release/platform-runtime-dependencies.md).
 
+> **Linux distro coverage.** macOS and Windows are the primary tested targets. On Linux, the plugin is regularly used on Fedora 44; other distributions (Arch, Ubuntu, Debian, etc.) should work but are not routinely verified. If you hit a problem on your distro, please open an issue with details.
+
 ## 🚀 Quick Start
 
 Install Local Dictation from Obsidian's Community Plugins. On first run, a **setup wizard** walks you through downloading the speech engine and picking a transcription model — that's the easiest path.

--- a/native/src/app.rs
+++ b/native/src/app.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -14,10 +15,10 @@ use crate::model_store::{
     scan_installed_models,
 };
 use crate::protocol::{
-    AccelerationPreference, Command, CompiledAdapterInfo, CompiledRuntimeInfo, ContextWindow,
-    Event, HealthStatus, ListeningMode, LlmPostprocessConfig, ModelInstallState, ModelProbeStatus,
-    QueueBackpressureTier, SelectedModel, SessionState, SessionStopReason, StageId,
-    system_info_string,
+    AccelerationPreference, AudioFrame, Command, CompiledAdapterInfo, CompiledRuntimeInfo,
+    ContextWindow, Event, HealthStatus, ListeningMode, LlmPostprocessConfig, ModelInstallState,
+    ModelProbeStatus, QueueBackpressureTier, SelectedModel, SessionState, SessionStopReason,
+    StageId, system_info_string,
 };
 use crate::session::{
     FinalizedUtterance, ListeningSession, SessionAction, SessionBaseState, SessionConfig,
@@ -39,6 +40,7 @@ const MAX_QUEUED_UTTERANCES: usize = 30;
 // 30-60 distinct terms.
 const CONTEXT_BUDGET_CHARS: u32 = 384;
 const CONTEXT_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+const MAX_ACTIVE_SESSIONS: usize = 5;
 type SessionFactory = fn(SessionConfig) -> Result<ListeningSession, SessionInitError>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -55,7 +57,7 @@ pub enum ControlFlow {
 /// any expired context-request dispatches before blocking on the next
 /// read.
 pub struct AppState {
-    active_session: Option<ActiveSession>,
+    active_sessions: HashMap<String, ActiveSession>,
     catalog: Arc<ModelCatalog>,
     install_manager: ModelInstallManager,
     registry: Arc<EngineRegistry>,
@@ -69,6 +71,7 @@ struct ActiveSession {
     context_budget_chars: u32,
     cancel_tx: watch::Sender<bool>,
     draining: bool,
+    drain_reason: Option<SessionStopReason>,
     last_reported_queue_tier: QueueBackpressureTier,
     last_reported_state: Option<SessionState>,
     overload_draining: bool,
@@ -126,7 +129,7 @@ impl AppState {
         };
 
         Self {
-            active_session: None,
+            active_sessions: HashMap::new(),
             catalog: Arc::new(catalog),
             install_manager: ModelInstallManager::new(model_probe),
             registry: Arc::clone(&registry),
@@ -162,44 +165,32 @@ impl AppState {
         events
     }
 
-    pub fn handle_audio_frame(&mut self, frame_bytes: Vec<u8>) -> Vec<Event> {
+    pub fn handle_audio_frame(&mut self, audio_frame: AudioFrame) -> Vec<Event> {
         let mut events = Vec::new();
-        if self
-            .active_session
-            .as_ref()
-            .is_some_and(|s| s.draining || s.overload_draining)
-        {
-            return events;
-        }
-
-        if self.active_session.is_none() {
-            events.push(Event::Warning {
-                code: "audio_without_active_session".to_string(),
-                details: None,
-                message: "Received audio without an active listening session.".to_string(),
-                session_id: None,
-            });
-            return events;
-        }
+        let session_id = audio_frame.session_id;
 
         let result = {
-            let active_session = self
-                .active_session
-                .as_mut()
-                .expect("active session should exist after early return");
+            let Some(active_session) = self.active_sessions.get_mut(&session_id) else {
+                return events;
+            };
+
+            if active_session.draining || active_session.overload_draining {
+                return events;
+            }
+
             active_session
                 .session
-                .ingest_audio_frame(&frame_bytes)
+                .ingest_audio_frame(&audio_frame.frame_bytes)
                 .map_err(|error| (active_session.session.config().session_id.clone(), error))
         };
 
         match result {
             Ok(actions) => {
                 for action in actions {
-                    self.handle_session_action(action, &mut events);
+                    self.handle_session_action(&session_id, action, &mut events);
                 }
 
-                self.emit_state_if_changed(&mut events);
+                self.emit_state_if_changed(&session_id, &mut events);
             }
             Err((session_id, error)) => {
                 events.push(Event::Error {
@@ -392,10 +383,26 @@ impl AppState {
                 speaking_style,
             } => {
                 let llm_postprocess = llm_postprocess.map(|boxed| *boxed);
-                if let Some(replaced_events) =
-                    self.finish_active_session(SessionStopReason::SessionReplaced)
-                {
-                    events.extend(replaced_events);
+                if self.active_sessions.len() >= MAX_ACTIVE_SESSIONS {
+                    events.push(Event::Error {
+                        code: "session_capacity_exceeded".to_string(),
+                        details: Some(format!("maximum active sessions: {MAX_ACTIVE_SESSIONS}")),
+                        message:
+                            "Local Dictation already has the maximum number of active sessions."
+                                .to_string(),
+                        session_id: Some(session_id),
+                    });
+                    return (ControlFlow::Continue, events);
+                }
+
+                if self.active_sessions.contains_key(&session_id) {
+                    events.push(Event::Error {
+                        code: "session_already_exists".to_string(),
+                        details: None,
+                        message: "A dictation session with this id already exists.".to_string(),
+                        session_id: Some(session_id),
+                    });
+                    return (ControlFlow::Continue, events);
                 }
 
                 match self.resolve_runtime_model_path(
@@ -468,30 +475,40 @@ impl AppState {
                             return (ControlFlow::Continue, events);
                         }
 
-                        self.active_session = Some(ActiveSession {
-                            cancel_tx,
-                            context_budget_chars,
-                            context_required,
-                            draining: false,
-                            last_reported_queue_tier: QueueBackpressureTier::Normal,
-                            last_reported_state: None,
-                            overload_draining: false,
-                            pending_context_requests: Vec::new(),
-                            queued_utterances: 0,
-                            session,
-                            transcription_active: false,
-                        });
+                        self.active_sessions.insert(
+                            session_id.clone(),
+                            ActiveSession {
+                                cancel_tx,
+                                context_budget_chars,
+                                context_required,
+                                draining: false,
+                                drain_reason: None,
+                                last_reported_queue_tier: QueueBackpressureTier::Normal,
+                                last_reported_state: None,
+                                overload_draining: false,
+                                pending_context_requests: Vec::new(),
+                                queued_utterances: 0,
+                                session,
+                                transcription_active: false,
+                            },
+                        );
 
                         events.push(Event::SessionStarted { mode, session_id });
-                        self.emit_state_if_changed(&mut events);
+                        let emitted_session_id = match events.last() {
+                            Some(Event::SessionStarted { session_id, .. }) => session_id.clone(),
+                            _ => unreachable!("session_started was just pushed"),
+                        };
+                        self.emit_state_if_changed(&emitted_session_id, &mut events);
                     }
                     Err(error_event) => events.push(*error_event),
                 }
 
                 (ControlFlow::Continue, events)
             }
-            Command::StopSession => {
-                if let Some(stop_events) = self.finish_active_session(SessionStopReason::UserStop) {
+            Command::StopSession { session_id } => {
+                if let Some(stop_events) =
+                    self.graceful_stop(&session_id, SessionStopReason::UserStop)
+                {
                     events.extend(stop_events);
                 } else {
                     events.push(Event::Warning {
@@ -499,14 +516,15 @@ impl AppState {
                         details: None,
                         message: "Stop session was requested without an active session."
                             .to_string(),
-                        session_id: None,
+                        session_id: Some(session_id),
                     });
                 }
 
                 (ControlFlow::Continue, events)
             }
-            Command::CancelSession => {
-                if let Some(stop_events) = self.finish_active_session(SessionStopReason::UserCancel)
+            Command::CancelSession { session_id } => {
+                if let Some(stop_events) =
+                    self.finish_session(&session_id, SessionStopReason::UserCancel)
                 {
                     events.extend(stop_events);
                 } else {
@@ -515,14 +533,40 @@ impl AppState {
                         details: None,
                         message: "Cancel session was requested without an active session."
                             .to_string(),
-                        session_id: None,
+                        session_id: Some(session_id),
+                    });
+                }
+
+                (ControlFlow::Continue, events)
+            }
+            Command::RunBatchCleanup {
+                session_id,
+                transcript_text,
+                config,
+                note_context,
+            } => {
+                if self
+                    .transcription_worker
+                    .send(WorkerCommand::RunBatchCleanup {
+                        config,
+                        note_context,
+                        session_id: session_id.clone(),
+                        transcript_text,
+                    })
+                    .is_err()
+                {
+                    events.push(Event::Error {
+                        code: "internal_error".to_string(),
+                        details: None,
+                        message: "Failed to queue batch cleanup.".to_string(),
+                        session_id: Some(session_id),
                     });
                 }
 
                 (ControlFlow::Continue, events)
             }
             Command::Shutdown => {
-                if let Some(active_session) = self.active_session.take() {
+                for (_, active_session) in self.active_sessions.drain() {
                     let _ = active_session.cancel_tx.send(true);
                 }
                 let _ = self.transcription_worker.send(WorkerCommand::Shutdown);
@@ -592,8 +636,8 @@ impl AppState {
         }
     }
 
-    fn emit_state_if_changed(&mut self, events: &mut Vec<Event>) {
-        let Some(active_session) = self.active_session.as_mut() else {
+    fn emit_state_if_changed(&mut self, session_id: &str, events: &mut Vec<Event>) {
+        let Some(active_session) = self.active_sessions.get_mut(session_id) else {
             return;
         };
         let next_state = derive_session_state(
@@ -611,12 +655,12 @@ impl AppState {
         }
     }
 
-    fn finish_active_session(&mut self, reason: SessionStopReason) -> Option<Vec<Event>> {
-        if reason == SessionStopReason::UserStop {
-            return self.graceful_stop();
-        }
-
-        let active_session = self.active_session.take()?;
+    fn finish_session(
+        &mut self,
+        session_id: &str,
+        reason: SessionStopReason,
+    ) -> Option<Vec<Event>> {
+        let active_session = self.active_sessions.remove(session_id)?;
         let _ = active_session.cancel_tx.send(true);
         let session_id = active_session.session.config().session_id.clone();
         let _ = self.transcription_worker.send(WorkerCommand::EndSession {
@@ -626,29 +670,26 @@ impl AppState {
         Some(vec![Event::SessionStopped { reason, session_id }])
     }
 
-    fn graceful_stop(&mut self) -> Option<Vec<Event>> {
-        let active_session = self.active_session.as_mut()?;
+    fn graceful_stop(&mut self, session_id: &str, reason: SessionStopReason) -> Option<Vec<Event>> {
+        let active_session = self.active_sessions.get_mut(session_id)?;
         let mut events = Vec::new();
 
         let final_utterance = active_session.session.maybe_finalize_utterance();
         active_session.session.clear_activity();
 
         if let Some(utterance) = final_utterance {
-            self.enqueue_utterance(utterance, &mut events);
+            self.enqueue_utterance(session_id, utterance, &mut events);
         }
 
-        let active_session = self.active_session.as_mut()?;
+        let active_session = self.active_sessions.get_mut(session_id)?;
         if !active_session.transcription_active {
             let _ = active_session.cancel_tx.send(true);
             let session_id = active_session.session.config().session_id.clone();
-            self.active_session.take()?;
+            self.active_sessions.remove(&session_id)?;
             let _ = self.transcription_worker.send(WorkerCommand::EndSession {
                 session_id: session_id.clone(),
             });
-            events.push(Event::SessionStopped {
-                reason: SessionStopReason::UserStop,
-                session_id,
-            });
+            events.push(Event::SessionStopped { reason, session_id });
             return Some(events);
         }
 
@@ -658,14 +699,15 @@ impl AppState {
         // completion with stages intact. maybe_complete_drain emits the final
         // cancel as teardown.
         active_session.draining = true;
-        self.emit_state_if_changed(&mut events);
+        active_session.drain_reason = Some(reason);
+        self.emit_state_if_changed(session_id, &mut events);
         Some(events)
     }
 
     /// If the session is draining and no transcription work remains, tear it
     /// down and emit `SessionStopped`. Returns `true` when the drain completed.
     fn maybe_complete_drain(&mut self, session_id: &str, events: &mut Vec<Event>) -> bool {
-        let Some(active_session) = self.active_session.as_ref() else {
+        let Some(active_session) = self.active_sessions.get(session_id) else {
             return false;
         };
 
@@ -681,10 +723,12 @@ impl AppState {
         let reason = if overload_draining {
             SessionStopReason::QueueOverload
         } else {
-            SessionStopReason::UserStop
+            active_session
+                .drain_reason
+                .unwrap_or(SessionStopReason::UserStop)
         };
 
-        let Some(active_session) = self.active_session.take() else {
+        let Some(active_session) = self.active_sessions.remove(session_id) else {
             return false;
         };
         let _ = active_session.cancel_tx.send(true);
@@ -698,13 +742,18 @@ impl AppState {
         true
     }
 
-    fn handle_session_action(&mut self, action: SessionAction, events: &mut Vec<Event>) {
+    fn handle_session_action(
+        &mut self,
+        session_id: &str,
+        action: SessionAction,
+        events: &mut Vec<Event>,
+    ) {
         match action {
             SessionAction::FinalizeUtterance(utterance) => {
-                self.enqueue_utterance(utterance, events);
+                self.enqueue_utterance(session_id, utterance, events);
             }
             SessionAction::Stop(reason) => {
-                if let Some(stop_events) = self.finish_active_session(reason) {
+                if let Some(stop_events) = self.graceful_stop(session_id, reason) {
                     events.extend(stop_events);
                 }
             }
@@ -721,13 +770,9 @@ impl AppState {
                 utterance_id: _,
             } => {
                 {
-                    let Some(active_session) = self.active_session.as_mut() else {
+                    let Some(active_session) = self.active_sessions.get_mut(&session_id) else {
                         return;
                     };
-
-                    if active_session.session.config().session_id != session_id {
-                        return;
-                    }
 
                     advance_transcription_queue(active_session);
                     emit_queue_tier_if_changed(active_session, events);
@@ -744,7 +789,20 @@ impl AppState {
                     return;
                 }
 
-                self.emit_state_if_changed(events);
+                self.emit_state_if_changed(&session_id, events);
+            }
+            WorkerEvent::BatchCleanupReady {
+                clean_text,
+                raw_text,
+                session_id,
+                stage_results,
+            } => {
+                events.push(Event::BatchCleanupReady {
+                    clean_text,
+                    raw_text,
+                    session_id,
+                    stage_results,
+                });
             }
             WorkerEvent::TranscriptReady {
                 pause_ms_before_utterance,
@@ -758,13 +816,9 @@ impl AppState {
                 warnings,
             } => {
                 {
-                    let Some(active_session) = self.active_session.as_mut() else {
+                    let Some(active_session) = self.active_sessions.get_mut(&session_id) else {
                         return;
                     };
-
-                    if active_session.session.config().session_id != session_id {
-                        return;
-                    }
 
                     advance_transcription_queue(active_session);
                     emit_queue_tier_if_changed(active_session, events);
@@ -802,26 +856,31 @@ impl AppState {
                     return;
                 }
 
-                let should_stop = self.active_session.as_ref().is_some_and(|s| {
+                let should_stop = self.active_sessions.get(&session_id).is_some_and(|s| {
                     s.session.config().mode == ListeningMode::OneSentence && !s.overload_draining
                 });
 
                 if should_stop {
                     if let Some(stop_events) =
-                        self.finish_active_session(SessionStopReason::SentenceComplete)
+                        self.graceful_stop(&session_id, SessionStopReason::SentenceComplete)
                     {
                         events.extend(stop_events);
                     }
                     return;
                 }
 
-                self.emit_state_if_changed(events);
+                self.emit_state_if_changed(&session_id, events);
             }
         }
     }
 
-    fn enqueue_utterance(&mut self, utterance: FinalizedUtterance, events: &mut Vec<Event>) {
-        let Some(active_session) = self.active_session.as_mut() else {
+    fn enqueue_utterance(
+        &mut self,
+        session_id: &str,
+        utterance: FinalizedUtterance,
+        events: &mut Vec<Event>,
+    ) {
+        let Some(active_session) = self.active_sessions.get_mut(session_id) else {
             return;
         };
 
@@ -873,7 +932,7 @@ impl AppState {
             self.dispatch_pending(pending, None, events);
         }
 
-        if let Some(active_session) = self.active_session.as_mut() {
+        if let Some(active_session) = self.active_sessions.get_mut(&session_id) {
             emit_queue_tier_if_changed(active_session, events);
 
             if active_session.queued_utterances >= MAX_QUEUED_UTTERANCES
@@ -898,18 +957,23 @@ impl AppState {
         context: Option<ContextWindow>,
         events: &mut Vec<Event>,
     ) {
-        let Some(active_session) = self.active_session.as_mut() else {
-            return;
-        };
-
-        let Some(index) = active_session
-            .pending_context_requests
-            .iter()
-            .position(|pending| pending.correlation_id == correlation_id)
+        let Some((session_id, index)) =
+            self.active_sessions
+                .iter()
+                .find_map(|(session_id, active_session)| {
+                    active_session
+                        .pending_context_requests
+                        .iter()
+                        .position(|pending| pending.correlation_id == correlation_id)
+                        .map(|index| (session_id.clone(), index))
+                })
         else {
             return;
         };
 
+        let Some(active_session) = self.active_sessions.get_mut(&session_id) else {
+            return;
+        };
         let pending = active_session.pending_context_requests.remove(index);
         let context_budget_chars = active_session.context_budget_chars;
         let context = context.filter(|window| {
@@ -922,18 +986,15 @@ impl AppState {
 
     /// Dispatch any pending context requests whose deadline has elapsed.
     pub(crate) fn tick(&mut self) -> Vec<Event> {
-        let Some(active_session) = self.active_session.as_mut() else {
-            return Vec::new();
-        };
-        if active_session.pending_context_requests.is_empty() {
-            return Vec::new();
-        }
-
         let now = Instant::now();
-        let expired: Vec<PendingContextRequest> = active_session
-            .pending_context_requests
-            .extract_if(.., |pending| pending.deadline <= now)
-            .collect();
+        let mut expired = Vec::new();
+        for active_session in self.active_sessions.values_mut() {
+            expired.extend(
+                active_session
+                    .pending_context_requests
+                    .extract_if(.., |pending| pending.deadline <= now),
+            );
+        }
 
         let mut events = Vec::new();
         for pending in expired {
@@ -958,14 +1019,15 @@ impl AppState {
             });
 
         if send_result.is_err() {
+            let session_id = pending.session_id.clone();
             events.push(Event::Error {
                 code: "internal_error".to_string(),
                 details: None,
                 message: "Failed to queue audio for local transcription.".to_string(),
-                session_id: Some(pending.session_id),
+                session_id: Some(session_id.clone()),
             });
 
-            if let Some(active_session) = self.active_session.as_mut() {
+            if let Some(active_session) = self.active_sessions.get_mut(&session_id) {
                 advance_transcription_queue(active_session);
                 emit_queue_tier_if_changed(active_session, events);
             }
@@ -1704,17 +1766,45 @@ mod tests {
     }
 
     #[test]
-    fn replacing_a_session_emits_session_replaced_stop() {
+    fn starting_a_second_session_keeps_the_first_session_active() {
         let model_file_path = create_model_file();
         let mut app = test_app();
         let _ = app.handle_command(start_session_command("session-1", &model_file_path));
 
         let (_, events) = app.handle_command(start_session_command("session-2", &model_file_path));
 
-        assert!(events.contains(&Event::SessionStopped {
-            reason: SessionStopReason::SessionReplaced,
-            session_id: "session-1".to_string(),
+        assert!(events.contains(&Event::SessionStarted {
+            mode: ListeningMode::AlwaysOn,
+            session_id: "session-2".to_string(),
         }));
+        assert!(app.active_sessions.contains_key("session-1"));
+        assert!(app.active_sessions.contains_key("session-2"));
+    }
+
+    #[test]
+    fn start_session_enforces_five_session_capacity() {
+        let model_file_path = create_model_file();
+        let mut app = test_app();
+
+        for index in 0..5 {
+            let _ = app.handle_command(start_session_command(
+                &format!("session-{index}"),
+                &model_file_path,
+            ));
+        }
+
+        let (_, events) =
+            app.handle_command(start_session_command("session-overflow", &model_file_path));
+
+        assert!(matches!(
+            events.first(),
+            Some(Event::Error {
+                code,
+                session_id: Some(session_id),
+                ..
+            }) if code == "session_capacity_exceeded" && session_id == "session-overflow"
+        ));
+        assert!(!app.active_sessions.contains_key("session-overflow"));
     }
 
     #[test]
@@ -1723,7 +1813,9 @@ mod tests {
         let mut app = test_app();
         let _ = app.handle_command(start_session_command("session-1", &model_file_path));
 
-        let (_, events) = app.handle_command(Command::StopSession);
+        let (_, events) = app.handle_command(Command::StopSession {
+            session_id: "session-1".to_string(),
+        });
 
         assert_eq!(
             events,
@@ -1763,7 +1855,7 @@ mod tests {
         let _ = app.handle_command(start_session_command("session-1", &model_file_path));
 
         let mut events = Vec::new();
-        app.enqueue_utterance(fake_utterance(), &mut events);
+        app.enqueue_utterance("session-1", fake_utterance(), &mut events);
 
         assert_eq!(events.len(), 1, "expected exactly one ContextRequest event");
         let (correlation_id, utterance_id) = match &events[0] {
@@ -1781,8 +1873,8 @@ mod tests {
         };
 
         let active = app
-            .active_session
-            .as_ref()
+            .active_sessions
+            .get("session-1")
             .expect("active session should still be present after enqueue");
         assert_eq!(active.pending_context_requests.len(), 1);
         let pending = &active.pending_context_requests[0];
@@ -1805,10 +1897,13 @@ mod tests {
         let _ = app.handle_command(start_session_command("session-1", &model_file_path));
 
         let mut events = Vec::new();
-        app.enqueue_utterance(fake_utterance(), &mut events);
+        app.enqueue_utterance("session-1", fake_utterance(), &mut events);
 
         assert!(events.is_empty(), "no context_request should be emitted");
-        let active = app.active_session.as_ref().expect("active session");
+        let active = app
+            .active_sessions
+            .get("session-1")
+            .expect("active session");
         assert!(active.pending_context_requests.is_empty());
         assert!(active.transcription_active);
     }
@@ -1820,7 +1915,7 @@ mod tests {
         let _ = app.handle_command(start_session_command("session-1", &model_file_path));
 
         let mut events = Vec::new();
-        app.enqueue_utterance(fake_utterance(), &mut events);
+        app.enqueue_utterance("session-1", fake_utterance(), &mut events);
         let correlation_id = match &events[0] {
             Event::ContextRequest { correlation_id, .. } => *correlation_id,
             other => panic!("expected ContextRequest, got {other:?}"),
@@ -1841,7 +1936,10 @@ mod tests {
         });
 
         assert!(response_events.is_empty());
-        let active = app.active_session.as_ref().expect("active session");
+        let active = app
+            .active_sessions
+            .get("session-1")
+            .expect("active session");
         assert!(active.pending_context_requests.is_empty());
     }
 
@@ -1852,7 +1950,7 @@ mod tests {
         let _ = app.handle_command(start_session_command("session-1", &model_file_path));
 
         let mut events = Vec::new();
-        app.enqueue_utterance(fake_utterance(), &mut events);
+        app.enqueue_utterance("session-1", fake_utterance(), &mut events);
         let correlation_id = match &events[0] {
             Event::ContextRequest { correlation_id, .. } => *correlation_id,
             other => panic!("expected ContextRequest, got {other:?}"),
@@ -1877,7 +1975,10 @@ mod tests {
             response_events.is_empty(),
             "ContextResponse should dispatch silently on success: {response_events:?}"
         );
-        let active = app.active_session.as_ref().expect("active session");
+        let active = app
+            .active_sessions
+            .get("session-1")
+            .expect("active session");
         assert!(active.pending_context_requests.is_empty());
     }
 
@@ -1888,7 +1989,7 @@ mod tests {
         let _ = app.handle_command(start_session_command("session-1", &model_file_path));
 
         let mut events = Vec::new();
-        app.enqueue_utterance(fake_utterance(), &mut events);
+        app.enqueue_utterance("session-1", fake_utterance(), &mut events);
         let correlation_id = match &events[0] {
             Event::ContextRequest { correlation_id, .. } => *correlation_id,
             other => panic!("expected ContextRequest, got {other:?}"),
@@ -1901,7 +2002,10 @@ mod tests {
 
         assert_eq!(control_flow, ControlFlow::Continue);
         assert!(response_events.is_empty());
-        let active = app.active_session.as_ref().expect("active session");
+        let active = app
+            .active_sessions
+            .get("session-1")
+            .expect("active session");
         assert!(active.pending_context_requests.is_empty());
     }
 
@@ -1912,7 +2016,7 @@ mod tests {
         let _ = app.handle_command(start_session_command("session-1", &model_file_path));
 
         let mut events = Vec::new();
-        app.enqueue_utterance(fake_utterance(), &mut events);
+        app.enqueue_utterance("session-1", fake_utterance(), &mut events);
 
         let (control_flow, response_events) = app.handle_command(Command::ContextResponse {
             correlation_id: Uuid::new_v4(),
@@ -1921,7 +2025,10 @@ mod tests {
 
         assert_eq!(control_flow, ControlFlow::Continue);
         assert!(response_events.is_empty());
-        let active = app.active_session.as_ref().expect("active session");
+        let active = app
+            .active_sessions
+            .get("session-1")
+            .expect("active session");
         assert_eq!(active.pending_context_requests.len(), 1);
     }
 
@@ -1932,9 +2039,9 @@ mod tests {
         let _ = app.handle_command(start_session_command("session-1", &model_file_path));
 
         let mut events = Vec::new();
-        app.enqueue_utterance(fake_utterance(), &mut events);
+        app.enqueue_utterance("session-1", fake_utterance(), &mut events);
 
-        if let Some(active) = app.active_session.as_mut() {
+        if let Some(active) = app.active_sessions.get_mut("session-1") {
             for pending in active.pending_context_requests.iter_mut() {
                 pending.deadline = Instant::now() - Duration::from_millis(1);
             }
@@ -1945,7 +2052,10 @@ mod tests {
             tick_events.is_empty(),
             "tick should dispatch silently on the timeout path: {tick_events:?}"
         );
-        let active = app.active_session.as_ref().expect("active session");
+        let active = app
+            .active_sessions
+            .get("session-1")
+            .expect("active session");
         assert!(active.pending_context_requests.is_empty());
     }
 
@@ -1956,11 +2066,14 @@ mod tests {
         let _ = app.handle_command(start_session_command("session-1", &model_file_path));
 
         let mut events = Vec::new();
-        app.enqueue_utterance(fake_utterance(), &mut events);
+        app.enqueue_utterance("session-1", fake_utterance(), &mut events);
 
         let tick_events = app.tick();
         assert!(tick_events.is_empty());
-        let active = app.active_session.as_ref().expect("active session");
+        let active = app
+            .active_sessions
+            .get("session-1")
+            .expect("active session");
         assert_eq!(active.pending_context_requests.len(), 1);
     }
 
@@ -2015,7 +2128,7 @@ mod tests {
     fn enqueue_n_utterances(app: &mut AppState, n: usize) -> Vec<Event> {
         let mut events = Vec::new();
         for _ in 0..n {
-            app.enqueue_utterance(fake_utterance(), &mut events);
+            app.enqueue_utterance("session-1", fake_utterance(), &mut events);
         }
         events
     }
@@ -2036,7 +2149,10 @@ mod tests {
             0,
             "no tier events expected while remaining in normal: {events:?}"
         );
-        let active = app.active_session.as_ref().expect("active session");
+        let active = app
+            .active_sessions
+            .get("session-1")
+            .expect("active session");
         assert_eq!(active.queued_utterances, 2);
         assert!(active.transcription_active);
     }
@@ -2110,7 +2226,10 @@ mod tests {
             .count();
         assert_eq!(overload_errors, 1, "exactly one overload error expected");
 
-        let active = app.active_session.as_ref().expect("active session");
+        let active = app
+            .active_sessions
+            .get("session-1")
+            .expect("active session");
         assert!(active.overload_draining);
         assert_eq!(active.queued_utterances, 30);
         assert_eq!(
@@ -2129,13 +2248,16 @@ mod tests {
         let _ = enqueue_n_utterances(&mut app, 31);
 
         let mut events = Vec::new();
-        app.enqueue_utterance(fake_utterance(), &mut events);
+        app.enqueue_utterance("session-1", fake_utterance(), &mut events);
 
         assert!(events.iter().any(|event| matches!(
             event,
             Event::Warning { code, .. } if code == "utterance_dropped_during_overload_drain"
         )));
-        let active = app.active_session.as_ref().expect("active session");
+        let active = app
+            .active_sessions
+            .get("session-1")
+            .expect("active session");
         assert_eq!(
             active.queued_utterances, 30,
             "overflow utterance must not bump depth"
@@ -2151,7 +2273,9 @@ mod tests {
 
         let _ = enqueue_n_utterances(&mut app, 3);
 
-        let (_, events) = app.handle_command(Command::StopSession);
+        let (_, events) = app.handle_command(Command::StopSession {
+            session_id: "session-1".to_string(),
+        });
 
         assert!(
             !events
@@ -2160,8 +2284,8 @@ mod tests {
             "graceful stop must defer SessionStopped until the queue drains: {events:?}"
         );
         let active = app
-            .active_session
-            .as_ref()
+            .active_sessions
+            .get("session-1")
             .expect("session should still exist while draining");
         assert!(active.draining, "graceful_stop must set draining=true");
         assert!(active.transcription_active);
@@ -2175,7 +2299,9 @@ mod tests {
         let _ = app.handle_command(start_session_command("session-1", &model_file_path));
 
         let _ = enqueue_n_utterances(&mut app, 3);
-        let _ = app.handle_command(Command::StopSession);
+        let _ = app.handle_command(Command::StopSession {
+            session_id: "session-1".to_string(),
+        });
 
         let mut events = Vec::new();
         for _ in 0..3 {
@@ -2196,8 +2322,8 @@ mod tests {
             "drain must complete with UserStop, got: {stop:?}"
         );
         assert!(
-            app.active_session.is_none(),
-            "active_session must be cleared when drain completes"
+            !app.active_sessions.contains_key("session-1"),
+            "session must be cleared when drain completes"
         );
     }
 
@@ -2209,7 +2335,9 @@ mod tests {
 
         let _ = enqueue_n_utterances(&mut app, 3);
 
-        let (_, events) = app.handle_command(Command::CancelSession);
+        let (_, events) = app.handle_command(Command::CancelSession {
+            session_id: "session-1".to_string(),
+        });
 
         let stop = events
             .iter()
@@ -2225,7 +2353,7 @@ mod tests {
             "cancel must emit SessionStopped{{UserCancel}} immediately, got: {stop:?}"
         );
         assert!(
-            app.active_session.is_none(),
+            !app.active_sessions.contains_key("session-1"),
             "cancel must drop the active session and its pending context requests"
         );
     }
@@ -2257,8 +2385,8 @@ mod tests {
             "overload drain must complete with QueueOverload, got: {stop:?}"
         );
         assert!(
-            app.active_session.is_none(),
-            "active_session must be cleared after overload drain completes"
+            !app.active_sessions.contains_key("session-1"),
+            "session must be cleared after overload drain completes"
         );
     }
 
@@ -2303,14 +2431,16 @@ mod tests {
 
         let _ = enqueue_n_utterances(&mut app, 31);
         assert!(
-            app.active_session
-                .as_ref()
+            app.active_sessions
+                .get("session-1")
                 .map(|s| s.overload_draining)
                 .unwrap_or(false),
             "test setup must enter overload drain"
         );
 
-        let (_, events) = app.handle_command(Command::CancelSession);
+        let (_, events) = app.handle_command(Command::CancelSession {
+            session_id: "session-1".to_string(),
+        });
 
         let stop = events
             .iter()
@@ -2325,7 +2455,7 @@ mod tests {
             ),
             "cancel must win over the overload state machine, got: {stop:?}"
         );
-        assert!(app.active_session.is_none());
+        assert!(!app.active_sessions.contains_key("session-1"));
     }
 
     #[test]
@@ -2335,7 +2465,7 @@ mod tests {
         let _ = app.handle_command(start_session_command("session-1", &model_file_path));
 
         let mut enqueue_events = Vec::new();
-        app.enqueue_utterance(fake_utterance(), &mut enqueue_events);
+        app.enqueue_utterance("session-1", fake_utterance(), &mut enqueue_events);
 
         let mut events = Vec::new();
         app.handle_worker_event(
@@ -2364,9 +2494,11 @@ mod tests {
         let _ = app.handle_command(start_session_command("session-1", &model_file_path));
 
         let mut enqueue_events = Vec::new();
-        app.enqueue_utterance(fake_utterance(), &mut enqueue_events);
-        let _ = app.handle_command(Command::CancelSession);
-        assert!(app.active_session.is_none());
+        app.enqueue_utterance("session-1", fake_utterance(), &mut enqueue_events);
+        let _ = app.handle_command(Command::CancelSession {
+            session_id: "session-1".to_string(),
+        });
+        assert!(!app.active_sessions.contains_key("session-1"));
 
         let mut events = Vec::new();
         app.handle_worker_event(fake_worker_transcript_ready("session-1", None), &mut events);

--- a/native/src/app.rs
+++ b/native/src/app.rs
@@ -181,7 +181,6 @@ impl AppState {
             active_session
                 .session
                 .ingest_audio_frame(&audio_frame.frame_bytes)
-                .map_err(|error| (active_session.session.config().session_id.clone(), error))
         };
 
         match result {
@@ -192,7 +191,7 @@ impl AppState {
 
                 self.emit_state_if_changed(&session_id, &mut events);
             }
-            Err((session_id, error)) => {
+            Err(error) => {
                 events.push(Event::Error {
                     code: error.code.to_string(),
                     details: error.details,
@@ -493,12 +492,11 @@ impl AppState {
                             },
                         );
 
-                        events.push(Event::SessionStarted { mode, session_id });
-                        let emitted_session_id = match events.last() {
-                            Some(Event::SessionStarted { session_id, .. }) => session_id.clone(),
-                            _ => unreachable!("session_started was just pushed"),
-                        };
-                        self.emit_state_if_changed(&emitted_session_id, &mut events);
+                        events.push(Event::SessionStarted {
+                            mode,
+                            session_id: session_id.clone(),
+                        });
+                        self.emit_state_if_changed(&session_id, &mut events);
                     }
                     Err(error_event) => events.push(*error_event),
                 }

--- a/native/src/main.rs
+++ b/native/src/main.rs
@@ -35,9 +35,9 @@ fn run_stdio(catalog: ModelCatalog, app_version: String) -> Result<()> {
         match input_rx.recv_timeout(Duration::from_millis(10)) {
             Ok(InputMessage::Frame(frame)) => {
                 let (control_flow, events) = match frame {
-                    IncomingFrame::Audio(frame_bytes) => (
+                    IncomingFrame::Audio(audio_frame) => (
                         ControlFlow::Continue,
-                        app_state.handle_audio_frame(frame_bytes),
+                        app_state.handle_audio_frame(audio_frame),
                     ),
                     IncomingFrame::Command(command) => app_state.handle_command(command),
                 };

--- a/native/src/protocol.rs
+++ b/native/src/protocol.rs
@@ -19,6 +19,7 @@ const JSON_FRAME_KIND: u8 = 0x01;
 const AUDIO_FRAME_KIND: u8 = 0x02;
 const FRAME_HEADER_LENGTH: usize = 5;
 const MAX_FRAME_PAYLOAD: usize = 16 * 1024 * 1024;
+const SESSION_ID_BYTES: usize = 16;
 
 pub const PCM_SAMPLE_RATE_HZ: usize = 16_000;
 pub const PCM_CHANNEL_COUNT: usize = 1;
@@ -101,7 +102,6 @@ pub enum SessionState {
 pub enum SessionStopReason {
     QueueOverload,
     SentenceComplete,
-    SessionReplaced,
     Timeout,
     UserCancel,
     UserStop,
@@ -329,8 +329,18 @@ pub enum Command {
     CancelModelInstall {
         install_id: String,
     },
-    StopSession,
-    CancelSession,
+    StopSession {
+        session_id: String,
+    },
+    CancelSession {
+        session_id: String,
+    },
+    RunBatchCleanup {
+        session_id: String,
+        transcript_text: String,
+        config: LlmPostprocessConfig,
+        note_context: Option<String>,
+    },
     Shutdown,
 }
 
@@ -464,6 +474,12 @@ pub enum Event {
         reason: SessionStopReason,
         session_id: String,
     },
+    BatchCleanupReady {
+        session_id: String,
+        clean_text: String,
+        raw_text: String,
+        stage_results: Vec<StageOutcome>,
+    },
     Error {
         code: String,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -476,8 +492,14 @@ pub enum Event {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum IncomingFrame {
-    Audio(Vec<u8>),
+    Audio(AudioFrame),
     Command(Command),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AudioFrame {
+    pub frame_bytes: Vec<u8>,
+    pub session_id: String,
 }
 
 impl CommandEnvelope {
@@ -519,9 +541,49 @@ pub fn read_frame<R: Read>(reader: &mut R) -> Result<Option<IncomingFrame>> {
         JSON_FRAME_KIND => Ok(Some(IncomingFrame::Command(CommandEnvelope::parse_json(
             &payload,
         )?))),
-        AUDIO_FRAME_KIND => Ok(Some(IncomingFrame::Audio(payload))),
+        AUDIO_FRAME_KIND => Ok(Some(IncomingFrame::Audio(decode_audio_frame_envelope(
+            &payload,
+        )?))),
         _ => Err(anyhow!("unsupported frame kind {frame_kind}")),
     }
+}
+
+pub fn encode_audio_frame_envelope(session_id: &str, frame_bytes: &[u8]) -> Result<Vec<u8>> {
+    ensure!(
+        frame_bytes.len() == PCM_BYTES_PER_FRAME,
+        "audio frames must be {PCM_BYTES_PER_FRAME} bytes, received {}",
+        frame_bytes.len()
+    );
+    let uuid = Uuid::parse_str(session_id).context("session id must be a UUID string")?;
+    ensure!(
+        uuid.get_version_num() == 4,
+        "session id must be a UUID v4 string"
+    );
+
+    let mut envelope = Vec::with_capacity(SESSION_ID_BYTES + frame_bytes.len());
+    envelope.extend_from_slice(uuid.as_bytes());
+    envelope.extend_from_slice(frame_bytes);
+    Ok(envelope)
+}
+
+pub fn decode_audio_frame_envelope(payload: &[u8]) -> Result<AudioFrame> {
+    ensure!(
+        payload.len() == SESSION_ID_BYTES + PCM_BYTES_PER_FRAME,
+        "audio frame envelopes must be {} bytes, received {}",
+        SESSION_ID_BYTES + PCM_BYTES_PER_FRAME,
+        payload.len()
+    );
+    let session_id = Uuid::from_slice(&payload[..SESSION_ID_BYTES])
+        .context("audio frame session id bytes must be a UUID")?;
+    ensure!(
+        session_id.get_version_num() == 4,
+        "audio frame session id must be UUID v4"
+    );
+
+    Ok(AudioFrame {
+        frame_bytes: payload[SESSION_ID_BYTES..].to_vec(),
+        session_id: session_id.to_string(),
+    })
 }
 
 pub fn write_event_frame<W: Write>(writer: &mut W, event: &Event) -> Result<()> {
@@ -581,10 +643,11 @@ fn read_exact_or_eof<R: Read>(reader: &mut R, buffer: &mut [u8]) -> Result<usize
 #[cfg(test)]
 mod tests {
     use super::{
-        AUDIO_FRAME_KIND, AccelerationPreference, Command, Event, EventEnvelope,
+        AUDIO_FRAME_KIND, AccelerationPreference, AudioFrame, Command, Event, EventEnvelope,
         FRAME_HEADER_LENGTH, IncomingFrame, JSON_FRAME_KIND, ListeningMode, MAX_FRAME_PAYLOAD,
         PCM_BYTES_PER_FRAME, QueueBackpressureTier, SelectedModel, SessionStopReason,
-        SpeakingStyle, StageId, read_frame, write_event_frame, write_frame,
+        SpeakingStyle, StageId, encode_audio_frame_envelope, read_frame, write_event_frame,
+        write_frame,
     };
     use crate::engine::capabilities::{ModelFamilyId, RuntimeId};
     use uuid::Uuid;
@@ -743,14 +806,23 @@ mod tests {
     #[test]
     fn audio_frame_round_trip_preserves_payload() {
         let payload = vec![7_u8; PCM_BYTES_PER_FRAME];
+        let session_id = "123e4567-e89b-42d3-a456-426614174000";
+        let envelope =
+            encode_audio_frame_envelope(session_id, &payload).expect("envelope should encode");
         let mut framed = Vec::new();
-        write_frame(&mut framed, AUDIO_FRAME_KIND, &payload).expect("frame should write");
+        write_frame(&mut framed, AUDIO_FRAME_KIND, &envelope).expect("frame should write");
 
         let parsed = read_frame(&mut framed.as_slice())
             .expect("frame should parse")
             .expect("frame should exist");
 
-        assert_eq!(parsed, IncomingFrame::Audio(payload));
+        assert_eq!(
+            parsed,
+            IncomingFrame::Audio(AudioFrame {
+                frame_bytes: payload,
+                session_id: session_id.to_string(),
+            })
+        );
     }
 
     #[test]

--- a/native/src/stages/mod.rs
+++ b/native/src/stages/mod.rs
@@ -77,8 +77,12 @@ pub trait StageProcessor: Send + Sync {
 pub fn post_engine_processors() -> Vec<Box<dyn StageProcessor>> {
     vec![
         Box::new(hallucination_filter::HallucinationFilterStage),
-        Box::new(llm_postprocess::LlmPostprocessStage::new()),
+        llm_postprocess_processor(),
     ]
+}
+
+pub fn llm_postprocess_processor() -> Box<dyn StageProcessor> {
+    Box::new(llm_postprocess::LlmPostprocessStage::new())
 }
 
 pub fn run_post_engine(

--- a/native/src/worker.rs
+++ b/native/src/worker.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet};
 use std::panic::{self, AssertUnwindSafe};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -9,6 +10,7 @@ use tokio::runtime::{Builder, Runtime};
 use tokio::sync::watch;
 use uuid::Uuid;
 
+use crate::audio_metadata::VoiceActivityEvidence;
 use crate::engine::capabilities::{
     ModelFamilyCapabilities, ModelFamilyId, RequestWarning, RuntimeId,
 };
@@ -16,11 +18,13 @@ use crate::engine::registry::{EngineRegistry, apply_capability_gates, missing_ad
 use crate::engine::traits::LoadedModel;
 use crate::panic_util::format_panic_message;
 use crate::protocol::{
-    ContextWindow, EngineStagePayload, LlmPostprocessConfig, StageId, StageOutcome, StageStatus,
+    ContextWindow, ContextWindowSource, EngineStagePayload, LlmPostprocessConfig, StageId,
+    StageOutcome, StageStatus, TimestampGranularity, TimestampSource, TranscriptSegment,
 };
 use crate::session::FinalizedUtterance;
 use crate::stages::{
-    StageContext, StageEnablement, StageProcessor, post_engine_processors, run_post_engine,
+    StageContext, StageEnablement, StageProcessor, llm_postprocess_processor,
+    post_engine_processors, run_post_engine,
 };
 use crate::transcription::{
     EngineTranscriptOutput, GpuConfig, Transcript, TranscriptionError, TranscriptionRequest,
@@ -46,6 +50,12 @@ pub enum WorkerCommand {
     EndSession {
         session_id: String,
     },
+    RunBatchCleanup {
+        config: LlmPostprocessConfig,
+        note_context: Option<String>,
+        session_id: String,
+        transcript_text: String,
+    },
     Shutdown,
     TranscribeUtterance {
         context: Option<ContextWindow>,
@@ -57,6 +67,12 @@ pub enum WorkerCommand {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum WorkerEvent {
+    BatchCleanupReady {
+        clean_text: String,
+        raw_text: String,
+        session_id: String,
+        stage_results: Vec<StageOutcome>,
+    },
     SessionError {
         code: String,
         details: Option<String>,
@@ -109,7 +125,7 @@ impl TranscriptionWorker {
     }
 }
 
-struct ActiveSession {
+struct WorkerSession {
     metadata: SessionMetadata,
     loaded_model: Box<dyn LoadedModel>,
     processors: Vec<Box<dyn StageProcessor>>,
@@ -130,7 +146,8 @@ fn worker_main(
     event_tx: Sender<WorkerEvent>,
     registry: Arc<EngineRegistry>,
 ) {
-    let mut active: Option<ActiveSession> = None;
+    let mut sessions: HashMap<String, WorkerSession> = HashMap::new();
+    let mut ended_sessions: HashSet<String> = HashSet::new();
     let tokio_runtime = Builder::new_current_thread()
         .enable_all()
         .build()
@@ -139,17 +156,21 @@ fn worker_main(
     while let Ok(command) = command_rx.recv() {
         match command {
             WorkerCommand::BeginSession(metadata) => {
+                ended_sessions.remove(&metadata.session_id);
                 let load_result = panic::catch_unwind(AssertUnwindSafe(|| {
                     load_model_for_session(registry.as_ref(), &metadata)
                 }));
 
                 match load_result {
                     Ok(Ok(loaded_model)) => {
-                        active = Some(ActiveSession {
-                            metadata,
-                            loaded_model,
-                            processors: post_engine_processors(),
-                        });
+                        sessions.insert(
+                            metadata.session_id.clone(),
+                            WorkerSession {
+                                metadata,
+                                loaded_model,
+                                processors: post_engine_processors(),
+                            },
+                        );
                     }
                     Ok(Err(error)) => {
                         let _ = event_tx.send(WorkerEvent::SessionError {
@@ -159,7 +180,6 @@ fn worker_main(
                             session_id: metadata.session_id,
                             utterance_id: None,
                         });
-                        active = None;
                     }
                     Err(payload) => {
                         let message = format_panic_message(
@@ -173,17 +193,46 @@ fn worker_main(
                             session_id: metadata.session_id,
                             utterance_id: None,
                         });
-                        active = None;
                     }
                 }
             }
             WorkerCommand::EndSession { session_id } => {
-                if active
-                    .as_ref()
-                    .map(|session| session.metadata.session_id == session_id)
-                    .unwrap_or(false)
-                {
-                    active = None;
+                ended_sessions.insert(session_id.clone());
+                sessions.remove(&session_id);
+            }
+            WorkerCommand::RunBatchCleanup {
+                config,
+                note_context,
+                session_id,
+                transcript_text,
+            } => {
+                let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                    run_batch_cleanup(
+                        &tokio_runtime,
+                        session_id.clone(),
+                        transcript_text,
+                        config,
+                        note_context,
+                    )
+                }));
+
+                match result {
+                    Ok(event) => {
+                        let _ = event_tx.send(event);
+                    }
+                    Err(payload) => {
+                        let message = format_panic_message(
+                            payload.as_ref(),
+                            "Worker thread panicked during batch cleanup",
+                        );
+                        let _ = event_tx.send(WorkerEvent::SessionError {
+                            code: "worker_panic".to_string(),
+                            details: None,
+                            message,
+                            session_id,
+                            utterance_id: None,
+                        });
+                    }
                 }
             }
             WorkerCommand::Shutdown => break,
@@ -193,13 +242,13 @@ fn worker_main(
                 utterance,
                 utterance_id,
             } => {
-                let Some(session) = active.as_mut() else {
-                    continue;
-                };
-
-                if session.metadata.session_id != session_id {
+                if ended_sessions.contains(&session_id) {
                     continue;
                 }
+
+                let Some(session) = sessions.get_mut(&session_id) else {
+                    continue;
+                };
 
                 let utterance_duration_ms = utterance.duration_ms();
                 let utterance_end_ms_in_session = utterance.utterance_end_ms_in_session();
@@ -362,6 +411,92 @@ fn assemble_transcript(input: TranscriptAssembly<'_>) -> Transcript {
     run_post_engine(&mut transcript, input.processors, &ctx);
 
     transcript
+}
+
+fn run_batch_cleanup(
+    tokio_runtime: &Runtime,
+    session_id: String,
+    transcript_text: String,
+    config: LlmPostprocessConfig,
+    note_context: Option<String>,
+) -> WorkerEvent {
+    let trimmed_input = transcript_text.trim().to_string();
+    let utterance_duration_ms = 1_000;
+    let context = note_context
+        .filter(|text| !text.trim().is_empty())
+        .map(|text| ContextWindow {
+            budget_chars: text.chars().count().min(u32::MAX as usize) as u32,
+            sources: vec![ContextWindowSource::NoteText {
+                text: text.clone(),
+                truncated: false,
+            }],
+            text,
+            truncated: false,
+        });
+    let voice_activity = VoiceActivityEvidence {
+        audio_start_ms: 0,
+        audio_end_ms: utterance_duration_ms,
+        speech_start_ms: 0,
+        speech_end_ms: utterance_duration_ms,
+        voiced_ms: utterance_duration_ms,
+        unvoiced_ms: 0,
+        mean_probability: 1.0,
+        max_probability: 1.0,
+    };
+    let (_cancel_tx, cancel_rx) = watch::channel(false);
+    let processors = vec![llm_postprocess_processor()];
+    let mut transcript = Transcript {
+        revision: 0,
+        segments: vec![TranscriptSegment {
+            end_ms: utterance_duration_ms,
+            start_ms: 0,
+            text: trimmed_input.clone(),
+            timestamp_granularity: TimestampGranularity::Utterance,
+            timestamp_source: TimestampSource::None,
+        }],
+        stage_history: Vec::new(),
+        utterance_id: Uuid::new_v4(),
+    };
+    let family_capabilities = ModelFamilyCapabilities::unknown();
+    let stage_enablement = StageEnablement::default();
+    let ctx = StageContext {
+        cancel_rx: &cancel_rx,
+        context: context.as_ref(),
+        family_capabilities: &family_capabilities,
+        is_final: true,
+        llm_postprocess: Some(&config),
+        pause_ms_before_utterance: None,
+        segment_diagnostics: &[],
+        stage_enabled: &stage_enablement,
+        tokio_runtime,
+        vad_probabilities: &[],
+        voice_activity: &voice_activity,
+    };
+
+    run_post_engine(&mut transcript, &processors, &ctx);
+
+    let last_stage = transcript.stage_history.last();
+    if !matches!(last_stage.map(|stage| &stage.status), Some(StageStatus::Ok)) {
+        let error = match last_stage.map(|stage| &stage.status) {
+            Some(StageStatus::Failed { error }) => error.clone(),
+            Some(StageStatus::Skipped { reason }) => format!("batch cleanup skipped: {reason}"),
+            Some(StageStatus::Ok) | None => "batch cleanup did not produce a result".to_string(),
+        };
+        return WorkerEvent::SessionError {
+            code: "batch_cleanup_failed".to_string(),
+            details: Some(error.clone()),
+            message: "Batch LLM cleanup failed; raw transcript was kept.".to_string(),
+            session_id,
+            utterance_id: None,
+        };
+    }
+
+    WorkerEvent::BatchCleanupReady {
+        clean_text: transcript.joined_text(),
+        raw_text: trimmed_input,
+        session_id,
+        stage_results: transcript.stage_history,
+    }
 }
 
 #[cfg(test)]

--- a/native/src/worker.rs
+++ b/native/src/worker.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::panic::{self, AssertUnwindSafe};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -147,7 +147,6 @@ fn worker_main(
     registry: Arc<EngineRegistry>,
 ) {
     let mut sessions: HashMap<String, WorkerSession> = HashMap::new();
-    let mut ended_sessions: HashSet<String> = HashSet::new();
     let tokio_runtime = Builder::new_current_thread()
         .enable_all()
         .build()
@@ -156,7 +155,6 @@ fn worker_main(
     while let Ok(command) = command_rx.recv() {
         match command {
             WorkerCommand::BeginSession(metadata) => {
-                ended_sessions.remove(&metadata.session_id);
                 let load_result = panic::catch_unwind(AssertUnwindSafe(|| {
                     load_model_for_session(registry.as_ref(), &metadata)
                 }));
@@ -197,7 +195,6 @@ fn worker_main(
                 }
             }
             WorkerCommand::EndSession { session_id } => {
-                ended_sessions.insert(session_id.clone());
                 sessions.remove(&session_id);
             }
             WorkerCommand::RunBatchCleanup {
@@ -242,10 +239,6 @@ fn worker_main(
                 utterance,
                 utterance_id,
             } => {
-                if ended_sessions.contains(&session_id) {
-                    continue;
-                }
-
                 let Some(session) = sessions.get_mut(&session_id) else {
                     continue;
                 };

--- a/scripts/install-dev-plugin.mjs
+++ b/scripts/install-dev-plugin.mjs
@@ -63,7 +63,10 @@ async function installSidecarVariant(options) {
   const executablePath = join(options.sourceDirectory, SIDECAR_EXECUTABLE);
 
   if (!(await fileExists(executablePath))) {
-    if (options.optional) return;
+    if (options.optional) {
+      await rm(options.destination, { force: true, recursive: true });
+      return;
+    }
     throw new Error(
       `Missing ${options.variant} sidecar at ${executablePath}. Build it before using --sidecars.`,
     );

--- a/src/audio/audio-capture-stream.ts
+++ b/src/audio/audio-capture-stream.ts
@@ -4,7 +4,7 @@ import type { PluginLogger } from '../shared/plugin-logger';
 import { PCM_RECORDER_WORKLET_NAME } from './pcm-recorder-worklet-shared';
 import { PCM_RECORDER_WORKLET_SOURCE } from './pcm-recorder-worklet-source';
 
-type AudioFrameListener = (frameBytes: Uint8Array) => void;
+type AudioFrameListener = (sessionId: string, frameBytes: Uint8Array) => void;
 
 interface AudioCaptureStreamOptions {
   logger?: PluginLogger;
@@ -24,7 +24,7 @@ export class AudioCaptureStream {
     return this.mediaStream !== null;
   }
 
-  async start(frameListener: AudioFrameListener): Promise<void> {
+  async start(sessionId: string, frameListener: AudioFrameListener): Promise<void> {
     if (this.isCapturing()) {
       throw new Error('Audio capture is already active.');
     }
@@ -75,7 +75,7 @@ export class AudioCaptureStream {
           return;
         }
 
-        this.frameListener?.(frameBytes);
+        this.frameListener?.(sessionId, frameBytes);
       };
 
       sourceNode.connect(recorderNode);

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -21,7 +21,7 @@ import type {
   SidecarEvent,
   TranscriptReadyEvent,
 } from '../sidecar/protocol';
-import type { SidecarConnection } from '../sidecar/sidecar-connection';
+import { type SidecarConnection, SidecarError } from '../sidecar/sidecar-connection';
 import { SidecarNotInstalledError } from '../sidecar/sidecar-paths';
 import type { TranscriptRenderOptions } from '../transcript/renderer';
 
@@ -67,14 +67,14 @@ interface ActiveSessionSnapshot {
   useNoteAsContext: PluginSettings['useNoteAsContext'];
 }
 
+type SessionPhase = 'starting' | 'active' | 'stopping' | 'cancelling' | 'stopped';
+
 interface ManagedSession {
   anchorTimerId: ReturnType<typeof setTimeout> | null;
-  draining: boolean;
   llmFailureLogged: boolean;
-  pendingStart: boolean;
+  phase: SessionPhase;
   session: ControllerSession;
   snapshot: ActiveSessionSnapshot;
-  startCancelled: boolean;
 }
 
 interface DictationSessionControllerDependencies {
@@ -213,10 +213,10 @@ export class DictationSessionController {
       session = this.dependencies.createSession({
         callbacks: {
           onLockedNoteClosed: () => {
-            this.handleLockedNoteClosed(sessionId);
+            this.cancelOnLockedNoteEvent(sessionId, 'closed');
           },
           onLockedNoteDeleted: () => {
-            this.handleLockedNoteDeleted(sessionId);
+            this.cancelOnLockedNoteEvent(sessionId, 'deleted');
           },
         },
         placement: { anchor: snapshot.dictationAnchor },
@@ -233,12 +233,10 @@ export class DictationSessionController {
 
     const entry: ManagedSession = {
       anchorTimerId: null,
-      draining: false,
       llmFailureLogged: false,
-      pendingStart: true,
+      phase: 'starting',
       session,
       snapshot,
-      startCancelled: false,
     };
     this.sessions.set(sessionId, entry);
     this.activeSessionId = sessionId;
@@ -258,11 +256,11 @@ export class DictationSessionController {
           ? { modelStorePathOverride: snapshot.modelStorePathOverride }
           : {}),
       });
-      entry.pendingStart = false;
 
-      if (entry.startCancelled || this.activeSessionId !== sessionId) {
+      if (entry.phase !== 'starting' || this.activeSessionId !== sessionId) {
         return;
       }
+      entry.phase = 'active';
 
       await this.dependencies.captureStream.start(sessionId, (frameSessionId, frameBytes) => {
         if (this.activeSessionId !== frameSessionId) {
@@ -270,7 +268,7 @@ export class DictationSessionController {
         }
 
         const activeEntry = this.sessions.get(frameSessionId);
-        if (activeEntry === undefined || activeEntry.draining || activeEntry.startCancelled) {
+        if (activeEntry === undefined || activeEntry.phase !== 'active') {
           return;
         }
 
@@ -305,20 +303,13 @@ export class DictationSessionController {
     }
 
     const entry = this.sessions.get(sessionId);
-    this.activeSessionId = null;
-    this.applyUiState('idle');
-    this.resetQueueTier();
-
     if (entry !== undefined) {
-      entry.draining = true;
-      entry.startCancelled = true;
+      entry.phase = 'stopping';
       this.clearAnchorTimer(entry);
       entry.session.setAnchorMode('hidden');
     }
 
-    if (this.dependencies.captureStream.isCapturing()) {
-      await this.dependencies.captureStream.stop();
-    }
+    await this.clearActiveSession(sessionId);
 
     try {
       this.dependencies.sidecarConnection.requestStopSession(sessionId);
@@ -329,15 +320,6 @@ export class DictationSessionController {
   }
 
   private async cleanupFailedStart(sessionId: string, error: unknown): Promise<void> {
-    if (error instanceof SidecarNotInstalledError) {
-      this.dependencies.logger?.debug('sidecar', 'sidecar not installed; prompting install');
-      this.disposeLocalSession(sessionId);
-      this.activeSessionId = null;
-      this.applyUiState('idle');
-      this.dependencies.onSidecarMissing?.();
-      return;
-    }
-
     const entry = this.sessions.get(sessionId);
     if (entry === undefined) {
       if (this.activeSessionId === sessionId) {
@@ -350,19 +332,11 @@ export class DictationSessionController {
     if (isCapacityExceededStartError(error)) {
       this.dependencies.logger?.warn('sidecar', formatErrorMessage(error));
       this.disposeLocalSession(sessionId);
-      if (this.activeSessionId === sessionId) {
-        this.activeSessionId = null;
-        this.applyUiState('idle');
-      }
       return;
     }
 
-    if (entry.pendingStart) {
+    if (entry.phase === 'starting') {
       this.disposeLocalSession(sessionId);
-      if (this.activeSessionId === sessionId) {
-        this.activeSessionId = null;
-        this.applyUiState('idle');
-      }
     } else {
       await this.cancelSession(sessionId);
     }
@@ -372,23 +346,28 @@ export class DictationSessionController {
   private async cancelSession(sessionId: string): Promise<void> {
     const entry = this.sessions.get(sessionId);
     if (entry !== undefined) {
-      entry.startCancelled = true;
+      entry.phase = 'cancelling';
     }
 
-    if (this.activeSessionId === sessionId) {
-      this.activeSessionId = null;
-      this.applyUiState('idle');
-      this.resetQueueTier();
-      if (this.dependencies.captureStream.isCapturing()) {
-        await this.dependencies.captureStream.stop();
-      }
-    }
+    await this.clearActiveSession(sessionId);
 
     try {
       await this.dependencies.sidecarConnection.cancelSession(sessionId);
     } catch (error) {
       this.dependencies.logger?.warn('session', 'failed to cancel dictation cleanly', error);
       this.disposeLocalSession(sessionId);
+    }
+  }
+
+  private async clearActiveSession(sessionId: string): Promise<void> {
+    if (this.activeSessionId !== sessionId) {
+      return;
+    }
+    this.activeSessionId = null;
+    this.applyUiState('idle');
+    this.resetQueueTier();
+    if (this.dependencies.captureStream.isCapturing()) {
+      await this.dependencies.captureStream.stop();
     }
   }
 
@@ -503,7 +482,7 @@ export class DictationSessionController {
 
     if (
       event.sessionId !== this.activeSessionId ||
-      entry.pendingStart ||
+      entry.phase !== 'active' ||
       !this.dependencies.captureStream.isCapturing()
     ) {
       return;
@@ -667,8 +646,7 @@ export class DictationSessionController {
       'session',
       `session ${event.sessionId} stopped (reason: ${event.reason})`,
     );
-    entry.draining = false;
-    entry.pendingStart = false;
+    entry.phase = 'stopped';
 
     if (event.sessionId === this.activeSessionId) {
       this.activeSessionId = null;
@@ -754,7 +732,7 @@ export class DictationSessionController {
   private async handleErrorEvent(event: Extract<SidecarEvent, { type: 'error' }>): Promise<void> {
     if (event.code === 'session_capacity_exceeded' && event.sessionId !== undefined) {
       this.dependencies.logger?.warn('sidecar', event.message, event.details);
-      await this.stopCaptureIfActive(event.sessionId);
+      await this.clearActiveSession(event.sessionId);
       this.disposeLocalSession(event.sessionId);
       return;
     }
@@ -794,20 +772,6 @@ export class DictationSessionController {
     await this.cancelSession(event.sessionId);
   }
 
-  private async stopCaptureIfActive(sessionId: string): Promise<void> {
-    if (this.activeSessionId !== sessionId) {
-      return;
-    }
-
-    this.activeSessionId = null;
-    this.applyUiState('idle');
-    this.resetQueueTier();
-
-    if (this.dependencies.captureStream.isCapturing()) {
-      await this.dependencies.captureStream.stop();
-    }
-  }
-
   private maybeLogLlmStageFailure(entry: ManagedSession, event: TranscriptReadyEvent): void {
     if (entry.llmFailureLogged) {
       return;
@@ -841,23 +805,12 @@ export class DictationSessionController {
     }
   }
 
-  private handleLockedNoteClosed(sessionId: string): void {
-    const entry = this.sessions.get(sessionId);
-    if (entry === undefined) {
+  private cancelOnLockedNoteEvent(sessionId: string, reason: 'closed' | 'deleted'): void {
+    if (!this.sessions.has(sessionId)) {
       return;
     }
 
-    this.dependencies.logger?.warn('session', `locked note closed for session ${sessionId}`);
-    void this.cancelSession(sessionId);
-  }
-
-  private handleLockedNoteDeleted(sessionId: string): void {
-    const entry = this.sessions.get(sessionId);
-    if (entry === undefined) {
-      return;
-    }
-
-    this.dependencies.logger?.warn('session', `locked note deleted for session ${sessionId}`);
+    this.dependencies.logger?.warn('session', `locked note ${reason} for session ${sessionId}`);
     void this.cancelSession(sessionId);
   }
 
@@ -873,7 +826,7 @@ function createSessionId(): string {
 }
 
 function isCapacityExceededStartError(error: unknown): boolean {
-  return /maximum number of active sessions|capacity/i.test(formatErrorMessage(error));
+  return error instanceof SidecarError && error.code === 'session_capacity_exceeded';
 }
 
 function createSessionSnapshot(

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -2,9 +2,8 @@ import { randomUUID } from 'node:crypto';
 
 import type { AudioCaptureStream } from '../audio/audio-capture-stream';
 import type { NotePlacementOptions } from '../editor/note-surface';
-import { OLLAMA_KEEP_ALIVE, type OllamaClient } from '../llm/ollama-client';
+import { OLLAMA_KEEP_ALIVE } from '../llm/ollama-client';
 import { type LlmPostprocessMode, resolveStyleOption } from '../llm/presets';
-import { formatBatchUserMessage } from '../llm/templates';
 import type { Session } from '../session/session';
 import type { StageId } from '../session/session-journal';
 import type { PluginSettings } from '../settings/plugin-settings';
@@ -12,6 +11,7 @@ import { formatErrorMessage } from '../shared/format-utils';
 import type { PluginLogger } from '../shared/plugin-logger';
 import { truncateLeadingText } from '../shared/text-truncation';
 import type {
+  BatchCleanupReadyEvent,
   ContextRequestEvent,
   ContextWindow,
   ContextWindowSource,
@@ -30,8 +30,6 @@ export type DictationControllerState =
   | 'starting'
   | 'listening'
   | 'speech_detected'
-  | 'speech_ending'
-  | 'transcribing'
   | 'error';
 
 type ControllerSession = Pick<
@@ -69,6 +67,16 @@ interface ActiveSessionSnapshot {
   useNoteAsContext: PluginSettings['useNoteAsContext'];
 }
 
+interface ManagedSession {
+  anchorTimerId: ReturnType<typeof setTimeout> | null;
+  draining: boolean;
+  llmFailureLogged: boolean;
+  pendingStart: boolean;
+  session: ControllerSession;
+  snapshot: ActiveSessionSnapshot;
+  startCancelled: boolean;
+}
+
 interface DictationSessionControllerDependencies {
   captureStream: Pick<AudioCaptureStream, 'isCapturing' | 'start' | 'stop'>;
   createSession: (options: {
@@ -83,7 +91,6 @@ interface DictationSessionControllerDependencies {
   getSettings: () => PluginSettings;
   logger?: PluginLogger;
   notice: (message: string) => void;
-  ollamaClient: Pick<OllamaClient, 'cleanup'>;
   onModelMissing?: () => void;
   onSidecarMissing?: () => void;
   setRibbonQueueTier: (tier: QueueBackpressureTier) => void;
@@ -92,27 +99,22 @@ interface DictationSessionControllerDependencies {
     SidecarConnection,
     | 'cancelSession'
     | 'ensureStarted'
+    | 'requestBatchCleanup'
+    | 'requestStopSession'
     | 'sendAudioFrame'
     | 'sendContextResponse'
     | 'startSession'
-    | 'stopSession'
     | 'subscribe'
   >;
 }
 
 const ANCHOR_VISIBLE_DELAY_MS = 2500;
+const MAX_CONTROLLER_SESSIONS = 5;
 
 export class DictationSessionController {
-  private abortingSessionId: string | null = null;
-  private anchorTimerId: ReturnType<typeof setTimeout> | null = null;
-  private batchCleanupAbortController: AbortController | null = null;
-  private llmFailureLoggedForSessionId: string | null = null;
-  private pendingStartSessionId: string | null = null;
-  private queueTier: QueueBackpressureTier = 'normal';
+  private activeSessionId: string | null = null;
   private readonly releaseSidecarSubscription: () => void;
-  private session: ControllerSession | null = null;
-  private sessionId: string | null = null;
-  private sessionSnapshot: ActiveSessionSnapshot | null = null;
+  private readonly sessions = new Map<string, ManagedSession>();
   private state: DictationControllerState = 'idle';
 
   constructor(private readonly dependencies: DictationSessionControllerDependencies) {
@@ -127,59 +129,48 @@ export class DictationSessionController {
   }
 
   isBusy(): boolean {
-    return this.sessionId !== null || this.state === 'starting' || this.abortingSessionId !== null;
+    return this.activeSessionId !== null || this.sessions.size > 0 || this.state === 'starting';
   }
 
   async cancelDictation(): Promise<void> {
-    if (this.sessionId === null) {
-      if (this.batchCleanupAbortController !== null) {
-        this.abortBatchCleanup();
-        return;
-      }
+    const sessionId = this.activeSessionId ?? this.latestSessionId();
 
+    if (sessionId === null) {
       this.dependencies.notice('Dictation is not currently active.');
       return;
     }
 
-    try {
-      await this.dependencies.sidecarConnection.cancelSession(this.sessionId);
-    } catch (error) {
-      await this.cleanupLocalSession();
-      this.handleError('Failed to cancel the dictation session', error);
-    }
+    await this.cancelSession(sessionId);
   }
 
   async dispose(): Promise<void> {
-    this.abortBatchCleanup();
-    const activeSessionId = this.sessionId;
-    if (activeSessionId !== null) {
-      try {
-        await this.dependencies.sidecarConnection.stopSession(activeSessionId, 500);
-      } catch (error) {
-        this.dependencies.logger?.warn(
-          'session',
-          'timed out stopping dictation during unload',
-          error,
-        );
-      }
+    if (this.dependencies.captureStream.isCapturing()) {
+      await this.dependencies.captureStream.stop();
     }
+
+    const sessionIds = [...this.sessions.keys()];
+    await Promise.allSettled(sessionIds.map((sessionId) => this.cancelSession(sessionId)));
     this.releaseSidecarSubscription();
-    await this.cleanupLocalSession();
+    for (const sessionId of [...this.sessions.keys()]) {
+      this.disposeLocalSession(sessionId);
+    }
+    this.activeSessionId = null;
+    this.resetQueueTier();
     this.applyUiState('idle');
   }
 
   async toggleDictation(): Promise<void> {
-    if (this.state === 'error' && this.sessionId === null) {
+    if (this.state === 'error' && this.activeSessionId === null) {
       this.applyUiState('idle');
       return;
     }
 
-    if (this.state === 'starting' || this.abortingSessionId !== null) {
+    if (this.activeSessionId !== null) {
+      await this.stopDictation();
       return;
     }
 
-    if (this.sessionId !== null) {
-      await this.stopDictation();
+    if (this.sessions.size >= MAX_CONTROLLER_SESSIONS) {
       return;
     }
 
@@ -187,20 +178,17 @@ export class DictationSessionController {
   }
 
   async startDictation(): Promise<void> {
-    if (this.sessionId !== null) {
-      this.dependencies.notice('Dictation is already active.');
+    if (this.activeSessionId !== null || this.sessions.size >= MAX_CONTROLLER_SESSIONS) {
       return;
     }
 
-    this.abortBatchCleanup();
-    // Synchronous so the ribbon flips before any await and toggleDictation's state gate works.
     this.applyUiState('starting');
 
     try {
       await this.dependencies.sidecarConnection.ensureStarted();
     } catch (error) {
       if (error instanceof SidecarNotInstalledError) {
-        this.dependencies.logger?.debug('sidecar', 'sidecar not installed — prompting install');
+        this.dependencies.logger?.debug('sidecar', 'sidecar not installed; prompting install');
         this.applyUiState('idle');
         this.dependencies.onSidecarMissing?.();
         return;
@@ -211,45 +199,14 @@ export class DictationSessionController {
 
     const settings = this.dependencies.getSettings();
     if (settings.selectedModel === null) {
-      this.dependencies.logger?.debug('session', 'no model selected — prompting model picker');
+      this.dependencies.logger?.debug('session', 'no model selected; prompting model picker');
       this.applyUiState('idle');
       this.dependencies.onModelMissing?.();
       return;
     }
-    const selectedModel = settings.selectedModel;
-    const effectiveGeneration = resolveActiveGenerationDefaults(settings);
-    const sessionStartUnixMs = Date.now();
-    const noteContextChars = settings.useLlmNoteContext
-      ? settings.llmPostprocessNoteContextChars
-      : 0;
-    const snapshot: ActiveSessionSnapshot = {
-      accelerationPreference: settings.accelerationPreference,
-      dictationAnchor: settings.dictationAnchor,
-      listeningMode: settings.listeningMode,
-      llmFeaturesEnabled: settings.llmFeaturesEnabled,
-      llmPostprocess: resolveLlmPostprocessSnapshot(settings, noteContextChars),
-      llmPostprocessMode: settings.llmPostprocessMode,
-      llmPostprocessModel: settings.llmPostprocessModel,
-      llmPostprocessNoteContextChars: noteContextChars,
-      llmPostprocessPrompt: settings.llmPostprocessPrompt,
-      llmPostprocessShowRawBelow: settings.llmPostprocessShowRawBelow,
-      llmPostprocessTemperature: effectiveGeneration.temperature,
-      modelSelection: selectedModel,
-      modelStorePathOverride: settings.modelStorePathOverride,
-      sessionStartUnixMs,
-      speakingStyle: settings.speakingStyle,
-      timestamps: {
-        clock: settings.timestampClock,
-        density: settings.timestampDensity,
-        enabled: settings.timestampsEnabled,
-        header: settings.timestampSessionHeader,
-        sessionStartUnixMs,
-        sparseIntervalMs: settings.timestampSparseIntervalMs,
-      },
-      transcriptFormatting: settings.transcriptFormatting,
-      useNoteAsContext: settings.useNoteAsContext,
-    };
+
     const sessionId = createSessionId();
+    const snapshot = createSessionSnapshot(settings, settings.selectedModel);
     let session: ControllerSession;
 
     try {
@@ -262,9 +219,7 @@ export class DictationSessionController {
             this.handleLockedNoteDeleted(sessionId);
           },
         },
-        placement: {
-          anchor: snapshot.dictationAnchor,
-        },
+        placement: { anchor: snapshot.dictationAnchor },
         rendererOptions: {
           timestamps: snapshot.timestamps,
           transcriptFormatting: snapshot.transcriptFormatting,
@@ -276,80 +231,164 @@ export class DictationSessionController {
       return;
     }
 
-    this.sessionId = sessionId;
-    this.session = session;
-    this.sessionSnapshot = snapshot;
+    const entry: ManagedSession = {
+      anchorTimerId: null,
+      draining: false,
+      llmFailureLogged: false,
+      pendingStart: true,
+      session,
+      snapshot,
+      startCancelled: false,
+    };
+    this.sessions.set(sessionId, entry);
+    this.activeSessionId = sessionId;
     this.dependencies.logger?.debug('session', `starting dictation session ${sessionId}`);
 
-    let frameForwardAborted = false;
-
     try {
-      await this.dependencies.captureStream.start((frameBytes) => {
-        if (frameForwardAborted || this.sessionId !== sessionId) {
+      await this.dependencies.sidecarConnection.startSession({
+        accelerationPreference: snapshot.accelerationPreference,
+        language: 'en',
+        ...(snapshot.llmPostprocess !== null ? { llmPostprocess: snapshot.llmPostprocess } : {}),
+        mode: snapshot.listeningMode,
+        modelSelection: snapshot.modelSelection,
+        sessionStartUnixMs: snapshot.sessionStartUnixMs,
+        sessionId,
+        speakingStyle: snapshot.speakingStyle,
+        ...(snapshot.modelStorePathOverride.length > 0
+          ? { modelStorePathOverride: snapshot.modelStorePathOverride }
+          : {}),
+      });
+      entry.pendingStart = false;
+
+      if (entry.startCancelled || this.activeSessionId !== sessionId) {
+        return;
+      }
+
+      await this.dependencies.captureStream.start(sessionId, (frameSessionId, frameBytes) => {
+        if (this.activeSessionId !== frameSessionId) {
+          return;
+        }
+
+        const activeEntry = this.sessions.get(frameSessionId);
+        if (activeEntry === undefined || activeEntry.draining || activeEntry.startCancelled) {
           return;
         }
 
         try {
-          this.dependencies.sidecarConnection.sendAudioFrame(frameBytes);
+          this.dependencies.sidecarConnection.sendAudioFrame(frameSessionId, frameBytes);
         } catch (error) {
-          frameForwardAborted = true;
           this.dependencies.logger?.warn(
             'session',
             'stopping audio capture: sidecar rejected an audio frame',
             error,
           );
-          void this.dependencies.captureStream.stop();
+          void this.cancelSession(frameSessionId);
         }
       });
-      this.pendingStartSessionId = sessionId;
-      try {
-        await this.dependencies.sidecarConnection.startSession({
-          accelerationPreference: snapshot.accelerationPreference,
-          language: 'en',
-          ...(snapshot.llmPostprocess !== null ? { llmPostprocess: snapshot.llmPostprocess } : {}),
-          mode: snapshot.listeningMode,
-          modelSelection: snapshot.modelSelection,
-          sessionStartUnixMs: snapshot.sessionStartUnixMs,
-          sessionId,
-          speakingStyle: snapshot.speakingStyle,
-          ...(snapshot.modelStorePathOverride.length > 0
-            ? { modelStorePathOverride: snapshot.modelStorePathOverride }
-            : {}),
-        });
-      } finally {
-        if (this.pendingStartSessionId === sessionId) {
-          this.pendingStartSessionId = null;
-        }
+
+      if (this.activeSessionId === sessionId) {
+        this.applyUiState('listening');
+      } else if (this.dependencies.captureStream.isCapturing()) {
+        await this.dependencies.captureStream.stop();
       }
     } catch (error) {
-      await this.cleanupLocalSession();
-      if (error instanceof SidecarNotInstalledError) {
-        this.dependencies.logger?.debug('sidecar', 'sidecar not installed — prompting install');
-        this.applyUiState('idle');
-        this.dependencies.onSidecarMissing?.();
-        return;
-      }
-      this.handleError('Failed to start the dictation session', error);
+      await this.cleanupFailedStart(sessionId, error);
     }
   }
 
   async stopDictation(): Promise<void> {
-    if (this.sessionId === null) {
+    const sessionId = this.activeSessionId;
+
+    if (sessionId === null) {
       this.dependencies.notice('Dictation is not currently active.');
       return;
     }
 
-    // Stop capture immediately so the mic turns off, but keep sessionId alive
-    // so transcript_ready events are still accepted while the sidecar drains.
+    const entry = this.sessions.get(sessionId);
+    this.activeSessionId = null;
+    this.applyUiState('idle');
+    this.resetQueueTier();
+
+    if (entry !== undefined) {
+      entry.draining = true;
+      entry.startCancelled = true;
+      this.clearAnchorTimer(entry);
+      entry.session.setAnchorMode('hidden');
+    }
+
     if (this.dependencies.captureStream.isCapturing()) {
       await this.dependencies.captureStream.stop();
     }
 
     try {
-      await this.dependencies.sidecarConnection.stopSession(this.sessionId);
+      this.dependencies.sidecarConnection.requestStopSession(sessionId);
     } catch (error) {
-      await this.cleanupLocalSession();
+      this.disposeLocalSession(sessionId);
       this.handleError('Failed to stop the dictation session', error);
+    }
+  }
+
+  private async cleanupFailedStart(sessionId: string, error: unknown): Promise<void> {
+    if (error instanceof SidecarNotInstalledError) {
+      this.dependencies.logger?.debug('sidecar', 'sidecar not installed; prompting install');
+      this.disposeLocalSession(sessionId);
+      this.activeSessionId = null;
+      this.applyUiState('idle');
+      this.dependencies.onSidecarMissing?.();
+      return;
+    }
+
+    const entry = this.sessions.get(sessionId);
+    if (entry === undefined) {
+      if (this.activeSessionId === sessionId) {
+        this.activeSessionId = null;
+        this.applyUiState('idle');
+      }
+      return;
+    }
+
+    if (isCapacityExceededStartError(error)) {
+      this.dependencies.logger?.warn('sidecar', formatErrorMessage(error));
+      this.disposeLocalSession(sessionId);
+      if (this.activeSessionId === sessionId) {
+        this.activeSessionId = null;
+        this.applyUiState('idle');
+      }
+      return;
+    }
+
+    if (entry.pendingStart) {
+      this.disposeLocalSession(sessionId);
+      if (this.activeSessionId === sessionId) {
+        this.activeSessionId = null;
+        this.applyUiState('idle');
+      }
+    } else {
+      await this.cancelSession(sessionId);
+    }
+    this.handleError('Failed to start the dictation session', error);
+  }
+
+  private async cancelSession(sessionId: string): Promise<void> {
+    const entry = this.sessions.get(sessionId);
+    if (entry !== undefined) {
+      entry.startCancelled = true;
+    }
+
+    if (this.activeSessionId === sessionId) {
+      this.activeSessionId = null;
+      this.applyUiState('idle');
+      this.resetQueueTier();
+      if (this.dependencies.captureStream.isCapturing()) {
+        await this.dependencies.captureStream.stop();
+      }
+    }
+
+    try {
+      await this.dependencies.sidecarConnection.cancelSession(sessionId);
+    } catch (error) {
+      this.dependencies.logger?.warn('session', 'failed to cancel dictation cleanly', error);
+      this.disposeLocalSession(sessionId);
     }
   }
 
@@ -358,191 +397,55 @@ export class DictationSessionController {
     this.dependencies.setRibbonState(state);
   }
 
-  private async detachSession(): Promise<ControllerSession | null> {
-    this.abortingSessionId = null;
-    this.pendingStartSessionId = null;
-    this.sessionId = null;
-    this.sessionSnapshot = null;
-    this.llmFailureLoggedForSessionId = null;
-    const session = this.session;
-    this.session = null;
-    this.clearAnchorTimer();
-    this.resetQueueTier();
-
-    if (this.dependencies.captureStream.isCapturing()) {
-      await this.dependencies.captureStream.stop();
-    }
-
-    return session;
+  private latestSessionId(): string | null {
+    return [...this.sessions.keys()].at(-1) ?? null;
   }
 
-  private async cleanupLocalSession(): Promise<void> {
-    const session = await this.detachSession();
-    session?.dispose();
-  }
-
-  private applySessionStateToAnchor(state: SessionState): void {
-    if (!isAnchorVisibleSessionState(state)) {
-      this.clearAnchorTimer();
-      this.session?.setAnchorMode('hidden');
+  private disposeLocalSession(sessionId: string): void {
+    const entry = this.sessions.get(sessionId);
+    if (entry === undefined) {
       return;
     }
 
-    if (this.anchorTimerId !== null) {
+    this.clearAnchorTimer(entry);
+    entry.session.clearSessionProcessingMark();
+    entry.session.dispose();
+    this.sessions.delete(sessionId);
+
+    if (this.activeSessionId === sessionId) {
+      this.activeSessionId = null;
+      this.applyUiState('idle');
+      this.resetQueueTier();
+    }
+  }
+
+  private applySessionStateToAnchor(entry: ManagedSession, state: SessionState): void {
+    if (!isAnchorVisibleSessionState(state)) {
+      this.clearAnchorTimer(entry);
+      entry.session.setAnchorMode('hidden');
+      return;
+    }
+
+    if (entry.anchorTimerId !== null) {
       return;
     }
 
     const timerId = setTimeout(() => {
-      if (this.anchorTimerId !== timerId) {
+      if (entry.anchorTimerId !== timerId) {
         return;
       }
 
-      this.session?.setAnchorMode('visible');
+      entry.session.setAnchorMode('visible');
     }, ANCHOR_VISIBLE_DELAY_MS);
 
-    this.anchorTimerId = timerId;
+    entry.anchorTimerId = timerId;
   }
 
-  private clearAnchorTimer(): void {
-    if (this.anchorTimerId !== null) {
-      clearTimeout(this.anchorTimerId);
-      this.anchorTimerId = null;
+  private clearAnchorTimer(entry: ManagedSession): void {
+    if (entry.anchorTimerId !== null) {
+      clearTimeout(entry.anchorTimerId);
+      entry.anchorTimerId = null;
     }
-  }
-
-  private async handleErrorEvent(event: Extract<SidecarEvent, { type: 'error' }>): Promise<void> {
-    if (
-      this.pendingStartSessionId !== null &&
-      (event.sessionId === undefined || event.sessionId === this.pendingStartSessionId)
-    ) {
-      return;
-    }
-
-    if (
-      event.sessionId !== undefined &&
-      event.sessionId !== this.sessionId &&
-      event.sessionId !== this.abortingSessionId
-    ) {
-      return;
-    }
-
-    const detail = event.details ? `${event.message} (${event.details})` : event.message;
-    this.applyUiState('error');
-    this.dependencies.notice(`Local Dictation: ${detail}`);
-
-    if (event.sessionId !== undefined && event.sessionId === this.sessionId) {
-      void this.abortSessionAfterError(event.sessionId);
-    }
-  }
-
-  private async handleSessionStopped(
-    event: Extract<SidecarEvent, { type: 'session_stopped' }>,
-  ): Promise<void> {
-    if (event.sessionId !== this.sessionId && event.sessionId !== this.abortingSessionId) {
-      return;
-    }
-
-    this.dependencies.logger?.debug(
-      'session',
-      `session ${event.sessionId} stopped (reason: ${event.reason})`,
-    );
-    const snapshot = this.sessionSnapshot;
-    const session = await this.detachSession();
-    this.applyUiState('idle');
-
-    if (snapshot !== null && session !== null && shouldRunBatchCleanup(snapshot, event.reason)) {
-      await this.runBatchCleanup(snapshot, session);
-    }
-
-    session?.dispose();
-
-    if (event.reason === 'timeout') {
-      this.dependencies.notice(
-        'Local Dictation: one-sentence mode timed out before speech started.',
-      );
-    }
-  }
-
-  private async runBatchCleanup(
-    snapshot: ActiveSessionSnapshot,
-    session: ControllerSession,
-  ): Promise<void> {
-    const model = snapshot.llmPostprocessModel.trim();
-    const sessionTranscript = session.readCurrentSessionText();
-
-    if (model.length === 0) {
-      this.dependencies.logger?.debug('llm', 'batch cleanup skipped: no Ollama model selected');
-      return;
-    }
-
-    if (sessionTranscript.length === 0) {
-      this.dependencies.logger?.debug('llm', 'batch cleanup skipped: no transcript text');
-      return;
-    }
-
-    const abortController = new AbortController();
-    this.batchCleanupAbortController = abortController;
-
-    const noteContext =
-      snapshot.llmPostprocessNoteContextChars > 0
-        ? (session.readNoteText(snapshot.llmPostprocessNoteContextChars)?.text ?? '')
-        : '';
-    const userMessage = formatBatchUserMessage(noteContext, sessionTranscript);
-
-    try {
-      this.dependencies.logger?.debug('llm', 'batch cleanup started', {
-        chars: sessionTranscript.length,
-        model,
-      });
-      session.markSessionRangeAsProcessing();
-      const cleanText = await this.dependencies.ollamaClient.cleanup({
-        abortSignal: abortController.signal,
-        model,
-        prompt: snapshot.llmPostprocessPrompt,
-        temperature: snapshot.llmPostprocessTemperature,
-        userMessage,
-      });
-      if (cleanText.trim().length === 0) {
-        this.dependencies.logger?.debug('llm', 'batch cleanup returned empty text');
-        return;
-      }
-
-      const replaced = session.replaceSessionRangeWithCleaned(cleanText, {
-        rawTextForCallout: sessionTranscript,
-        showRawBelow: snapshot.llmPostprocessShowRawBelow,
-      });
-      if (!replaced) {
-        this.dependencies.logger?.warn(
-          'llm',
-          'batch cleanup replacement skipped — session range no longer available',
-        );
-        return;
-      }
-
-      this.dependencies.logger?.debug('llm', 'batch cleanup complete', {
-        chars: cleanText.trim().length,
-      });
-    } catch (error) {
-      if (abortController.signal.aborted) {
-        return;
-      }
-
-      this.dependencies.logger?.warn(
-        'llm',
-        `batch cleanup failed; raw transcript kept: ${formatErrorMessage(error)}`,
-        error,
-      );
-    } finally {
-      session.clearSessionProcessingMark();
-      if (this.batchCleanupAbortController === abortController) {
-        this.batchCleanupAbortController = null;
-      }
-    }
-  }
-
-  private abortBatchCleanup(): void {
-    this.batchCleanupAbortController?.abort();
-    this.batchCleanupAbortController = null;
   }
 
   private async handleSidecarEvent(event: SidecarEvent): Promise<void> {
@@ -555,10 +458,7 @@ export class DictationSessionController {
         return;
 
       case 'session_state_changed':
-        if (event.sessionId === this.sessionId) {
-          this.applyUiState(event.state);
-          this.applySessionStateToAnchor(event.state);
-        }
+        this.handleSessionStateChanged(event);
         return;
 
       case 'transcript_ready':
@@ -573,15 +473,16 @@ export class DictationSessionController {
         this.handleContextRequest(event);
         return;
 
+      case 'batch_cleanup_ready':
+        this.handleBatchCleanupReady(event);
+        return;
+
       case 'warning':
-        if (event.sessionId === undefined || event.sessionId === this.sessionId) {
-          const detail = event.details ? `${event.message} (${event.details})` : event.message;
-          this.dependencies.notice(`Local Dictation: ${detail}`);
-        }
+        this.dependencies.logger?.warn('sidecar', event.message, event.details);
         return;
 
       case 'session_stopped':
-        await this.handleSessionStopped(event);
+        this.handleSessionStopped(event);
         return;
 
       case 'error':
@@ -590,48 +491,54 @@ export class DictationSessionController {
     }
   }
 
+  private handleSessionStateChanged(
+    event: Extract<SidecarEvent, { type: 'session_state_changed' }>,
+  ): void {
+    const entry = this.sessions.get(event.sessionId);
+    if (entry === undefined) {
+      return;
+    }
+
+    this.applySessionStateToAnchor(entry, event.state);
+
+    if (
+      event.sessionId !== this.activeSessionId ||
+      entry.pendingStart ||
+      !this.dependencies.captureStream.isCapturing()
+    ) {
+      return;
+    }
+
+    const nextState = toCaptureUiState(event.state);
+    if (nextState !== null) {
+      this.applyUiState(nextState);
+    }
+  }
+
   private handleQueueTierChange(
     event: Extract<SidecarEvent, { type: 'transcription_queue_changed' }>,
   ): void {
-    if (event.sessionId !== this.sessionId) {
+    const entry = this.sessions.get(event.sessionId);
+    if (entry === undefined) {
       return;
     }
 
-    const previousTier = this.queueTier;
-    if (previousTier === event.tier) {
-      return;
-    }
-    this.queueTier = event.tier;
-    this.dependencies.setRibbonQueueTier(event.tier);
-
-    // Only notify on upward entry into falling_behind. Recovering from
-    // `saturated` also passes through this tier, but the session is already
-    // shutting down and the "pause to let it catch up" guidance would be
-    // misleading on top of the saturation error.
-    const recoveringFromSaturation = previousTier === 'saturated';
-    if (
-      event.tier === 'falling_behind' &&
-      previousTier !== 'falling_behind' &&
-      !recoveringFromSaturation
-    ) {
-      this.dependencies.notice(
-        'Local Dictation: transcription is falling behind — pause to let it catch up.',
-      );
+    if (event.sessionId === this.activeSessionId) {
+      this.dependencies.setRibbonQueueTier(event.tier);
     }
   }
 
   private resetQueueTier(): void {
-    this.queueTier = 'normal';
     this.dependencies.setRibbonQueueTier('normal');
   }
 
   private handleContextRequest(event: ContextRequestEvent): void {
-    if (event.sessionId !== this.sessionId) {
+    const entry = this.sessions.get(event.sessionId);
+    if (entry === undefined) {
       return;
     }
 
-    const snapshot = this.sessionSnapshot;
-    const context = snapshot === null ? null : this.buildContextWindow(snapshot, event.budgetChars);
+    const context = this.buildContextWindow(entry, event.budgetChars);
 
     this.dependencies.logger?.debug(
       'session',
@@ -645,15 +552,12 @@ export class DictationSessionController {
     }
   }
 
-  private buildContextWindow(
-    snapshot: ActiveSessionSnapshot,
-    budgetChars: number,
-  ): ContextWindow | null {
+  private buildContextWindow(entry: ManagedSession, budgetChars: number): ContextWindow | null {
     const sources: ContextWindowSource[] = [];
     let promptText = '';
 
-    if (snapshot.useNoteAsContext) {
-      const glossary = this.session?.readNoteGlossary(Math.min(384, budgetChars)) ?? null;
+    if (entry.snapshot.useNoteAsContext) {
+      const glossary = entry.session.readNoteGlossary(Math.min(384, budgetChars));
       if (glossary !== null) {
         sources.push({
           kind: 'note_glossary',
@@ -664,30 +568,29 @@ export class DictationSessionController {
       }
     }
 
-    if (snapshot.llmPostprocess !== null) {
-      sources.push(...this.buildLlmContextSources(snapshot.llmPostprocess));
+    if (entry.snapshot.llmPostprocess !== null) {
+      sources.push(...this.buildLlmContextSources(entry, entry.snapshot.llmPostprocess));
     }
 
     if (sources.length === 0) {
       return null;
     }
 
-    const truncated = sources.some((source) => source.truncated);
-
     return {
       budgetChars,
       sources,
       text: promptText,
-      truncated,
+      truncated: sources.some((source) => source.truncated),
     };
   }
 
-  private buildLlmContextSources(config: LlmPostprocessConfig): ContextWindowSource[] {
+  private buildLlmContextSources(
+    entry: ManagedSession,
+    config: LlmPostprocessConfig,
+  ): ContextWindowSource[] {
     const sources: ContextWindowSource[] = [];
     const noteText =
-      config.noteContextChars > 0
-        ? (this.session?.readNoteText(config.noteContextChars) ?? null)
-        : null;
+      config.noteContextChars > 0 ? entry.session.readNoteText(config.noteContextChars) : null;
 
     if (noteText !== null) {
       sources.push({ kind: 'note_text', text: noteText.text, truncated: noteText.truncated });
@@ -697,10 +600,10 @@ export class DictationSessionController {
       config.priorUtterancesN > 0
         ? Math.max(1, Math.ceil(config.totalContextCap / config.priorUtterancesN))
         : 0;
-    for (const utterance of this.session?.readPriorUtterances(
+    for (const utterance of entry.session.readPriorUtterances(
       config.priorUtterancesN,
       priorUtteranceBudget,
-    ) ?? []) {
+    )) {
       sources.push({
         kind: 'prior_utterance',
         text: utterance.text,
@@ -712,7 +615,8 @@ export class DictationSessionController {
   }
 
   private async handleTranscriptReady(event: TranscriptReadyEvent): Promise<void> {
-    if (event.sessionId !== this.sessionId) {
+    const entry = this.sessions.get(event.sessionId);
+    if (entry === undefined) {
       return;
     }
 
@@ -721,9 +625,6 @@ export class DictationSessionController {
       `transcript received (${event.text.length} chars, ${event.processingDurationMs}ms processing)`,
     );
 
-    // Capability-gate warnings are intentionally dev-console only — users
-    // don't need to know the worker soft-dropped an unsupported field. Do not
-    // surface these via Notice.
     for (const warning of event.warnings) {
       this.dependencies.logger?.debug(
         'session',
@@ -731,18 +632,11 @@ export class DictationSessionController {
       );
     }
     this.logDroppedHallucinations(event);
-    this.maybeLogLlmStageFailure(event);
+    this.maybeLogLlmStageFailure(entry, event);
 
-    const text = event.text.trim();
-
-    const session = this.session;
-    if (session === null) {
-      return;
-    }
-
-    const result = session.acceptTranscript({
+    const result = entry.session.acceptTranscript({
       isFinal: event.isFinal,
-      llmPostprocessRawText: shouldAppendRawLlmPostprocessCallout(event, this.sessionSnapshot)
+      llmPostprocessRawText: shouldAppendRawLlmPostprocessCallout(event, entry.snapshot)
         ? event.llmPostprocessRawText
         : null,
       pauseMsBeforeUtterance: event.pauseMsBeforeUtterance,
@@ -750,20 +644,172 @@ export class DictationSessionController {
       segments: event.segments,
       sessionId: event.sessionId,
       stageResults: event.stageResults,
-      text,
+      text: event.text.trim(),
       utteranceEndMsInSession: event.utteranceEndMsInSession,
       utteranceId: event.utteranceId,
       utteranceIndex: event.utteranceIndex,
       utteranceStartMsInSession: event.utteranceStartMsInSession,
     });
+
     if (result.kind === 'rejected') {
       this.handleError('Failed to record the local transcript', new Error(result.reason));
-      void this.abortSessionAfterError(event.sessionId);
+      await this.cancelSession(event.sessionId);
     }
   }
 
-  private maybeLogLlmStageFailure(event: TranscriptReadyEvent): void {
-    if (this.llmFailureLoggedForSessionId === event.sessionId) {
+  private handleSessionStopped(event: Extract<SidecarEvent, { type: 'session_stopped' }>): void {
+    const entry = this.sessions.get(event.sessionId);
+    if (entry === undefined) {
+      return;
+    }
+
+    this.dependencies.logger?.debug(
+      'session',
+      `session ${event.sessionId} stopped (reason: ${event.reason})`,
+    );
+    entry.draining = false;
+    entry.pendingStart = false;
+
+    if (event.sessionId === this.activeSessionId) {
+      this.activeSessionId = null;
+      this.applyUiState('idle');
+      this.resetQueueTier();
+    }
+
+    if (shouldRunBatchCleanup(entry.snapshot, event.reason)) {
+      this.requestBatchCleanup(event.sessionId, entry);
+      return;
+    }
+
+    this.disposeLocalSession(event.sessionId);
+  }
+
+  private requestBatchCleanup(sessionId: string, entry: ManagedSession): void {
+    const config = resolveBatchLlmPostprocessConfig(entry.snapshot);
+    const transcriptText = entry.session.readCurrentSessionText();
+
+    if (config === null || transcriptText.length === 0) {
+      this.disposeLocalSession(sessionId);
+      return;
+    }
+
+    const noteContext =
+      entry.snapshot.llmPostprocessNoteContextChars > 0
+        ? (entry.session.readNoteText(entry.snapshot.llmPostprocessNoteContextChars)?.text ?? null)
+        : null;
+
+    entry.session.markSessionRangeAsProcessing();
+    try {
+      this.dependencies.sidecarConnection.requestBatchCleanup({
+        config,
+        noteContext,
+        sessionId,
+        transcriptText,
+      });
+    } catch (error) {
+      this.dependencies.logger?.warn(
+        'llm',
+        `batch cleanup request failed; raw transcript kept: ${formatErrorMessage(error)}`,
+        error,
+      );
+      entry.session.clearSessionProcessingMark();
+      this.disposeLocalSession(sessionId);
+    }
+  }
+
+  private handleBatchCleanupReady(event: BatchCleanupReadyEvent): void {
+    const entry = this.sessions.get(event.sessionId);
+    if (entry === undefined) {
+      return;
+    }
+
+    entry.session.clearSessionProcessingMark();
+
+    const cleanText = event.cleanText.trim();
+    if (cleanText.length === 0) {
+      this.dependencies.logger?.debug('llm', 'batch cleanup returned empty text');
+      this.disposeLocalSession(event.sessionId);
+      return;
+    }
+
+    const replaced = entry.session.replaceSessionRangeWithCleaned(cleanText, {
+      rawTextForCallout: event.rawText,
+      showRawBelow: entry.snapshot.llmPostprocessShowRawBelow,
+    });
+
+    if (!replaced) {
+      this.dependencies.logger?.warn(
+        'llm',
+        'batch cleanup replacement skipped; session range no longer available',
+      );
+    } else {
+      this.dependencies.logger?.debug('llm', 'batch cleanup complete', {
+        chars: cleanText.length,
+      });
+    }
+
+    this.disposeLocalSession(event.sessionId);
+  }
+
+  private async handleErrorEvent(event: Extract<SidecarEvent, { type: 'error' }>): Promise<void> {
+    if (event.code === 'session_capacity_exceeded' && event.sessionId !== undefined) {
+      this.dependencies.logger?.warn('sidecar', event.message, event.details);
+      await this.stopCaptureIfActive(event.sessionId);
+      this.disposeLocalSession(event.sessionId);
+      return;
+    }
+
+    if (event.code === 'batch_cleanup_failed' && event.sessionId !== undefined) {
+      const entry = this.sessions.get(event.sessionId);
+      if (entry !== undefined) {
+        entry.session.clearSessionProcessingMark();
+        this.dependencies.logger?.warn(
+          'llm',
+          `batch cleanup failed; raw transcript kept: ${event.details ?? event.message}`,
+        );
+        this.disposeLocalSession(event.sessionId);
+      }
+      return;
+    }
+
+    const detail = event.details ? `${event.message} (${event.details})` : event.message;
+
+    if (event.sessionId === undefined) {
+      this.handleError('Local Dictation sidecar error', detail);
+      return;
+    }
+
+    const entry = this.sessions.get(event.sessionId);
+    if (entry === undefined) {
+      return;
+    }
+
+    if (event.sessionId === this.activeSessionId) {
+      this.applyUiState('error');
+      this.dependencies.notice(`Local Dictation: ${detail}`);
+    } else {
+      this.dependencies.logger?.warn('session', detail);
+    }
+
+    await this.cancelSession(event.sessionId);
+  }
+
+  private async stopCaptureIfActive(sessionId: string): Promise<void> {
+    if (this.activeSessionId !== sessionId) {
+      return;
+    }
+
+    this.activeSessionId = null;
+    this.applyUiState('idle');
+    this.resetQueueTier();
+
+    if (this.dependencies.captureStream.isCapturing()) {
+      await this.dependencies.captureStream.stop();
+    }
+  }
+
+  private maybeLogLlmStageFailure(entry: ManagedSession, event: TranscriptReadyEvent): void {
+    if (entry.llmFailureLogged) {
       return;
     }
     const failed = event.stageResults.find(
@@ -772,7 +818,7 @@ export class DictationSessionController {
     if (failed === undefined || failed.status.kind !== 'failed') {
       return;
     }
-    this.llmFailureLoggedForSessionId = event.sessionId;
+    entry.llmFailureLogged = true;
     this.dependencies.logger?.warn(
       'llm',
       `per-utterance LLM transform failed: ${failed.status.error}`,
@@ -796,21 +842,23 @@ export class DictationSessionController {
   }
 
   private handleLockedNoteClosed(sessionId: string): void {
-    if (this.sessionId !== sessionId) {
+    const entry = this.sessions.get(sessionId);
+    if (entry === undefined) {
       return;
     }
 
-    this.dependencies.notice('Dictation stopped — locked note was closed');
-    void this.stopDictation();
+    this.dependencies.logger?.warn('session', `locked note closed for session ${sessionId}`);
+    void this.cancelSession(sessionId);
   }
 
   private handleLockedNoteDeleted(sessionId: string): void {
-    if (this.sessionId !== sessionId) {
+    const entry = this.sessions.get(sessionId);
+    if (entry === undefined) {
       return;
     }
 
-    this.dependencies.notice('Dictation cancelled — locked note was deleted');
-    void this.cancelDictation();
+    this.dependencies.logger?.warn('session', `locked note deleted for session ${sessionId}`);
+    void this.cancelSession(sessionId);
   }
 
   private handleError(message: string, error: unknown): void {
@@ -818,36 +866,51 @@ export class DictationSessionController {
     this.applyUiState('error');
     this.dependencies.notice(`${message}: ${formatErrorMessage(error)}`);
   }
-
-  private async abortSessionAfterError(sessionId: string): Promise<void> {
-    if (this.abortingSessionId === sessionId) {
-      return;
-    }
-
-    this.abortingSessionId = sessionId;
-
-    try {
-      await this.dependencies.sidecarConnection.cancelSession(sessionId);
-    } catch (error) {
-      this.dependencies.logger?.warn(
-        'session',
-        'failed to cancel an errored session cleanly',
-        error,
-      );
-
-      if (this.sessionId === sessionId) {
-        await this.cleanupLocalSession();
-      }
-    } finally {
-      if (this.abortingSessionId === sessionId) {
-        this.abortingSessionId = null;
-      }
-    }
-  }
 }
 
 function createSessionId(): string {
-  return `session-${randomUUID()}`;
+  return randomUUID();
+}
+
+function isCapacityExceededStartError(error: unknown): boolean {
+  return /maximum number of active sessions|capacity/i.test(formatErrorMessage(error));
+}
+
+function createSessionSnapshot(
+  settings: PluginSettings,
+  selectedModel: NonNullable<PluginSettings['selectedModel']>,
+): ActiveSessionSnapshot {
+  const effectiveGeneration = resolveActiveGenerationDefaults(settings);
+  const sessionStartUnixMs = Date.now();
+  const noteContextChars = settings.useLlmNoteContext ? settings.llmPostprocessNoteContextChars : 0;
+
+  return {
+    accelerationPreference: settings.accelerationPreference,
+    dictationAnchor: settings.dictationAnchor,
+    listeningMode: settings.listeningMode,
+    llmFeaturesEnabled: settings.llmFeaturesEnabled,
+    llmPostprocess: resolveLlmPostprocessSnapshot(settings, noteContextChars),
+    llmPostprocessMode: settings.llmPostprocessMode,
+    llmPostprocessModel: settings.llmPostprocessModel,
+    llmPostprocessNoteContextChars: noteContextChars,
+    llmPostprocessPrompt: settings.llmPostprocessPrompt,
+    llmPostprocessShowRawBelow: settings.llmPostprocessShowRawBelow,
+    llmPostprocessTemperature: effectiveGeneration.temperature,
+    modelSelection: selectedModel,
+    modelStorePathOverride: settings.modelStorePathOverride,
+    sessionStartUnixMs,
+    speakingStyle: settings.speakingStyle,
+    timestamps: {
+      clock: settings.timestampClock,
+      density: settings.timestampDensity,
+      enabled: settings.timestampsEnabled,
+      header: settings.timestampSessionHeader,
+      sessionStartUnixMs,
+      sparseIntervalMs: settings.timestampSparseIntervalMs,
+    },
+    transcriptFormatting: settings.transcriptFormatting,
+    useNoteAsContext: settings.useNoteAsContext,
+  };
 }
 
 function resolveLlmPostprocessSnapshot(
@@ -876,6 +939,32 @@ function resolveLlmPostprocessSnapshot(
     skipMinWords,
     temperature,
     totalContextCap: settings.llmPostprocessTotalContextCap,
+  };
+}
+
+function resolveBatchLlmPostprocessConfig(
+  snapshot: ActiveSessionSnapshot,
+): LlmPostprocessConfig | null {
+  const model = snapshot.llmPostprocessModel.trim();
+
+  if (
+    !snapshot.llmFeaturesEnabled ||
+    snapshot.llmPostprocessMode !== 'batch' ||
+    model.length === 0
+  ) {
+    return null;
+  }
+
+  return {
+    keepAlive: OLLAMA_KEEP_ALIVE,
+    model,
+    noteContextChars: snapshot.llmPostprocessNoteContextChars,
+    priorUtterancesN: 0,
+    prompt: snapshot.llmPostprocessPrompt,
+    showRawBelow: snapshot.llmPostprocessShowRawBelow,
+    skipMinWords: 0,
+    temperature: snapshot.llmPostprocessTemperature,
+    totalContextCap: snapshot.llmPostprocessNoteContextChars,
   };
 }
 
@@ -908,11 +997,25 @@ function isAnchorVisibleSessionState(state: SessionState): boolean {
   return state === 'speech_detected' || state === 'speech_ending' || state === 'transcribing';
 }
 
+function toCaptureUiState(state: SessionState): DictationControllerState | null {
+  switch (state) {
+    case 'speech_detected':
+    case 'speech_ending':
+      return 'speech_detected';
+    case 'listening':
+    case 'transcribing':
+    case 'idle':
+      return 'listening';
+    case 'error':
+      return 'error';
+  }
+}
+
 function shouldAppendRawLlmPostprocessCallout(
   event: TranscriptReadyEvent,
-  snapshot: ActiveSessionSnapshot | null,
+  snapshot: ActiveSessionSnapshot,
 ): boolean {
-  if (snapshot?.llmPostprocess?.showRawBelow !== true || event.llmPostprocessRawText === null) {
+  if (snapshot.llmPostprocess?.showRawBelow !== true || event.llmPostprocessRawText === null) {
     return false;
   }
 

--- a/src/editor/note-surface.ts
+++ b/src/editor/note-surface.ts
@@ -1,5 +1,5 @@
 import type { Extension } from '@codemirror/state';
-import { Transaction } from '@codemirror/state';
+import { Annotation, Transaction } from '@codemirror/state';
 import { EditorView, type ViewUpdate } from '@codemirror/view';
 
 import type { UtteranceId } from '../session/session-journal';
@@ -99,23 +99,47 @@ export type RewriteResult =
       reason: RewriteDenialReason;
     };
 
-let activeNoteSurface: NoteSurface | null = null;
+const noteSurfaceInsertOrder = Annotation.define<number>();
+const noteSurfacesByView = new WeakMap<EditorView, Set<NoteSurface>>();
+let nextSurfaceOrder = 0;
 
-export function setActiveNoteSurface(surface: NoteSurface | null): void {
-  activeNoteSurface = surface;
+function registerNoteSurface(surface: NoteSurface): void {
+  const existing = noteSurfacesByView.get(surface.view);
+  if (existing !== undefined) {
+    existing.add(surface);
+    return;
+  }
+
+  noteSurfacesByView.set(surface.view, new Set([surface]));
+}
+
+function unregisterNoteSurface(surface: NoteSurface): void {
+  const surfaces = noteSurfacesByView.get(surface.view);
+  if (surfaces === undefined) {
+    return;
+  }
+
+  surfaces.delete(surface);
 }
 
 export function noteSurfaceUpdateListenerExtension(): Extension {
   return EditorView.updateListener.of((update) => {
-    if (activeNoteSurface !== null && update.view === activeNoteSurface.view) {
-      activeNoteSurface.observeTransaction(update);
+    const surfaces = noteSurfacesByView.get(update.view);
+    if (surfaces === undefined) {
+      return;
+    }
+
+    for (const surface of [...surfaces]) {
+      surface.observeTransaction(update);
     }
   });
 }
 
 export class NoteSurface {
+  private readonly createdAt = nextSurfaceOrder;
   private disposed = false;
   private initialAnchorPos: number;
+  private readonly initialBoundaryPos: number;
   private pendingInitialPrefix = '';
   private readonly spans = new Map<UtteranceId, ProjectedSpan>();
 
@@ -123,10 +147,12 @@ export class NoteSurface {
     readonly view: EditorView,
     private readonly placement: NotePlacementOptions,
   ) {
+    nextSurfaceOrder += 1;
     this.initialAnchorPos = this.computePinPosition();
     this.insertInitialPrefix();
+    this.initialBoundaryPos = this.initialAnchorPos;
     this.view.dispatch({ effects: setAnchorEffect.of(this.initialAnchorPos) });
-    setActiveNoteSurface(this);
+    registerNoteSurface(this);
   }
 
   observeTransaction(update: ViewUpdate): void {
@@ -179,6 +205,7 @@ export class NoteSurface {
     const to = from + projection.projectedText.length;
 
     this.view.dispatch({
+      annotations: noteSurfaceInsertOrder.of(this.createdAt),
       changes: { from, insert: projection.projectedText },
       effects: [setAnchorEffect.of(to), EditorView.scrollIntoView(to, { y: 'nearest' })],
     });
@@ -359,10 +386,7 @@ export class NoteSurface {
       effects: [clearAnchorEffect.of(null), setSessionProcessingEffect.of(null)],
     });
     this.disposed = true;
-
-    if (activeNoteSurface === this) {
-      setActiveNoteSurface(null);
-    }
+    unregisterNoteSurface(this);
   }
 
   getSpan(utteranceId: UtteranceId): ProjectedSpan | undefined {
@@ -425,7 +449,27 @@ export class NoteSurface {
   }
 
   private writingRegionTail(): number {
-    return Math.max(this.initialAnchorPos, ...[...this.spans.values()].map((span) => span.end));
+    let tail = Math.max(this.initialAnchorPos, ...[...this.spans.values()].map((span) => span.end));
+    const siblingSurfaces = noteSurfacesByView.get(this.view);
+
+    if (siblingSurfaces === undefined) {
+      return tail;
+    }
+
+    for (const surface of siblingSurfaces) {
+      if (
+        surface === this ||
+        surface.disposed ||
+        surface.initialBoundaryPos !== this.initialBoundaryPos ||
+        surface.createdAt >= this.createdAt
+      ) {
+        continue;
+      }
+
+      tail = Math.max(tail, surface.writingRegionTail());
+    }
+
+    return tail;
   }
 
   private lastSpan(): ProjectedSpan | null {
@@ -441,9 +485,15 @@ export class NoteSurface {
   }
 
   private mapSpans(update: ViewUpdate): void {
+    const insertOrder = update.transactions
+      .map((transaction) => transaction.annotation(noteSurfaceInsertOrder))
+      .find((order) => order !== undefined);
+    const spanStartBias = insertOrder !== undefined && insertOrder < this.createdAt ? 1 : -1;
+    const initialAnchorBias = insertOrder !== undefined && insertOrder > this.createdAt ? -1 : 1;
+
     for (const span of this.spans.values()) {
-      span.start = update.changes.mapPos(span.start, -1);
-      span.textStart = update.changes.mapPos(span.textStart, -1);
+      span.start = update.changes.mapPos(span.start, spanStartBias);
+      span.textStart = update.changes.mapPos(span.textStart, spanStartBias);
       // Text bias: insertions at textEnd land outside the span, so a sibling
       // append at writingRegionTail() doesn't swallow the next utterance.
       span.textEnd = update.changes.mapPos(span.textEnd, -1);
@@ -451,7 +501,7 @@ export class NoteSurface {
     }
 
     // Tail bias: insertions at the initial anchor extend the writing region.
-    this.initialAnchorPos = update.changes.mapPos(this.initialAnchorPos, 1);
+    this.initialAnchorPos = update.changes.mapPos(this.initialAnchorPos, initialAnchorBias);
   }
 
   private latchedReason(span: ProjectedSpan): ReplaceDenialReason {

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,7 +105,6 @@ export default class LocalSttPlugin extends Plugin {
       notice: (message) => {
         new Notice(message);
       },
-      ollamaClient,
       onModelMissing: () => {
         void this.openModelPicker();
       },

--- a/src/sidecar/protocol.ts
+++ b/src/sidecar/protocol.ts
@@ -474,16 +474,7 @@ export function encodeAudioFrame(sessionId: string, frameBytes: Uint8Array): Uin
 }
 
 export function sessionIdToBytes(sessionId: string): Uint8Array {
-  const normalized = normalizeSessionId(sessionId);
-  const bytes = new Uint8Array(SESSION_ID_BYTES);
-  let byteOffset = 0;
-
-  for (let index = 0; index < normalized.length; index += 2) {
-    bytes[byteOffset] = Number.parseInt(normalized.slice(index, index + 2), 16);
-    byteOffset += 1;
-  }
-
-  return bytes;
+  return Buffer.from(normalizeSessionId(sessionId), 'hex');
 }
 
 export function bytesToSessionId(bytes: Uint8Array): string {
@@ -491,7 +482,7 @@ export function bytesToSessionId(bytes: Uint8Array): string {
     throw new Error(`Session ids must be ${SESSION_ID_BYTES} bytes, received ${bytes.byteLength}.`);
   }
 
-  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+  const hex = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString('hex');
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 

--- a/src/sidecar/protocol.ts
+++ b/src/sidecar/protocol.ts
@@ -38,6 +38,7 @@ import { isRecord } from '../shared/type-guards';
 export const JSON_FRAME_KIND = 0x01;
 export const AUDIO_FRAME_KIND = 0x02;
 export const FRAME_HEADER_LENGTH = 5;
+export const SESSION_ID_BYTES = 16;
 
 export type AccelerationPreference = 'auto' | 'cpu_only';
 export type SpeakingStyle = 'responsive' | 'balanced' | 'patient';
@@ -58,7 +59,6 @@ export type SessionState = (typeof SESSION_STATES)[number];
 export const SESSION_STOP_REASONS = [
   'queue_overload',
   'sentence_complete',
-  'session_replaced',
   'timeout',
   'user_cancel',
   'user_stop',
@@ -193,9 +193,20 @@ export interface CancelModelInstallCommand extends EnvelopeBase<'cancel_model_in
   installId: string;
 }
 
-export interface StopSessionCommand extends EnvelopeBase<'stop_session'> {}
+export interface StopSessionCommand extends EnvelopeBase<'stop_session'> {
+  sessionId: string;
+}
 
-export interface CancelSessionCommand extends EnvelopeBase<'cancel_session'> {}
+export interface CancelSessionCommand extends EnvelopeBase<'cancel_session'> {
+  sessionId: string;
+}
+
+export interface RunBatchCleanupCommand extends EnvelopeBase<'run_batch_cleanup'> {
+  config: LlmPostprocessConfig;
+  noteContext: string | null;
+  sessionId: string;
+  transcriptText: string;
+}
 
 export interface ShutdownCommand extends EnvelopeBase<'shutdown'> {}
 
@@ -213,6 +224,7 @@ export type SidecarCommand =
   | ListModelCatalogCommand
   | ProbeModelSelectionCommand
   | RemoveModelCommand
+  | RunBatchCleanupCommand
   | ShutdownCommand
   | StartSessionCommand
   | StopSessionCommand;
@@ -301,6 +313,13 @@ export interface SessionStoppedEvent extends EnvelopeBase<'session_stopped'> {
   sessionId: string;
 }
 
+export interface BatchCleanupReadyEvent extends EnvelopeBase<'batch_cleanup_ready'> {
+  cleanText: string;
+  rawText: string;
+  sessionId: string;
+  stageResults: StageOutcome[];
+}
+
 export interface ErrorEvent extends EnvelopeBase<'error'> {
   code: string;
   details?: string;
@@ -309,6 +328,7 @@ export interface ErrorEvent extends EnvelopeBase<'error'> {
 }
 
 export type SidecarEvent =
+  | BatchCleanupReadyEvent
   | ContextRequestEvent
   | ErrorEvent
   | HealthOkEvent
@@ -397,12 +417,27 @@ export function createCancelModelInstallCommand(installId: string): CancelModelI
   };
 }
 
-export function createStopSessionCommand(): StopSessionCommand {
-  return createEnvelope('stop_session');
+export function createStopSessionCommand(sessionId: string): StopSessionCommand {
+  return {
+    ...createEnvelope('stop_session'),
+    sessionId,
+  };
 }
 
-export function createCancelSessionCommand(): CancelSessionCommand {
-  return createEnvelope('cancel_session');
+export function createCancelSessionCommand(sessionId: string): CancelSessionCommand {
+  return {
+    ...createEnvelope('cancel_session'),
+    sessionId,
+  };
+}
+
+export function createRunBatchCleanupCommand(
+  payload: Omit<RunBatchCleanupCommand, 'type'>,
+): RunBatchCleanupCommand {
+  return {
+    ...createEnvelope('run_batch_cleanup'),
+    ...payload,
+  };
 }
 
 export function createShutdownCommand(): ShutdownCommand {
@@ -424,14 +459,56 @@ export function encodeJsonFrame(envelope: SidecarCommand | SidecarEvent): Uint8A
   return encodeFrame(JSON_FRAME_KIND, textEncoder.encode(JSON.stringify(envelope)));
 }
 
-export function encodeAudioFrame(frameBytes: Uint8Array): Uint8Array {
+export function encodeAudioFrame(sessionId: string, frameBytes: Uint8Array): Uint8Array {
   if (frameBytes.byteLength !== PCM_BYTES_PER_FRAME) {
     throw new Error(
       `Audio frames must be ${PCM_BYTES_PER_FRAME} bytes, received ${frameBytes.byteLength}.`,
     );
   }
 
-  return encodeFrame(AUDIO_FRAME_KIND, frameBytes);
+  const envelope = new Uint8Array(SESSION_ID_BYTES + frameBytes.byteLength);
+  envelope.set(sessionIdToBytes(sessionId), 0);
+  envelope.set(frameBytes, SESSION_ID_BYTES);
+
+  return encodeFrame(AUDIO_FRAME_KIND, envelope);
+}
+
+export function sessionIdToBytes(sessionId: string): Uint8Array {
+  const normalized = normalizeSessionId(sessionId);
+  const bytes = new Uint8Array(SESSION_ID_BYTES);
+  let byteOffset = 0;
+
+  for (let index = 0; index < normalized.length; index += 2) {
+    bytes[byteOffset] = Number.parseInt(normalized.slice(index, index + 2), 16);
+    byteOffset += 1;
+  }
+
+  return bytes;
+}
+
+export function bytesToSessionId(bytes: Uint8Array): string {
+  if (bytes.byteLength !== SESSION_ID_BYTES) {
+    throw new Error(`Session ids must be ${SESSION_ID_BYTES} bytes, received ${bytes.byteLength}.`);
+  }
+
+  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+export function decodeAudioFrameEnvelope(payload: Uint8Array): {
+  frameBytes: Uint8Array;
+  sessionId: string;
+} {
+  if (payload.byteLength !== SESSION_ID_BYTES + PCM_BYTES_PER_FRAME) {
+    throw new Error(
+      `Audio frame envelopes must be ${SESSION_ID_BYTES + PCM_BYTES_PER_FRAME} bytes, received ${payload.byteLength}.`,
+    );
+  }
+
+  return {
+    frameBytes: payload.slice(SESSION_ID_BYTES),
+    sessionId: bytesToSessionId(payload.slice(0, SESSION_ID_BYTES)),
+  };
 }
 
 export interface JsonFrame<TEnvelope> {
@@ -440,8 +517,9 @@ export interface JsonFrame<TEnvelope> {
 }
 
 export interface AudioFrame {
+  frameBytes: Uint8Array<ArrayBufferLike>;
   kind: typeof AUDIO_FRAME_KIND;
-  payload: Uint8Array<ArrayBufferLike>;
+  sessionId: string;
 }
 
 export type ParsedFrame<TEnvelope> = AudioFrame | JsonFrame<TEnvelope>;
@@ -483,9 +561,11 @@ export class FramedMessageParser<TEnvelope> {
           kind,
         });
       } else if (kind === AUDIO_FRAME_KIND) {
+        const { frameBytes, sessionId } = decodeAudioFrameEnvelope(payload);
         frames.push({
+          frameBytes,
           kind,
-          payload,
+          sessionId,
         });
       } else {
         throw new Error(`Unsupported sidecar frame kind: ${kind}`);
@@ -664,6 +744,15 @@ export function parseEventFrame(jsonText: string): SidecarEvent {
         utteranceId: readString(parsedValue.utteranceId, 'event.utteranceId'),
       };
 
+    case 'batch_cleanup_ready':
+      return {
+        cleanText: readString(parsedValue.cleanText, 'event.cleanText'),
+        rawText: readString(parsedValue.rawText, 'event.rawText'),
+        sessionId: readString(parsedValue.sessionId, 'event.sessionId'),
+        stageResults: readStageOutcomes(parsedValue.stageResults),
+        type,
+      };
+
     case 'warning':
       return createWarningEvent(parsedValue);
 
@@ -715,6 +804,17 @@ function readUint32LE(bytes: Uint8Array, offset: number): number {
   }
 
   return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(offset, true);
+}
+
+function normalizeSessionId(sessionId: string): string {
+  const normalized = sessionId.toLowerCase();
+  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+
+  if (!uuidPattern.test(normalized)) {
+    throw new Error(`Session id must be a UUID v4 string: ${sessionId}`);
+  }
+
+  return normalized.replaceAll('-', '');
 }
 
 function readString(value: unknown, fieldName: string): string {

--- a/src/sidecar/sidecar-connection.ts
+++ b/src/sidecar/sidecar-connection.ts
@@ -14,6 +14,7 @@ import {
   createListModelCatalogCommand,
   createProbeModelSelectionCommand,
   createRemoveModelCommand,
+  createRunBatchCleanupCommand,
   createShutdownCommand,
   createStartSessionCommand,
   createStopSessionCommand,
@@ -241,12 +242,12 @@ export class SidecarConnection {
     );
   }
 
-  async stopSession(
+  async cancelSession(
     sessionId: string,
     timeoutMs = this.options.getRequestTimeoutMs(),
   ): Promise<SessionStoppedEvent> {
     return this.sendCommandAndWait(
-      createStopSessionCommand(),
+      createCancelSessionCommand(sessionId),
       (event): event is SessionStoppedEvent =>
         event.type === 'session_stopped' && event.sessionId === sessionId,
       `session_stopped:${sessionId}`,
@@ -255,18 +256,20 @@ export class SidecarConnection {
     );
   }
 
-  async cancelSession(
-    sessionId: string,
-    timeoutMs = this.options.getRequestTimeoutMs(),
-  ): Promise<SessionStoppedEvent> {
-    return this.sendCommandAndWait(
-      createCancelSessionCommand(),
-      (event): event is SessionStoppedEvent =>
-        event.type === 'session_stopped' && event.sessionId === sessionId,
-      `session_stopped:${sessionId}`,
-      timeoutMs,
-      (event) => event.sessionId === undefined || event.sessionId === sessionId,
-    );
+  requestStopSession(sessionId: string): void {
+    if (!this.process.isRunning()) {
+      return;
+    }
+
+    this.process.write(encodeJsonFrame(createStopSessionCommand(sessionId)));
+  }
+
+  requestBatchCleanup(payload: Parameters<typeof createRunBatchCleanupCommand>[0]): void {
+    if (!this.process.isRunning()) {
+      return;
+    }
+
+    this.process.write(encodeJsonFrame(createRunBatchCleanupCommand(payload)));
   }
 
   async restart(startupTimeoutMs = this.options.getRequestTimeoutMs()): Promise<HealthOkEvent> {
@@ -288,8 +291,8 @@ export class SidecarConnection {
     }
   }
 
-  sendAudioFrame(frameBytes: Uint8Array): void {
-    this.process.write(encodeAudioFrame(frameBytes));
+  sendAudioFrame(sessionId: string, frameBytes: Uint8Array): void {
+    this.process.write(encodeAudioFrame(sessionId, frameBytes));
   }
 
   sendContextResponse(correlationId: string, context: ContextWindow | null): void {
@@ -451,6 +454,7 @@ function shouldLogProtocolEvent(event: SidecarEvent): boolean {
     case 'session_started':
     case 'session_state_changed':
     case 'session_stopped':
+    case 'batch_cleanup_ready':
     case 'transcript_ready':
     case 'warning':
       return true;
@@ -471,6 +475,8 @@ function summarizeProtocolEvent(event: SidecarEvent): string {
       return `event: session_state_changed (${event.sessionId}, ${event.state})`;
     case 'session_stopped':
       return `event: session_stopped (${event.sessionId}, ${event.reason})`;
+    case 'batch_cleanup_ready':
+      return `event: batch_cleanup_ready (${event.sessionId}, ${event.cleanText.length} chars)`;
     case 'transcript_ready':
       return `event: transcript_ready (${event.sessionId}, ${event.text.length} chars)`;
     case 'warning':

--- a/src/sidecar/sidecar-connection.ts
+++ b/src/sidecar/sidecar-connection.ts
@@ -43,6 +43,20 @@ import { type ResolveSidecarLaunchSpec, SidecarProcess } from './sidecar-process
 
 type SidecarEventListener = (event: SidecarEvent) => void;
 
+export class SidecarError extends Error {
+  readonly code: string;
+  readonly details: string | undefined;
+  readonly sessionId: string | undefined;
+
+  constructor(event: ErrorEvent) {
+    super(event.details ? `${event.message} (${event.details})` : event.message);
+    this.name = 'SidecarError';
+    this.code = event.code;
+    this.details = event.details;
+    this.sessionId = event.sessionId;
+  }
+}
+
 interface PendingEventWaiter {
   description: string;
   matches: (event: SidecarEvent) => boolean;
@@ -434,7 +448,7 @@ export class SidecarConnection {
       if (event.type === 'error' && waiter.rejectOnError(event)) {
         globalThis.clearTimeout(waiter.timeoutHandle);
         this.pendingWaiters.delete(waiter);
-        waiter.reject(new Error(`${event.message}${event.details ? ` (${event.details})` : ''}`));
+        waiter.reject(new SidecarError(event));
       }
     }
   }

--- a/src/ui/dictation-ribbon.ts
+++ b/src/ui/dictation-ribbon.ts
@@ -4,13 +4,7 @@ import type { DictationControllerState } from '../dictation/dictation-session-co
 import type { QueueBackpressureTier } from '../sidecar/protocol';
 
 type RibbonIcon = 'audio-lines' | 'loader' | 'mic' | 'mic-off';
-type RibbonVisualState =
-  | 'idle'
-  | 'starting'
-  | 'working'
-  | 'listening'
-  | 'speech_detected'
-  | 'error';
+type RibbonVisualState = 'idle' | 'starting' | 'listening' | 'speech_detected' | 'error';
 
 export class DictationRibbonController {
   private state: DictationControllerState = 'idle';
@@ -57,7 +51,7 @@ export class DictationRibbonController {
 
 function buildRibbonState(
   state: DictationControllerState,
-  queueTier: QueueBackpressureTier,
+  _queueTier: QueueBackpressureTier,
 ): {
   icon: RibbonIcon;
   label: string;
@@ -73,13 +67,7 @@ function buildRibbonState(
       return { icon: 'audio-lines', label: 'Local Dictation — listening' };
 
     case 'speech_detected':
-    case 'speech_ending':
       return { icon: 'audio-lines', label: 'Local Dictation — hearing speech' };
-
-    case 'transcribing':
-      return queueTier === 'catching_up'
-        ? { icon: 'loader', label: 'Local Dictation — catching up…' }
-        : { icon: 'loader', label: 'Local Dictation — transcribing…' };
 
     case 'error':
       return { icon: 'mic-off', label: 'Local Dictation — error' };
@@ -94,10 +82,7 @@ function toVisualState(state: DictationControllerState): RibbonVisualState {
       return 'starting';
     case 'listening':
       return 'listening';
-    case 'transcribing':
-      return 'working';
     case 'speech_detected':
-    case 'speech_ending':
       return 'speech_detected';
     case 'error':
       return 'error';

--- a/styles.css
+++ b/styles.css
@@ -369,60 +369,40 @@
 }
 
 /* 8 spokes, each offset by 0.15s = 1.2s full cycle */
-.side-dock-ribbon-action:is(
-    [data-local-stt-state="starting"],
-    [data-local-stt-state="working"]
-  ) > svg
-  > path {
+.side-dock-ribbon-action[data-local-stt-state="starting"] > svg > path {
   animation: local-stt-chase 1.2s ease-in-out infinite;
   opacity: 0.2;
 }
 
-.side-dock-ribbon-action:is([data-local-stt-state="starting"], [data-local-stt-state="working"])
-  > svg
-  > path:nth-child(1) {
+.side-dock-ribbon-action[data-local-stt-state="starting"] > svg > path:nth-child(1) {
   animation-delay: 0s;
 }
 
-.side-dock-ribbon-action:is([data-local-stt-state="starting"], [data-local-stt-state="working"])
-  > svg
-  > path:nth-child(2) {
+.side-dock-ribbon-action[data-local-stt-state="starting"] > svg > path:nth-child(2) {
   animation-delay: 0.15s;
 }
 
-.side-dock-ribbon-action:is([data-local-stt-state="starting"], [data-local-stt-state="working"])
-  > svg
-  > path:nth-child(3) {
+.side-dock-ribbon-action[data-local-stt-state="starting"] > svg > path:nth-child(3) {
   animation-delay: 0.3s;
 }
 
-.side-dock-ribbon-action:is([data-local-stt-state="starting"], [data-local-stt-state="working"])
-  > svg
-  > path:nth-child(4) {
+.side-dock-ribbon-action[data-local-stt-state="starting"] > svg > path:nth-child(4) {
   animation-delay: 0.45s;
 }
 
-.side-dock-ribbon-action:is([data-local-stt-state="starting"], [data-local-stt-state="working"])
-  > svg
-  > path:nth-child(5) {
+.side-dock-ribbon-action[data-local-stt-state="starting"] > svg > path:nth-child(5) {
   animation-delay: 0.6s;
 }
 
-.side-dock-ribbon-action:is([data-local-stt-state="starting"], [data-local-stt-state="working"])
-  > svg
-  > path:nth-child(6) {
+.side-dock-ribbon-action[data-local-stt-state="starting"] > svg > path:nth-child(6) {
   animation-delay: 0.75s;
 }
 
-.side-dock-ribbon-action:is([data-local-stt-state="starting"], [data-local-stt-state="working"])
-  > svg
-  > path:nth-child(7) {
+.side-dock-ribbon-action[data-local-stt-state="starting"] > svg > path:nth-child(7) {
   animation-delay: 0.9s;
 }
 
-.side-dock-ribbon-action:is([data-local-stt-state="starting"], [data-local-stt-state="working"])
-  > svg
-  > path:nth-child(8) {
+.side-dock-ribbon-action[data-local-stt-state="starting"] > svg > path:nth-child(8) {
   animation-delay: 1.05s;
 }
 

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -8,24 +8,36 @@ import type { TranscriptRevision } from '../src/session/session-journal';
 import { DEFAULT_PLUGIN_SETTINGS, type PluginSettings } from '../src/settings/plugin-settings';
 import type {
   ContextWindow,
+  LlmPostprocessConfig,
   QueueBackpressureTier,
   SidecarEvent,
   StartSessionCommand,
 } from '../src/sidecar/protocol';
-import { SidecarNotInstalledError } from '../src/sidecar/sidecar-paths';
 import type { TranscriptRenderOptions } from '../src/transcript/renderer';
 
 class FakeCaptureStream {
   public capturing = false;
-  public frameListener: ((frameBytes: Uint8Array) => void) | null = null;
-  public start = vi.fn(async (listener: (frameBytes: Uint8Array) => void) => {
-    this.capturing = true;
-    this.frameListener = listener;
-  });
+  public frameListener: ((sessionId: string, frameBytes: Uint8Array) => void) | null = null;
+  public sessionId: string | null = null;
+  public start = vi.fn(
+    async (sessionId: string, listener: (sessionId: string, frameBytes: Uint8Array) => void) => {
+      this.capturing = true;
+      this.sessionId = sessionId;
+      this.frameListener = listener;
+    },
+  );
   public stop = vi.fn(async () => {
     this.capturing = false;
+    this.sessionId = null;
     this.frameListener = null;
   });
+
+  emitFrame(frameBytes: Uint8Array): void {
+    if (this.sessionId === null) {
+      throw new Error('capture is not active');
+    }
+    this.frameListener?.(this.sessionId, frameBytes);
+  }
 
   isCapturing(): boolean {
     return this.capturing;
@@ -34,14 +46,16 @@ class FakeCaptureStream {
 
 class FakeSession {
   public currentSessionText = '';
-  public rawSessionText = '';
-  public readonly acceptTranscript = vi.fn((_revision: TranscriptRevision) => ({
-    kind: 'accepted' as const,
-  }));
-  public readonly joinRawSessionText = vi.fn(() => this.rawSessionText);
-  public readonly readCurrentSessionText = vi.fn(
-    () => this.currentSessionText || this.rawSessionText,
-  );
+  public readonly acceptTranscript = vi.fn((revision: TranscriptRevision) => {
+    if (revision.isFinal) {
+      this.currentSessionText = revision.text;
+    }
+    return { kind: 'accepted' as const };
+  });
+  public readonly clearSessionProcessingMark = vi.fn();
+  public readonly dispose = vi.fn();
+  public readonly markSessionRangeAsProcessing = vi.fn(() => true);
+  public readonly readCurrentSessionText = vi.fn(() => this.currentSessionText);
   public readonly readNoteGlossary = vi.fn(
     (_maxChars: number): { text: string; truncated: boolean } | null => null,
   );
@@ -57,23 +71,19 @@ class FakeSession {
       truncated: boolean;
     }> => [],
   );
-  public readonly dispose = vi.fn(() => {});
-  public readonly modeCalls: string[] = [];
   public readonly replaceSessionRangeWithCleaned = vi.fn(
     (
-      _cleanText: string,
+      cleanText: string,
       _options?: {
         rawTextForCallout?: string;
         showRawBelow?: boolean;
       },
-    ) => true,
+    ) => {
+      this.currentSessionText = cleanText;
+      return true;
+    },
   );
-  public readonly markSessionRangeAsProcessing = vi.fn(() => true);
-  public readonly clearSessionProcessingMark = vi.fn();
-
-  setAnchorMode(mode: 'hidden' | 'visible'): void {
-    this.modeCalls.push(mode);
-  }
+  public readonly setAnchorMode = vi.fn((_mode: 'hidden' | 'visible') => {});
 }
 
 class FakeLogger {
@@ -82,72 +92,41 @@ class FakeLogger {
   public readonly warn = vi.fn();
 }
 
-class FakeOllamaClient {
-  public cleanup = vi.fn(
-    async (_options: {
-      abortSignal?: AbortSignal;
-      model: string;
-      prompt: string;
-      temperature: number;
-      userMessage: string;
-    }) => 'Cleaned transcript.',
-  );
-}
-
 class FakeSidecarConnection {
-  public cancelSession = vi.fn(async (sessionId: string) => {
-    this.emit({
-      reason: 'user_cancel',
-      sessionId,
-      type: 'session_stopped',
-    });
-    return {
-      reason: 'user_cancel',
-      sessionId,
-      type: 'session_stopped',
-    } as const;
+  public readonly batchCleanupRequests: Array<{
+    config: LlmPostprocessConfig;
+    noteContext: string | null;
+    sessionId: string;
+    transcriptText: string;
+  }> = [];
+  public readonly cancelSession = vi.fn(async (sessionId: string) => {
+    this.emit({ reason: 'user_cancel', sessionId, type: 'session_stopped' });
+    return { reason: 'user_cancel', sessionId, type: 'session_stopped' } as const;
   });
-  public ensureStarted = vi.fn(async () => {});
-  public listeners = new Set<(event: SidecarEvent) => void>();
-  public lastSessionId: string | null = null;
-  public sendAudioFrame = vi.fn(() => {});
-  public sendContextResponse = vi.fn(
+  public readonly ensureStarted = vi.fn(async () => {});
+  public readonly listeners = new Set<(event: SidecarEvent) => void>();
+  public readonly requestBatchCleanup = vi.fn(
+    (payload: {
+      config: LlmPostprocessConfig;
+      noteContext: string | null;
+      sessionId: string;
+      transcriptText: string;
+    }) => {
+      this.batchCleanupRequests.push(payload);
+    },
+  );
+  public readonly requestStopSession = vi.fn((_sessionId: string) => {});
+  public readonly sendAudioFrame = vi.fn((_sessionId: string, _frameBytes: Uint8Array) => {});
+  public readonly sendContextResponse = vi.fn(
     (_correlationId: string, _context: ContextWindow | null) => {},
   );
-  public startSession = vi.fn(async (payload: Omit<StartSessionCommand, 'type'>) => {
-    this.lastSessionId = payload.sessionId;
-    this.emit({
-      mode: payload.mode,
-      sessionId: payload.sessionId,
-      type: 'session_started',
-    });
-    this.emit({
-      sessionId: payload.sessionId,
-      state: 'listening',
-      type: 'session_state_changed',
-    });
-
-    return {
-      mode: payload.mode,
-      sessionId: payload.sessionId,
-      type: 'session_started',
-    } as const;
+  public readonly startSession = vi.fn(async (payload: Omit<StartSessionCommand, 'type'>) => {
+    this.emit({ mode: payload.mode, sessionId: payload.sessionId, type: 'session_started' });
+    this.emit({ sessionId: payload.sessionId, state: 'listening', type: 'session_state_changed' });
+    return { mode: payload.mode, sessionId: payload.sessionId, type: 'session_started' } as const;
   });
-  public stopSession = vi.fn(async (sessionId: string) => {
-    this.emit({
-      reason: 'user_stop',
-      sessionId,
-      type: 'session_stopped',
-    });
-    return {
-      reason: 'user_stop',
-      sessionId,
-      type: 'session_stopped',
-    } as const;
-  });
-  public subscribe = vi.fn((listener: (event: SidecarEvent) => void) => {
+  public readonly subscribe = vi.fn((listener: (event: SidecarEvent) => void) => {
     this.listeners.add(listener);
-
     return () => {
       this.listeners.delete(listener);
     };
@@ -161,1576 +140,259 @@ class FakeSidecarConnection {
 }
 
 describe('DictationSessionController', () => {
-  it('starts a session and begins capture', async () => {
+  it('starts a bare-UUID session and tags audio frames with that session id', async () => {
     const captureStream = new FakeCaptureStream();
     const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      captureStream,
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      sidecarConnection,
-    });
+    const controller = createController({ captureStream, sidecarConnection });
 
     await controller.startDictation();
 
-    expect(captureStream.start).toHaveBeenCalledTimes(1);
-    expect(sidecarConnection.startSession).toHaveBeenCalledTimes(1);
-    expect(sidecarConnection.startSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        accelerationPreference: 'auto',
-      }),
+    const startPayload = sidecarConnection.startSession.mock.calls[0]?.[0];
+    expect(startPayload?.sessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
     );
-    expect(sidecarConnection.startSession.mock.calls[0]?.[0]).not.toHaveProperty('useGpu');
+    expect(startPayload?.sessionId.startsWith('session-')).toBe(false);
+
+    const frame = new Uint8Array(640).fill(3);
+    captureStream.emitFrame(frame);
+
+    expect(sidecarConnection.sendAudioFrame).toHaveBeenCalledWith(startPayload?.sessionId, frame);
     expect(controller.getState()).toBe('listening');
   });
 
-  it('forces CPU when accelerationPreference is cpu_only', async () => {
+  it('accepts late transcript events from a stopped session after a new session starts', async () => {
     const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
     const controller = createController({
-      getSettings: () =>
-        createSettings({
-          accelerationPreference: 'cpu_only',
-          selectedModel: createExternalModelSelection(),
-        }),
+      createSession: (session) => {
+        sessions.push(session);
+      },
       sidecarConnection,
     });
 
     await controller.startDictation();
+    const sessionA = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    await controller.stopDictation();
+    await controller.startDictation();
+    const sessionB = sidecarConnection.startSession.mock.calls[1]?.[0].sessionId ?? '';
 
-    expect(sidecarConnection.startSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        accelerationPreference: 'cpu_only',
-      }),
+    sidecarConnection.emit(transcriptReady(sessionA, 'alpha'));
+    sidecarConnection.emit(transcriptReady(sessionB, 'bravo'));
+
+    expect(sessions[0]?.acceptTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: sessionA, text: 'alpha' }),
     );
-    expect(sidecarConnection.startSession.mock.calls[0]?.[0]).not.toHaveProperty('useGpu');
+    expect(sessions[1]?.acceptTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: sessionB, text: 'bravo' }),
+    );
+    expect(controller.getState()).toBe('listening');
   });
 
-  it('includes llmPostprocess in the session snapshot for per-utterance cleanup', async () => {
+  it('silently enforces the five-session active plus draining cap', async () => {
     const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      getSettings: () =>
-        createSettings({
-          llmFeaturesEnabled: true,
-          llmPostprocessMode: 'per_utterance',
-          llmPostprocessModel: ' llama3.2:latest ',
-          llmPostprocessShowRawBelow: true,
-          llmPostprocessPrompt: 'Clean it.',
-          selectedModel: createExternalModelSelection(),
-        }),
-      sidecarConnection,
-    });
+    const controller = createController({ sidecarConnection });
 
-    await controller.startDictation();
-
-    expect(sidecarConnection.startSession.mock.calls[0]?.[0]).toMatchObject({
-      llmPostprocess: {
-        keepAlive: '30m',
-        model: 'llama3.2:latest',
-        prompt: 'Clean it.',
-        showRawBelow: true,
-        temperature: 0.2,
-      },
-    });
-  });
-
-  it('applies per-preset minWords and temperature overrides to the snapshot', async () => {
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      getSettings: () =>
-        createSettings({
-          llmFeaturesEnabled: true,
-          llmPostprocessActivePresetRef: 'user:translate',
-          llmPostprocessMode: 'per_utterance',
-          llmPostprocessModel: 'llama3.2:latest',
-          llmPostprocessPrompt: 'Translate.',
-          llmPostprocessSkipMinWords: 4,
-          llmPostprocessTemperature: 0.2,
-          llmPostprocessUserPresets: [
-            {
-              description: '',
-              id: 'translate',
-              label: 'Translate',
-              minWords: 0,
-              prompt: 'Translate.',
-              temperature: 0.7,
-            },
-          ],
-          selectedModel: createExternalModelSelection(),
-        }),
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-
-    expect(sidecarConnection.startSession.mock.calls[0]?.[0]).toMatchObject({
-      llmPostprocess: {
-        skipMinWords: 0,
-        temperature: 0.7,
-      },
-    });
-  });
-
-  it.each([
-    'off',
-    'batch',
-  ] as const)('omits llmPostprocess from the sidecar snapshot when mode is %s', async (llmPostprocessMode) => {
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      getSettings: () =>
-        createSettings({
-          llmFeaturesEnabled: true,
-          llmPostprocessMode,
-          llmPostprocessModel: 'llama3.2:latest',
-          selectedModel: createExternalModelSelection(),
-        }),
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-
-    expect(sidecarConnection.startSession.mock.calls[0]?.[0]).not.toHaveProperty('llmPostprocess');
-  });
-
-  it('omits llmPostprocess when LLM features are disabled', async () => {
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      getSettings: () =>
-        createSettings({
-          llmFeaturesEnabled: false,
-          llmPostprocessMode: 'per_utterance',
-          llmPostprocessModel: 'llama3.2:latest',
-          selectedModel: createExternalModelSelection(),
-        }),
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-
-    expect(sidecarConnection.startSession.mock.calls[0]?.[0]).not.toHaveProperty('llmPostprocess');
-  });
-
-  it('includes per-utterance llmPostprocess when timestamps are enabled', async () => {
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      getSettings: () =>
-        createSettings({
-          llmFeaturesEnabled: true,
-          llmPostprocessMode: 'per_utterance',
-          llmPostprocessModel: 'llama3.2:latest',
-          selectedModel: createExternalModelSelection(),
-          timestampsEnabled: true,
-        }),
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-
-    expect(sidecarConnection.startSession.mock.calls[0]?.[0]).toMatchObject({
-      llmPostprocess: {
-        model: 'llama3.2:latest',
-      },
-    });
-  });
-
-  it('recovers from capture startup failures without staying busy', async () => {
-    const captureStream = new FakeCaptureStream();
-    const sidecarConnection = new FakeSidecarConnection();
-    captureStream.start.mockImplementationOnce(async () => {
-      throw new Error('Microphone denied.');
-    });
-    const controller = createController({
-      captureStream,
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-
-    expect(sidecarConnection.startSession).not.toHaveBeenCalled();
-    expect(controller.getState()).toBe('error');
-    expect(controller.isBusy()).toBe(false);
-  });
-
-  it('recovers from session creation failures before starting capture', async () => {
-    const captureStream = new FakeCaptureStream();
-    const notice = vi.fn();
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      captureStream,
-      createSession: () => {
-        throw new Error('No active Markdown editor is available.');
-      },
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      notice,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-
-    expect(captureStream.start).not.toHaveBeenCalled();
-    expect(sidecarConnection.startSession).not.toHaveBeenCalled();
-    expect(controller.getState()).toBe('error');
-    expect(controller.isBusy()).toBe(false);
-    expect(notice.mock.calls[0]?.[0]).toContain('No active Markdown editor is available.');
-  });
-
-  it('recovers from sidecar start failures without staying busy', async () => {
-    const captureStream = new FakeCaptureStream();
-    const session = new FakeSession();
-    const sidecarConnection = new FakeSidecarConnection();
-    sidecarConnection.startSession.mockImplementationOnce(async () => {
-      throw new Error('Sidecar refused session.');
-    });
-    const controller = createController({
-      captureStream,
-      createSession: () => session,
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-
-    expect(captureStream.stop).toHaveBeenCalledTimes(1);
-    expect(session.dispose).toHaveBeenCalled();
-    expect(controller.getState()).toBe('error');
-    expect(controller.isBusy()).toBe(false);
-  });
-
-  it('prompts install when the sidecar is not installed and suppresses the error notice', async () => {
-    const captureStream = new FakeCaptureStream();
-    const notice = vi.fn();
-    const onSidecarMissing = vi.fn();
-    const sidecarConnection = new FakeSidecarConnection();
-    sidecarConnection.ensureStarted.mockImplementationOnce(async () => {
-      throw new SidecarNotInstalledError('Sidecar executable was not found in ...');
-    });
-    const controller = createController({
-      captureStream,
-      getSettings: () => createSettings({ selectedModel: null }),
-      notice,
-      onSidecarMissing,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-
-    expect(onSidecarMissing).toHaveBeenCalledTimes(1);
-    expect(notice).not.toHaveBeenCalled();
-    expect(captureStream.start).not.toHaveBeenCalled();
-    expect(sidecarConnection.startSession).not.toHaveBeenCalled();
-    expect(controller.isBusy()).toBe(false);
-  });
-
-  it('does not call onSidecarMissing for generic sidecar errors', async () => {
-    const notice = vi.fn();
-    const onSidecarMissing = vi.fn();
-    const sidecarConnection = new FakeSidecarConnection();
-    sidecarConnection.startSession.mockImplementationOnce(async () => {
-      throw new Error('Sidecar refused session.');
-    });
-    const controller = createController({
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      notice,
-      onSidecarMissing,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-
-    expect(onSidecarMissing).not.toHaveBeenCalled();
-    expect(notice).toHaveBeenCalledTimes(1);
-    expect(notice.mock.calls[0]?.[0]).toContain('Failed to start the dictation session');
-  });
-
-  it('surfaces a generic error when the sidecar pre-check fails non-sentinel', async () => {
-    const notice = vi.fn();
-    const onSidecarMissing = vi.fn();
-    const sidecarConnection = new FakeSidecarConnection();
-    sidecarConnection.ensureStarted.mockImplementationOnce(async () => {
-      throw new Error('Sidecar path override does not exist');
-    });
-    const controller = createController({
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      notice,
-      onSidecarMissing,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-
-    expect(onSidecarMissing).not.toHaveBeenCalled();
-    expect(sidecarConnection.startSession).not.toHaveBeenCalled();
-    expect(notice).toHaveBeenCalledTimes(1);
-    expect(notice.mock.calls[0]?.[0]).toContain('Failed to start the dictation session');
-  });
-
-  it('handles startup error events through the rejected startSession call only once', async () => {
-    const captureStream = new FakeCaptureStream();
-    const notice = vi.fn();
-    const sidecarConnection = new FakeSidecarConnection();
-    sidecarConnection.startSession.mockImplementationOnce(async (payload) => {
-      sidecarConnection.emit({
-        code: 'vad_init_failed',
-        details: 'Failed to initialize the bundled Silero VAD.',
-        message: 'Failed to initialize the bundled Silero VAD.',
-        type: 'error',
-      });
-      throw new Error(`Failed to initialize start session ${payload.sessionId}.`);
-    });
-    const controller = createController({
-      captureStream,
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      notice,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-
-    expect(sidecarConnection.cancelSession).not.toHaveBeenCalled();
-    expect(captureStream.stop).toHaveBeenCalledTimes(1);
-    expect(controller.getState()).toBe('error');
-    expect(controller.isBusy()).toBe(false);
-    expect(notice).toHaveBeenCalledTimes(1);
-    expect(notice.mock.calls[0]?.[0]).toContain('Failed to start the dictation session');
-  });
-
-  it('keeps transcript_ready from cancelling a pending state timer', async () => {
-    vi.useFakeTimers();
-    try {
-      const session = new FakeSession();
-      const sidecarConnection = new FakeSidecarConnection();
-      const controller = createController({
-        createSession: () => session,
-        getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-        sidecarConnection,
-      });
-
+    for (let index = 0; index < 5; index += 1) {
       await controller.startDictation();
-      const sessionId = sidecarConnection.lastSessionId ?? 'session-1';
-
-      sidecarConnection.emit({
-        sessionId,
-        state: 'speech_detected',
-        type: 'session_state_changed',
-      });
-      vi.advanceTimersByTime(1000);
-      sidecarConnection.emit({ sessionId, state: 'transcribing', type: 'session_state_changed' });
-      vi.advanceTimersByTime(1000);
-      sidecarConnection.emit(
-        transcriptReadyEvent({
-          processingDurationMs: 200,
-          sessionId,
-          text: 'hello',
-          utteranceDurationMs: 500,
-          utteranceId: 'utt-anchor',
-        }),
-      );
-      vi.advanceTimersByTime(499);
-
-      vi.advanceTimersByTime(1);
-      expect(controller.getState()).toBe('transcribing');
-      expect(session.modeCalls.at(-1)).toBe('visible');
-    } finally {
-      vi.useRealTimers();
+      await controller.stopDictation();
     }
+
+    await controller.startDictation();
+
+    expect(sidecarConnection.startSession).toHaveBeenCalledTimes(5);
   });
 
-  it('cancels the visible-anchor timer when the session settles before the threshold', async () => {
-    vi.useFakeTimers();
-    try {
-      const session = new FakeSession();
-      const sidecarConnection = new FakeSidecarConnection();
-      const controller = createController({
-        createSession: () => session,
-        getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-        sidecarConnection,
-      });
-
-      await controller.startDictation();
-      const sessionId = sidecarConnection.lastSessionId ?? 'session-1';
-
-      sidecarConnection.emit({
-        sessionId,
-        state: 'speech_detected',
-        type: 'session_state_changed',
-      });
-      vi.advanceTimersByTime(1000);
-      sidecarConnection.emit({ sessionId, state: 'transcribing', type: 'session_state_changed' });
-      vi.advanceTimersByTime(1000);
-      sidecarConnection.emit({ sessionId, state: 'listening', type: 'session_state_changed' });
-      vi.advanceTimersByTime(5000);
-
-      expect(controller.getState()).toBe('listening');
-      expect(session.modeCalls).toEqual(['hidden', 'hidden']);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('creates the session with configured placement and renderer options', async () => {
+  it('runs batch cleanup through the sidecar and applies the ready event', async () => {
     const sidecarConnection = new FakeSidecarConnection();
-    const createdSessions: Array<{
-      placement: NotePlacementOptions;
-      rendererOptions: TranscriptRenderOptions;
-      session: FakeSession;
-    }> = [];
+    const sessions: FakeSession[] = [];
     const controller = createController({
-      createSession: ({ placement, rendererOptions }) => {
-        const session = new FakeSession();
-        createdSessions.push({ placement, rendererOptions, session });
-        return session;
+      createSession: (session) => {
+        sessions.push(session);
       },
       getSettings: () =>
         createSettings({
-          dictationAnchor: 'end_of_note',
+          llmFeaturesEnabled: true,
+          llmPostprocessMode: 'batch',
+          llmPostprocessModel: 'llama3.2:latest',
           selectedModel: createExternalModelSelection(),
-          timestampClock: 'wallclock',
-          timestampDensity: 'every_utterance',
-          timestampsEnabled: true,
-          timestampSessionHeader: false,
-          timestampSparseIntervalMs: 60_000,
-          transcriptFormatting: 'new_paragraph',
         }),
       sidecarConnection,
     });
 
     await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    sidecarConnection.emit(transcriptReady(sessionId, 'raw transcript'));
+    await controller.stopDictation();
+    sidecarConnection.emit({ reason: 'user_stop', sessionId, type: 'session_stopped' });
 
-    expect(createdSessions.map((entry) => entry.placement)).toEqual([{ anchor: 'end_of_note' }]);
-    expect(createdSessions.map((entry) => entry.rendererOptions)).toEqual([
-      {
-        timestamps: {
-          clock: 'wallclock',
-          density: 'every_utterance',
-          enabled: true,
-          header: false,
-          sessionStartUnixMs: expect.any(Number),
-          sparseIntervalMs: 60_000,
-        },
-        transcriptFormatting: 'new_paragraph',
-      },
-    ]);
-  });
-
-  it('delegates normalized transcripts to the active session', async () => {
-    const session = new FakeSession();
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      createSession: () => session,
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-
-    sidecarConnection.emit(
-      transcriptReadyEvent({
-        pauseMsBeforeUtterance: 1250,
-        sessionId: sidecarConnection.lastSessionId ?? 'session-1',
-        text: 'hello obsidian',
-        utteranceId: 'utt-from-sidecar',
-      }),
-    );
-
-    expect(session.acceptTranscript).toHaveBeenCalledWith(
+    expect(sidecarConnection.requestBatchCleanup).toHaveBeenCalledWith(
       expect.objectContaining({
-        isFinal: true,
-        pauseMsBeforeUtterance: 1250,
-        revision: 0,
-        sessionId: sidecarConnection.lastSessionId,
-        text: 'hello obsidian',
-        utteranceId: 'utt-from-sidecar',
+        sessionId,
+        transcriptText: 'raw transcript',
       }),
     );
-  });
-
-  it('replies to context_request with note glossary wrapped as a context window', async () => {
-    const session = new FakeSession();
-    session.readNoteGlossary.mockReturnValueOnce({ text: 'prior text', truncated: false });
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      createSession: () => session,
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    const sessionId = sidecarConnection.lastSessionId ?? 'session-1';
 
     sidecarConnection.emit({
-      budgetChars: 384,
-      correlationId: 'corr-1',
+      cleanText: 'Clean transcript.',
+      rawText: 'raw transcript',
       sessionId,
-      type: 'context_request',
-      utteranceId: 'utt-next',
+      stageResults: [],
+      type: 'batch_cleanup_ready',
     });
 
-    expect(session.readNoteGlossary).toHaveBeenCalledWith(384);
-    const expected: ContextWindow = {
-      budgetChars: 384,
-      sources: [{ kind: 'note_glossary', text: 'prior text', truncated: false }],
-      text: 'prior text',
-      truncated: false,
-    };
-    expect(sidecarConnection.sendContextResponse).toHaveBeenCalledWith('corr-1', expected);
+    expect(sessions[0]?.replaceSessionRangeWithCleaned).toHaveBeenCalledWith(
+      'Clean transcript.',
+      expect.objectContaining({ rawTextForCallout: 'raw transcript' }),
+    );
+    expect(sessions[0]?.dispose).toHaveBeenCalledTimes(1);
   });
 
-  it('replies with null when the session returns no note context', async () => {
-    const session = new FakeSession();
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      createSession: () => session,
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    const sessionId = sidecarConnection.lastSessionId ?? 'session-1';
-
-    sidecarConnection.emit({
-      budgetChars: 384,
-      correlationId: 'corr-empty',
-      sessionId,
-      type: 'context_request',
-      utteranceId: 'utt-first',
-    });
-
-    expect(sidecarConnection.sendContextResponse).toHaveBeenCalledWith('corr-empty', null);
-  });
-
-  it('replies with null when useNoteAsContext is disabled, without consulting the session', async () => {
-    const session = new FakeSession();
-    session.readNoteGlossary.mockReturnValueOnce({ text: 'should be ignored', truncated: false });
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      createSession: () => session,
-      getSettings: () =>
-        createSettings({
-          selectedModel: createExternalModelSelection(),
-          useNoteAsContext: false,
-        }),
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    const sessionId = sidecarConnection.lastSessionId ?? 'session-1';
-
-    sidecarConnection.emit({
-      budgetChars: 384,
-      correlationId: 'corr-off',
-      sessionId,
-      type: 'context_request',
-      utteranceId: 'utt-off',
-    });
-
-    expect(session.readNoteGlossary).not.toHaveBeenCalled();
-    expect(sidecarConnection.sendContextResponse).toHaveBeenCalledWith('corr-off', null);
-  });
-
-  it('uses the start snapshot for context policy across context_request events', async () => {
-    const session = new FakeSession();
-    session.readNoteGlossary.mockReturnValue({ text: 'note text', truncated: false });
-    const sidecarConnection = new FakeSidecarConnection();
-    let useNoteAsContext = true;
-    const controller = createController({
-      createSession: () => session,
-      getSettings: () =>
-        createSettings({
-          selectedModel: createExternalModelSelection(),
-          useNoteAsContext,
-        }),
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    const sessionId = sidecarConnection.lastSessionId ?? 'session-1';
-
-    sidecarConnection.emit({
-      budgetChars: 384,
-      correlationId: 'corr-on',
-      sessionId,
-      type: 'context_request',
-      utteranceId: 'utt-on',
-    });
-
-    useNoteAsContext = false;
-
-    sidecarConnection.emit({
-      budgetChars: 384,
-      correlationId: 'corr-off',
-      sessionId,
-      type: 'context_request',
-      utteranceId: 'utt-off',
-    });
-
-    expect(sidecarConnection.sendContextResponse).toHaveBeenNthCalledWith(1, 'corr-on', {
-      budgetChars: 384,
-      sources: [{ kind: 'note_glossary', text: 'note text', truncated: false }],
-      text: 'note text',
-      truncated: false,
-    });
-    expect(sidecarConnection.sendContextResponse).toHaveBeenNthCalledWith(2, 'corr-off', {
-      budgetChars: 384,
-      sources: [{ kind: 'note_glossary', text: 'note text', truncated: false }],
-      text: 'note text',
-      truncated: false,
-    });
-  });
-
-  it('ignores context_request for an unrelated session', async () => {
-    const session = new FakeSession();
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      createSession: () => session,
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-
-    sidecarConnection.emit({
-      budgetChars: 384,
-      correlationId: 'corr-stale',
-      sessionId: 'session-from-elsewhere',
-      type: 'context_request',
-      utteranceId: 'utt-foreign',
-    });
-
-    expect(session.readNoteGlossary).not.toHaveBeenCalled();
-    expect(sidecarConnection.sendContextResponse).not.toHaveBeenCalled();
-  });
-
-  it('silently discards an empty transcript and continues the session', async () => {
+  it('cleans up silently when the sidecar rejects capacity as a backstop', async () => {
+    const captureStream = new FakeCaptureStream();
+    const logger = new FakeLogger();
     const notice = vi.fn();
     const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      notice,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-
-    sidecarConnection.emit(
-      transcriptReadyEvent({
-        sessionId: sidecarConnection.lastSessionId ?? 'session-1',
-        text: '   ',
-        utteranceId: 'utt-empty',
-      }),
-    );
-
-    await vi.waitFor(() => {
-      expect(notice).not.toHaveBeenCalled();
-      expect(sidecarConnection.cancelSession).not.toHaveBeenCalled();
-      expect(controller.getState()).not.toBe('error');
-    });
-  });
-
-  it('keeps the session alive while stop drains in-flight transcripts', async () => {
-    const captureStream = new FakeCaptureStream();
-    const session = new FakeSession();
-    const sidecarConnection = new FakeSidecarConnection();
-    sidecarConnection.stopSession.mockImplementationOnce(async (sessionId: string) => ({
-      reason: 'user_stop',
-      sessionId,
-      type: 'session_stopped',
-    }));
+    const sessions: FakeSession[] = [];
     const controller = createController({
       captureStream,
-      createSession: () => session,
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
+      createSession: (session) => {
+        sessions.push(session);
+      },
+      logger,
+      notice,
       sidecarConnection,
     });
 
     await controller.startDictation();
-    const sessionId = sidecarConnection.lastSessionId ?? 'session-1';
-    await controller.stopDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
 
-    sidecarConnection.emit(
-      transcriptReadyEvent({
-        sessionId,
-        text: 'drained transcript',
-        utteranceId: 'utt-drained',
-      }),
-    );
+    sidecarConnection.emit({
+      code: 'session_capacity_exceeded',
+      message: 'capacity exceeded',
+      sessionId,
+      type: 'error',
+    });
+    await Promise.resolve();
+    await Promise.resolve();
 
+    expect(notice).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
     expect(captureStream.stop).toHaveBeenCalledTimes(1);
-    expect(session.acceptTranscript).toHaveBeenCalledWith(
-      expect.objectContaining({ text: 'drained transcript' }),
-    );
-    expect(session.dispose).not.toHaveBeenCalled();
-
-    sidecarConnection.emit({
-      reason: 'user_stop',
-      sessionId,
-      type: 'session_stopped',
-    });
-
-    await vi.waitFor(() => {
-      expect(session.dispose).toHaveBeenCalled();
-    });
+    expect(sessions[0]?.dispose).toHaveBeenCalledTimes(1);
+    expect(controller.getState()).toBe('idle');
   });
 
-  it('runs batch cleanup on session_stopped with the active prompt and composed user message', async () => {
-    const ollamaClient = new FakeOllamaClient();
-    const session = new FakeSession();
-    session.currentSessionText = 'edited dictated text';
-    session.rawSessionText = 'original dictated text';
-    session.readNoteText.mockReturnValue({ text: 'note context', truncated: false });
+  it('handles stop during a pending start without opening capture', async () => {
+    const captureStream = new FakeCaptureStream();
     const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      createSession: () => session,
-      getSettings: () =>
-        createSettings({
-          llmFeaturesEnabled: true,
-          llmPostprocessMode: 'batch',
-          llmPostprocessModel: 'llama3.2:latest',
-          llmPostprocessPrompt: 'Clean the session.',
-          llmPostprocessShowRawBelow: true,
-          selectedModel: createExternalModelSelection(),
-          useLlmNoteContext: true,
-        }),
-      ollamaClient,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    await controller.stopDictation();
-
-    await vi.waitFor(() => {
-      expect(ollamaClient.cleanup).toHaveBeenCalledTimes(1);
-    });
-    expect(ollamaClient.cleanup).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model: 'llama3.2:latest',
-        prompt: 'Clean the session.',
-        temperature: 0.2,
-        userMessage: expect.stringContaining('<session_transcript>\nedited dictated text'),
-      }),
-    );
-    expect(ollamaClient.cleanup.mock.calls[0]?.[0].userMessage).toContain(
-      '<note_context>\nnote context',
-    );
-    expect(session.replaceSessionRangeWithCleaned).toHaveBeenCalledWith('Cleaned transcript.', {
-      rawTextForCallout: 'edited dictated text',
-      showRawBelow: true,
-    });
-    expect(session.markSessionRangeAsProcessing).toHaveBeenCalledTimes(1);
-    expect(session.clearSessionProcessingMark).toHaveBeenCalledTimes(1);
-    expect(
-      session.markSessionRangeAsProcessing.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
-    ).toBeLessThan(ollamaClient.cleanup.mock.invocationCallOrder[0] ?? 0);
-    expect(session.clearSessionProcessingMark.mock.invocationCallOrder[0] ?? 0).toBeGreaterThan(
-      ollamaClient.cleanup.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
-    );
-  });
-
-  it('omits note context from the batch cleanup message when useLlmNoteContext is off', async () => {
-    const ollamaClient = new FakeOllamaClient();
-    const session = new FakeSession();
-    session.currentSessionText = 'dictated text';
-    session.readNoteText.mockReturnValue({ text: 'note context', truncated: false });
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      createSession: () => session,
-      getSettings: () =>
-        createSettings({
-          llmFeaturesEnabled: true,
-          llmPostprocessMode: 'batch',
-          llmPostprocessModel: 'llama3.2:latest',
-          llmPostprocessPrompt: 'Clean the session.',
-          selectedModel: createExternalModelSelection(),
-          useLlmNoteContext: false,
-        }),
-      ollamaClient,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    await controller.stopDictation();
-
-    await vi.waitFor(() => {
-      expect(ollamaClient.cleanup).toHaveBeenCalledTimes(1);
-    });
-    expect(session.readNoteText).not.toHaveBeenCalled();
-    expect(ollamaClient.cleanup.mock.calls[0]?.[0].userMessage).toContain(
-      '<note_context>\n\n</note_context>',
-    );
-  });
-
-  it('omits the note_text source from the per-utterance context window when useLlmNoteContext is off', async () => {
-    const session = new FakeSession();
-    session.readNoteText.mockReturnValue({ text: 'should be ignored', truncated: false });
-    session.readPriorUtterances.mockReturnValue([{ text: 'earlier line', truncated: false }]);
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      createSession: () => session,
-      getSettings: () =>
-        createSettings({
-          llmFeaturesEnabled: true,
-          llmPostprocessMode: 'per_utterance',
-          llmPostprocessModel: 'llama3.2:latest',
-          selectedModel: createExternalModelSelection(),
-          useLlmNoteContext: false,
-          useNoteAsContext: false,
-        }),
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    const sessionId = sidecarConnection.lastSessionId ?? 'session-1';
-
-    sidecarConnection.emit({
-      budgetChars: 384,
-      correlationId: 'corr-llm-off',
-      sessionId,
-      type: 'context_request',
-      utteranceId: 'utt-llm-off',
-    });
-
-    expect(session.readNoteText).not.toHaveBeenCalled();
-    const response = sidecarConnection.sendContextResponse.mock.calls[0]?.[1] as ContextWindow;
-    expect(response).not.toBeNull();
-    expect(response.sources.some((source) => source.kind === 'note_text')).toBe(false);
-    expect(response.sources.some((source) => source.kind === 'prior_utterance')).toBe(true);
-  });
-
-  it('logs a missing Ollama model instead of showing a cleanup notice', async () => {
-    const logger = new FakeLogger();
-    const notice = vi.fn();
-    const ollamaClient = new FakeOllamaClient();
-    const session = new FakeSession();
-    session.rawSessionText = 'raw dictated text';
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      createSession: () => session,
-      getSettings: () =>
-        createSettings({
-          llmFeaturesEnabled: true,
-          llmPostprocessMode: 'batch',
-          llmPostprocessModel: '',
-          selectedModel: createExternalModelSelection(),
-        }),
-      logger,
-      notice,
-      ollamaClient,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    await controller.stopDictation();
-
-    await vi.waitFor(() => {
-      expect(logger.debug).toHaveBeenCalledWith(
-        'llm',
-        'batch cleanup skipped: no Ollama model selected',
-      );
-    });
-    expect(notice).not.toHaveBeenCalled();
-    expect(ollamaClient.cleanup).not.toHaveBeenCalled();
-    expect(session.replaceSessionRangeWithCleaned).not.toHaveBeenCalled();
-  });
-
-  it('logs an empty transcript instead of showing a cleanup notice', async () => {
-    const logger = new FakeLogger();
-    const notice = vi.fn();
-    const ollamaClient = new FakeOllamaClient();
-    const session = new FakeSession();
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      createSession: () => session,
-      getSettings: () =>
-        createSettings({
-          llmFeaturesEnabled: true,
-          llmPostprocessMode: 'batch',
-          llmPostprocessModel: 'llama3.2:latest',
-          selectedModel: createExternalModelSelection(),
-        }),
-      logger,
-      notice,
-      ollamaClient,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    await controller.stopDictation();
-
-    await vi.waitFor(() => {
-      expect(logger.debug).toHaveBeenCalledWith('llm', 'batch cleanup skipped: no transcript text');
-    });
-    expect(notice).not.toHaveBeenCalled();
-    expect(ollamaClient.cleanup).not.toHaveBeenCalled();
-    expect(session.replaceSessionRangeWithCleaned).not.toHaveBeenCalled();
-  });
-
-  it('keeps raw text and logs when batch cleanup returns empty output', async () => {
-    const logger = new FakeLogger();
-    const notice = vi.fn();
-    const ollamaClient = new FakeOllamaClient();
-    ollamaClient.cleanup.mockResolvedValueOnce('');
-    const session = new FakeSession();
-    session.rawSessionText = 'raw dictated text';
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      createSession: () => session,
-      getSettings: () =>
-        createSettings({
-          llmFeaturesEnabled: true,
-          llmPostprocessMode: 'batch',
-          llmPostprocessModel: 'llama3.2:latest',
-          selectedModel: createExternalModelSelection(),
-        }),
-      logger,
-      notice,
-      ollamaClient,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    await controller.stopDictation();
-
-    await vi.waitFor(() => {
-      expect(logger.debug).toHaveBeenCalledWith('llm', 'batch cleanup returned empty text');
-    });
-    expect(notice).not.toHaveBeenCalled();
-    expect(session.replaceSessionRangeWithCleaned).not.toHaveBeenCalled();
-  });
-
-  it('keeps raw text and logs when batch replacement cannot rewrite the range', async () => {
-    const logger = new FakeLogger();
-    const notice = vi.fn();
-    const session = new FakeSession();
-    session.rawSessionText = 'raw dictated text';
-    session.replaceSessionRangeWithCleaned.mockReturnValue(false);
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      createSession: () => session,
-      getSettings: () =>
-        createSettings({
-          llmFeaturesEnabled: true,
-          llmPostprocessMode: 'batch',
-          llmPostprocessModel: 'llama3.2:latest',
-          selectedModel: createExternalModelSelection(),
-        }),
-      logger,
-      notice,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    await controller.stopDictation();
-
-    await vi.waitFor(() => {
-      expect(logger.warn).toHaveBeenCalledWith(
-        'llm',
-        'batch cleanup replacement skipped — session range no longer available',
-      );
-    });
-    expect(notice).not.toHaveBeenCalled();
-  });
-
-  it('keeps raw text and logs when batch cleanup fails', async () => {
-    const logger = new FakeLogger();
-    const notice = vi.fn();
-    const ollamaClient = new FakeOllamaClient();
-    ollamaClient.cleanup.mockRejectedValueOnce(new Error('Ollama failed'));
-    const session = new FakeSession();
-    session.rawSessionText = 'raw dictated text';
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      createSession: () => session,
-      getSettings: () =>
-        createSettings({
-          llmFeaturesEnabled: true,
-          llmPostprocessMode: 'batch',
-          llmPostprocessModel: 'llama3.2:latest',
-          selectedModel: createExternalModelSelection(),
-        }),
-      logger,
-      notice,
-      ollamaClient,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    await controller.stopDictation();
-
-    await vi.waitFor(() => {
-      expect(logger.warn).toHaveBeenCalledWith(
-        'llm',
-        'batch cleanup failed; raw transcript kept: Ollama failed',
-        expect.any(Error),
-      );
-    });
-    expect(notice).not.toHaveBeenCalled();
-    expect(session.replaceSessionRangeWithCleaned).not.toHaveBeenCalled();
-    expect(session.markSessionRangeAsProcessing).toHaveBeenCalledTimes(1);
-    expect(session.clearSessionProcessingMark).toHaveBeenCalledTimes(1);
-  });
-
-  it('aborts in-flight batch cleanup when cancel is requested after sidecar stop', async () => {
-    const cleanupState: { signal: AbortSignal | null } = { signal: null };
-    const ollamaClient = new FakeOllamaClient();
-    ollamaClient.cleanup.mockImplementationOnce(
-      async ({ abortSignal }) =>
-        await new Promise<string>((_resolve, reject) => {
-          cleanupState.signal = abortSignal ?? null;
-          abortSignal?.addEventListener('abort', () => {
-            reject(new Error('aborted'));
+    const resolveStart: {
+      current?: (value: Awaited<ReturnType<FakeSidecarConnection['startSession']>>) => void;
+    } = {};
+    sidecarConnection.startSession.mockImplementationOnce(
+      (payload: Omit<StartSessionCommand, 'type'>) =>
+        new Promise((resolve) => {
+          resolveStart.current = resolve;
+          sidecarConnection.emit({
+            mode: payload.mode,
+            sessionId: payload.sessionId,
+            type: 'session_started',
           });
         }),
     );
-    const session = new FakeSession();
-    session.rawSessionText = 'raw dictated text';
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      createSession: () => session,
-      getSettings: () =>
-        createSettings({
-          llmFeaturesEnabled: true,
-          llmPostprocessMode: 'batch',
-          llmPostprocessModel: 'llama3.2:latest',
-          selectedModel: createExternalModelSelection(),
-        }),
-      ollamaClient,
-      sidecarConnection,
-    });
+    const controller = createController({ captureStream, sidecarConnection });
 
-    await controller.startDictation();
-    await controller.stopDictation();
-    await vi.waitFor(() => {
-      expect(ollamaClient.cleanup).toHaveBeenCalledTimes(1);
-    });
-
-    await controller.cancelDictation();
-
-    expect(cleanupState.signal?.aborted).toBe(true);
-    await vi.waitFor(() => {
-      expect(session.dispose).toHaveBeenCalled();
-    });
-  });
-
-  it('disposes the session when the sidecar stops regardless of reason', async () => {
-    const session = new FakeSession();
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      createSession: () => session,
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    const sessionId = sidecarConnection.lastSessionId ?? 'session-1';
-
-    sidecarConnection.emit({
-      reason: 'timeout',
-      sessionId,
-      type: 'session_stopped',
-    });
-
-    await vi.waitFor(() => {
-      expect(session.dispose).toHaveBeenCalled();
-    });
-  });
-
-  it('requests graceful stop when the active session reports locked-note close', async () => {
-    const captureStream = new FakeCaptureStream();
-    const notice = vi.fn();
-    let onLockedNoteClosed: () => void = () => {
-      throw new Error('Expected session callbacks to be captured.');
-    };
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      captureStream,
-      createSession: (options) => {
-        onLockedNoteClosed = options.callbacks.onLockedNoteClosed;
-        return new FakeSession();
-      },
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      notice,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    onLockedNoteClosed();
-
-    await vi.waitFor(() => {
-      expect(sidecarConnection.stopSession).toHaveBeenCalledTimes(1);
-    });
-    expect(notice).toHaveBeenCalledWith('Dictation stopped — locked note was closed');
-    expect(captureStream.stop).toHaveBeenCalledTimes(1);
-  });
-
-  it('requests cancel when the active session reports locked-note delete', async () => {
-    const notice = vi.fn();
-    let onLockedNoteDeleted: () => void = () => {
-      throw new Error('Expected session callbacks to be captured.');
-    };
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      createSession: (options) => {
-        onLockedNoteDeleted = options.callbacks.onLockedNoteDeleted;
-        return new FakeSession();
-      },
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      notice,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    onLockedNoteDeleted();
-
-    await vi.waitFor(() => {
-      expect(sidecarConnection.cancelSession).toHaveBeenCalledTimes(1);
-    });
-    expect(notice).toHaveBeenCalledWith('Dictation cancelled — locked note was deleted');
-  });
-
-  it('stops local capture even when stopSession fails', async () => {
-    const captureStream = new FakeCaptureStream();
-    const sidecarConnection = new FakeSidecarConnection();
-    sidecarConnection.stopSession.mockImplementationOnce(async () => {
-      throw new Error('stop failed');
-    });
-    const controller = createController({
-      captureStream,
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
+    const startPromise = controller.startDictation();
+    await Promise.resolve();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
     await controller.stopDictation();
 
-    expect(captureStream.stop).toHaveBeenCalledTimes(1);
-    expect(controller.getState()).toBe('error');
-    expect(controller.isBusy()).toBe(false);
-  });
+    const completeStart = resolveStart.current;
+    if (completeStart === undefined) {
+      throw new Error('startSession promise was not captured');
+    }
+    completeStart({ mode: 'always_on', sessionId, type: 'session_started' });
+    await startPromise;
 
-  it('toggles from idle to an active dictation session', async () => {
-    const captureStream = new FakeCaptureStream();
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      captureStream,
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      sidecarConnection,
-    });
-
-    await controller.toggleDictation();
-
-    expect(captureStream.start).toHaveBeenCalledTimes(1);
-    expect(sidecarConnection.startSession).toHaveBeenCalledTimes(1);
-    expect(controller.getState()).toBe('listening');
-  });
-
-  it('toggles an active dictation session to graceful stop', async () => {
-    const captureStream = new FakeCaptureStream();
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      captureStream,
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    await controller.toggleDictation();
-
-    expect(captureStream.stop).toHaveBeenCalledTimes(1);
-    expect(sidecarConnection.stopSession).toHaveBeenCalledTimes(1);
-    expect(sidecarConnection.cancelSession).not.toHaveBeenCalled();
+    expect(sidecarConnection.requestStopSession).toHaveBeenCalledWith(sessionId);
+    expect(captureStream.start).not.toHaveBeenCalled();
     expect(controller.getState()).toBe('idle');
-  });
-
-  it('ignores a rapid second toggle while a start is still in flight', async () => {
-    const captureStream = new FakeCaptureStream();
-    const sidecarConnection = new FakeSidecarConnection();
-    let releaseEnsureStarted: () => void = () => {
-      throw new Error('Expected ensureStarted resolver to be captured.');
-    };
-    sidecarConnection.ensureStarted.mockImplementationOnce(
-      async () =>
-        await new Promise<void>((resolve) => {
-          releaseEnsureStarted = resolve;
-        }),
-    );
-    const controller = createController({
-      captureStream,
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      sidecarConnection,
-    });
-
-    const firstToggle = controller.toggleDictation();
-    expect(controller.getState()).toBe('starting');
-
-    await controller.toggleDictation();
-
-    releaseEnsureStarted();
-    await firstToggle;
-
-    expect(captureStream.start).toHaveBeenCalledTimes(1);
-    expect(sidecarConnection.startSession).toHaveBeenCalledTimes(1);
-    expect(controller.getState()).toBe('listening');
-  });
-
-  it('toggles an inactive error state back to idle without restarting', async () => {
-    const captureStream = new FakeCaptureStream();
-    const sidecarConnection = new FakeSidecarConnection();
-    sidecarConnection.cancelSession.mockImplementationOnce(async () => {
-      throw new Error('cancel failed');
-    });
-    const controller = createController({
-      captureStream,
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    sidecarConnection.emit({
-      code: 'session_failed',
-      message: 'The engine crashed.',
-      sessionId: sidecarConnection.lastSessionId ?? 'session-1',
-      type: 'error',
-    });
-
-    await vi.waitFor(() => {
-      expect(captureStream.stop).toHaveBeenCalledTimes(1);
-      expect(controller.getState()).toBe('error');
-      expect(controller.isBusy()).toBe(false);
-    });
-
-    await controller.toggleDictation();
-
-    expect(controller.getState()).toBe('idle');
-    expect(sidecarConnection.startSession).toHaveBeenCalledTimes(1);
-  });
-
-  it('cancels an errored session only once when duplicate errors arrive', async () => {
-    const sidecarConnection = new FakeSidecarConnection();
-    let resolveCancel: () => void = () => {
-      throw new Error('Expected cancel resolver to be captured.');
-    };
-    sidecarConnection.cancelSession.mockImplementationOnce(
-      async (sessionId: string) =>
-        await new Promise((resolve) => {
-          resolveCancel = () => {
-            sidecarConnection.emit({
-              reason: 'user_cancel',
-              sessionId,
-              type: 'session_stopped',
-            });
-            resolve({
-              reason: 'user_cancel',
-              sessionId,
-              type: 'session_stopped',
-            });
-          };
-        }),
-    );
-    const controller = createController({
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-
-    const sessionId = sidecarConnection.lastSessionId ?? 'session-1';
-    sidecarConnection.emit({
-      code: 'session_failed',
-      message: 'The engine crashed.',
-
-      sessionId,
-      type: 'error',
-    });
-    sidecarConnection.emit({
-      code: 'session_failed',
-      message: 'The engine crashed again.',
-      sessionId,
-      type: 'error',
-    });
-
-    await vi.waitFor(() => {
-      expect(sidecarConnection.cancelSession).toHaveBeenCalledTimes(1);
-    });
-
-    resolveCancel();
-
-    await vi.waitFor(() => {
-      expect(controller.getState()).toBe('idle');
-    });
-  });
-
-  it('updates the ribbon tier when the queue advances and the session state is unchanged', async () => {
-    const setRibbonQueueTier = vi.fn();
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      setRibbonQueueTier,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    const sessionId = sidecarConnection.lastSessionId ?? 'session-1';
-    setRibbonQueueTier.mockClear();
-
-    sidecarConnection.emit({
-      queuedUtterances: 3,
-      sessionId,
-      tier: 'catching_up',
-      type: 'transcription_queue_changed',
-    });
-
-    expect(setRibbonQueueTier).toHaveBeenCalledTimes(1);
-    expect(setRibbonQueueTier).toHaveBeenLastCalledWith('catching_up');
-    expect(controller.getState()).toBe('listening');
-  });
-
-  it('emits the falling-behind notice exactly once per tier entry', async () => {
-    const notice = vi.fn();
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      notice,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    const sessionId = sidecarConnection.lastSessionId ?? 'session-1';
-    notice.mockClear();
-
-    sidecarConnection.emit({
-      queuedUtterances: 10,
-      sessionId,
-      tier: 'falling_behind',
-      type: 'transcription_queue_changed',
-    });
-    sidecarConnection.emit({
-      queuedUtterances: 12,
-      sessionId,
-      tier: 'falling_behind',
-      type: 'transcription_queue_changed',
-    });
-
-    const fallingBehindCalls = notice.mock.calls.filter(
-      ([message]) => typeof message === 'string' && message.includes('falling behind'),
-    );
-    expect(fallingBehindCalls).toHaveLength(1);
-  });
-
-  it('suppresses the falling-behind notice when recovering from saturated', async () => {
-    const notice = vi.fn();
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      notice,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    const sessionId = sidecarConnection.lastSessionId ?? 'session-1';
-    notice.mockClear();
-
-    sidecarConnection.emit({
-      queuedUtterances: 30,
-      sessionId,
-      tier: 'saturated',
-      type: 'transcription_queue_changed',
-    });
-    sidecarConnection.emit({
-      queuedUtterances: 29,
-      sessionId,
-      tier: 'falling_behind',
-      type: 'transcription_queue_changed',
-    });
-
-    const fallingBehindCalls = notice.mock.calls.filter(
-      ([message]) => typeof message === 'string' && message.includes('falling behind'),
-    );
-    expect(fallingBehindCalls).toHaveLength(0);
-  });
-
-  it('ignores transcription_queue_changed events for an unrelated session', async () => {
-    const setRibbonQueueTier = vi.fn();
-    const notice = vi.fn();
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      notice,
-      setRibbonQueueTier,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    setRibbonQueueTier.mockClear();
-    notice.mockClear();
-
-    sidecarConnection.emit({
-      queuedUtterances: 10,
-      sessionId: 'session-other',
-      tier: 'falling_behind',
-      type: 'transcription_queue_changed',
-    });
-
-    expect(setRibbonQueueTier).not.toHaveBeenCalled();
-    expect(notice).not.toHaveBeenCalled();
-  });
-
-  it('treats queue_overload like any other session_stopped reason', async () => {
-    const session = new FakeSession();
-    const setRibbonQueueTier = vi.fn();
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      createSession: () => session,
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      setRibbonQueueTier,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    const sessionId = sidecarConnection.lastSessionId ?? 'session-1';
-
-    sidecarConnection.emit({
-      queuedUtterances: 30,
-      sessionId,
-      tier: 'saturated',
-      type: 'transcription_queue_changed',
-    });
-    sidecarConnection.emit({
-      reason: 'queue_overload',
-      sessionId,
-      type: 'session_stopped',
-    });
-
-    await vi.waitFor(() => {
-      expect(session.dispose).toHaveBeenCalled();
-      expect(controller.getState()).toBe('idle');
-    });
-    expect(setRibbonQueueTier).toHaveBeenLastCalledWith('normal');
-  });
-
-  it.each([
-    { reason: 'user_stop' as const },
-    { reason: 'user_cancel' as const },
-    { reason: 'timeout' as const },
-    { reason: 'session_replaced' as const },
-  ])('resets the ribbon tier to normal on session_stopped reason=$reason', async ({ reason }) => {
-    const session = new FakeSession();
-    const setRibbonQueueTier = vi.fn();
-    const sidecarConnection = new FakeSidecarConnection();
-    const controller = createController({
-      createSession: () => session,
-      getSettings: () => createSettings({ selectedModel: createExternalModelSelection() }),
-      setRibbonQueueTier,
-      sidecarConnection,
-    });
-
-    await controller.startDictation();
-    const sessionId = sidecarConnection.lastSessionId ?? 'session-1';
-
-    sidecarConnection.emit({
-      queuedUtterances: 5,
-      sessionId,
-      tier: 'catching_up',
-      type: 'transcription_queue_changed',
-    });
-    expect(setRibbonQueueTier).toHaveBeenLastCalledWith('catching_up');
-
-    sidecarConnection.emit({
-      reason,
-      sessionId,
-      type: 'session_stopped',
-    });
-
-    await vi.waitFor(() => {
-      expect(controller.getState()).toBe('idle');
-    });
-    expect(setRibbonQueueTier).toHaveBeenLastCalledWith('normal');
   });
 });
 
-function createController(overrides: {
+function createController({
+  captureStream = new FakeCaptureStream(),
+  createSession,
+  getSettings = () => createSettings({ selectedModel: createExternalModelSelection() }),
+  logger = new FakeLogger(),
+  notice = vi.fn(),
+  sidecarConnection = new FakeSidecarConnection(),
+}: {
   captureStream?: FakeCaptureStream;
-  createSession?: (options: {
-    callbacks: {
-      onLockedNoteClosed: () => void;
-      onLockedNoteDeleted: () => void;
-    };
-    placement: NotePlacementOptions;
-    rendererOptions: TranscriptRenderOptions;
-    sessionId: string;
-  }) => FakeSession;
+  createSession?: (session: FakeSession) => void;
   getSettings?: () => PluginSettings;
   logger?: FakeLogger;
-  notice?: ReturnType<typeof vi.fn>;
-  ollamaClient?: FakeOllamaClient;
-  onSidecarMissing?: () => void;
-  setRibbonQueueTier?: (tier: QueueBackpressureTier) => void;
-  setRibbonState?: (state: DictationControllerState) => void;
+  notice?: (message: string) => void;
   sidecarConnection?: FakeSidecarConnection;
-}): DictationSessionController {
+} = {}): DictationSessionController {
   return new DictationSessionController({
-    captureStream: overrides.captureStream ?? new FakeCaptureStream(),
-    createSession: overrides.createSession ?? (() => new FakeSession()),
-    getSettings: overrides.getSettings ?? (() => createSettings({})),
-    ...(overrides.logger ? { logger: overrides.logger } : {}),
-    notice: overrides.notice ?? (() => {}),
-    ollamaClient: overrides.ollamaClient ?? new FakeOllamaClient(),
-    ...(overrides.onSidecarMissing ? { onSidecarMissing: overrides.onSidecarMissing } : {}),
-    setRibbonQueueTier: overrides.setRibbonQueueTier ?? (() => {}),
-    setRibbonState: overrides.setRibbonState ?? (() => {}),
-    sidecarConnection: overrides.sidecarConnection ?? new FakeSidecarConnection(),
+    captureStream,
+    createSession: (_options: {
+      callbacks: {
+        onLockedNoteClosed: () => void;
+        onLockedNoteDeleted: () => void;
+      };
+      placement: NotePlacementOptions;
+      rendererOptions: TranscriptRenderOptions;
+      sessionId: string;
+    }) => {
+      const session = new FakeSession();
+      createSession?.(session);
+      return session;
+    },
+    getSettings,
+    logger,
+    notice,
+    onModelMissing: vi.fn(),
+    onSidecarMissing: vi.fn(),
+    setRibbonQueueTier: vi.fn((_tier: QueueBackpressureTier) => {}),
+    setRibbonState: vi.fn((_state: DictationControllerState) => {}),
+    sidecarConnection,
   });
 }
 
-function createSettings(overrides: Partial<PluginSettings>): PluginSettings {
+function createSettings(overrides: Partial<PluginSettings> = {}): PluginSettings {
   return {
     ...DEFAULT_PLUGIN_SETTINGS,
     ...overrides,
   };
 }
 
-function okEngineStage(durationMs: number): TranscriptRevision['stageResults'][number] {
+function createExternalModelSelection(): NonNullable<PluginSettings['selectedModel']> {
   return {
-    durationMs,
-    isFinal: true,
-    revisionIn: 0,
-    revisionOut: 0,
-    stageId: 'engine',
-    status: { kind: 'ok' },
+    familyId: 'whisper',
+    filePath: '/tmp/model.bin',
+    kind: 'external_file',
+    runtimeId: 'whisper_cpp',
   };
 }
 
-function transcriptReadyEvent(args: {
-  pauseMsBeforeUtterance?: number | null;
-  processingDurationMs?: number;
-  sessionId: string;
-  text: string;
-  utteranceDurationMs?: number;
-  utteranceId: string;
-}): Extract<SidecarEvent, { type: 'transcript_ready' }> {
-  const processingDurationMs = args.processingDurationMs ?? 75;
+function transcriptReady(sessionId: string, text: string): SidecarEvent {
   return {
     isFinal: true,
     llmPostprocessRawText: null,
-    pauseMsBeforeUtterance: args.pauseMsBeforeUtterance ?? null,
-    processingDurationMs,
+    pauseMsBeforeUtterance: null,
+    processingDurationMs: 12,
     revision: 0,
     segments: [],
-    sessionId: args.sessionId,
-    stageResults: [okEngineStage(processingDurationMs)],
-    text: args.text,
+    sessionId,
+    stageResults: [],
+    text,
     type: 'transcript_ready',
-    utteranceDurationMs: args.utteranceDurationMs ?? 700,
-    utteranceEndMsInSession: 700,
+    utteranceDurationMs: 1000,
+    utteranceEndMsInSession: 1000,
+    utteranceId: crypto.randomUUID(),
     utteranceIndex: 0,
     utteranceStartMsInSession: 0,
-    utteranceId: args.utteranceId,
     warnings: [],
-  };
-}
-
-function createExternalModelSelection() {
-  return {
-    familyId: 'whisper' as const,
-    filePath: '/tmp/ggml-small.en-q5_1.bin',
-    kind: 'external_file' as const,
-    runtimeId: 'whisper_cpp' as const,
   };
 }

--- a/test/note-surface.test.ts
+++ b/test/note-surface.test.ts
@@ -44,6 +44,7 @@ function renderOptions(overrides: Partial<TranscriptRenderOptions> = {}): Transc
 }
 
 class FakeEditorView {
+  public lastUpdate: ViewUpdate | null = null;
   public state: EditorState;
 
   constructor(doc: string, selectionHead: number, extensions: Extension = []) {
@@ -55,19 +56,27 @@ class FakeEditorView {
   }
 
   dispatch(spec: TransactionSpec): void {
-    this.state = this.state.update(spec).state;
+    const transaction = this.state.update(spec);
+    this.state = transaction.state;
+    this.lastUpdate = {
+      changes: transaction.changes,
+      docChanged: transaction.docChanged,
+      transactions: [transaction],
+      view: this,
+    } as unknown as ViewUpdate;
   }
 
   apply(spec: TransactionSpec): ViewUpdate {
     const transaction = this.state.update(spec);
     this.state = transaction.state;
 
-    return {
+    this.lastUpdate = {
       changes: transaction.changes,
       docChanged: transaction.docChanged,
       transactions: [transaction],
       view: this,
     } as unknown as ViewUpdate;
+    return this.lastUpdate;
   }
 }
 
@@ -128,6 +137,42 @@ function doc(view: FakeEditorView): string {
 }
 
 describe('NoteSurface', () => {
+  it('keeps same-cursor sessions ordered when the later session writes first', () => {
+    const view = new FakeEditorView('', 0);
+    const earlier = new NoteSurface(view as unknown as EditorView, { anchor: 'at_cursor' });
+    const later = new NoteSurface(view as unknown as EditorView, { anchor: 'at_cursor' });
+
+    expect(append(later, 'later', 'B').kind).toBe('appended');
+    if (view.lastUpdate === null) {
+      throw new Error('later append should produce an update');
+    }
+    earlier.observeTransaction(view.lastUpdate);
+
+    expect(append(earlier, 'earlier', 'A').kind).toBe('appended');
+    if (view.lastUpdate === null) {
+      throw new Error('earlier append should produce an update');
+    }
+    later.observeTransaction(view.lastUpdate);
+
+    expect(doc(view)).toBe('AB');
+  });
+
+  it('keeps same-cursor sessions ordered when the earlier session writes first', () => {
+    const view = new FakeEditorView('', 0);
+    const earlier = new NoteSurface(view as unknown as EditorView, { anchor: 'at_cursor' });
+    const later = new NoteSurface(view as unknown as EditorView, { anchor: 'at_cursor' });
+
+    expect(append(earlier, 'earlier', 'A').kind).toBe('appended');
+    if (view.lastUpdate === null) {
+      throw new Error('earlier append should produce an update');
+    }
+    later.observeTransaction(view.lastUpdate);
+
+    expect(append(later, 'later', 'B').kind).toBe('appended');
+
+    expect(doc(view)).toBe('A B');
+  });
+
   it('extends the writing-region tail past user text typed at the initial anchor before any utterance', () => {
     const { surface, view } = createSurface();
 

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -3,20 +3,29 @@ import { describe, expect, it } from 'vitest';
 import { PCM_BYTES_PER_FRAME } from '../src/shared/pcm-format';
 import {
   AUDIO_FRAME_KIND,
+  bytesToSessionId,
   type ContextWindow,
+  createCancelSessionCommand,
   createContextResponseCommand,
   createGetSystemInfoCommand,
   createHealthCommand,
+  createRunBatchCleanupCommand,
   createStartSessionCommand,
+  createStopSessionCommand,
+  decodeAudioFrameEnvelope,
   encodeAudioFrame,
   encodeJsonFrame,
   FRAME_HEADER_LENGTH,
   FramedMessageParser,
   JSON_FRAME_KIND,
   parseEventFrame,
+  SESSION_ID_BYTES,
+  sessionIdToBytes,
 } from '../src/sidecar/protocol';
 
 describe('sidecar protocol', () => {
+  const SESSION_ID = '123e4567-e89b-42d3-a456-426614174000';
+
   it('serializes JSON commands with the framed header', () => {
     const frame = encodeJsonFrame(createHealthCommand());
 
@@ -28,10 +37,21 @@ describe('sidecar protocol', () => {
 
   it('serializes audio frames with the expected byte size', () => {
     const payload = new Uint8Array(PCM_BYTES_PER_FRAME).fill(7);
-    const frame = encodeAudioFrame(payload);
+    const frame = encodeAudioFrame(SESSION_ID, payload);
 
     expect(frame[0]).toBe(AUDIO_FRAME_KIND);
-    expect(frame.byteLength).toBe(5 + PCM_BYTES_PER_FRAME);
+    expect(frame.byteLength).toBe(5 + SESSION_ID_BYTES + PCM_BYTES_PER_FRAME);
+    expect(decodeAudioFrameEnvelope(frame.slice(FRAME_HEADER_LENGTH))).toEqual({
+      frameBytes: payload,
+      sessionId: SESSION_ID,
+    });
+  });
+
+  it('round-trips UUID session ids through raw bytes', () => {
+    expect(bytesToSessionId(sessionIdToBytes(SESSION_ID))).toBe(SESSION_ID);
+    expect(() => sessionIdToBytes('session-not-a-uuid')).toThrow(
+      'Session id must be a UUID v4 string',
+    );
   });
 
   it('serializes start_session command with accelerationPreference', () => {
@@ -97,6 +117,43 @@ describe('sidecar protocol', () => {
         totalContextCap: 7000,
       },
       type: 'start_session',
+    });
+  });
+
+  it('serializes session-addressed stop, cancel, and batch cleanup commands', () => {
+    expect(readPayload(encodeJsonFrame(createStopSessionCommand(SESSION_ID)))).toEqual({
+      sessionId: SESSION_ID,
+      type: 'stop_session',
+    });
+    expect(readPayload(encodeJsonFrame(createCancelSessionCommand(SESSION_ID)))).toEqual({
+      sessionId: SESSION_ID,
+      type: 'cancel_session',
+    });
+    expect(
+      readPayload(
+        encodeJsonFrame(
+          createRunBatchCleanupCommand({
+            config: {
+              keepAlive: '30m',
+              model: 'llama3.2:latest',
+              noteContextChars: 100,
+              priorUtterancesN: 0,
+              prompt: 'Clean it.',
+              showRawBelow: false,
+              skipMinWords: 0,
+              temperature: 0.2,
+              totalContextCap: 100,
+            },
+            noteContext: null,
+            sessionId: SESSION_ID,
+            transcriptText: 'raw',
+          }),
+        ),
+      ),
+    ).toMatchObject({
+      sessionId: SESSION_ID,
+      transcriptText: 'raw',
+      type: 'run_batch_cleanup',
     });
   });
 
@@ -266,7 +323,7 @@ describe('sidecar protocol', () => {
   });
 
   it('rejects wrong-size payload in encodeAudioFrame', () => {
-    expect(() => encodeAudioFrame(new Uint8Array(1))).toThrow(
+    expect(() => encodeAudioFrame(SESSION_ID, new Uint8Array(1))).toThrow(
       `Audio frames must be ${PCM_BYTES_PER_FRAME} bytes, received 1.`,
     );
   });
@@ -597,7 +654,7 @@ describe('sidecar protocol', () => {
       utteranceId: 'utt-1',
       warnings: [],
     });
-    const audioFrame = encodeAudioFrame(new Uint8Array(PCM_BYTES_PER_FRAME).fill(3));
+    const audioFrame = encodeAudioFrame(SESSION_ID, new Uint8Array(PCM_BYTES_PER_FRAME).fill(3));
     const combined = new Uint8Array(transcriptFrame.byteLength + audioFrame.byteLength);
 
     combined.set(transcriptFrame, 0);
@@ -630,7 +687,11 @@ describe('sidecar protocol', () => {
       },
       kind: JSON_FRAME_KIND,
     });
-    expect(frames[1]?.kind).toBe(AUDIO_FRAME_KIND);
+    expect(frames[1]).toEqual({
+      frameBytes: new Uint8Array(PCM_BYTES_PER_FRAME).fill(3),
+      kind: AUDIO_FRAME_KIND,
+      sessionId: SESSION_ID,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Replace single-session sidecar routing with session-keyed native app state and session-addressed audio/stop/cancel protocol.
- Refactor the worker to hold multiple per-session model instances while preserving one FIFO compute queue, including native-side batch LLM cleanup.
- Rewrite the JS controller around active/draining session entries, fire-and-forget stop, session-tagged capture, decoupled ribbon state, and multi-surface note anchoring.
- Refresh protocol/controller/note-surface tests for UUID audio envelopes, multi-session lifecycle, capacity handling, batch cleanup, and same-cursor ordering.

## Verification
- npm run check
