### PR TITLE
refactor(audio): centralize PCM channel mixing

### DIFF
--- a/src/audio/pcm-frame-processor.ts
+++ b/src/audio/pcm-frame-processor.ts
@@ -77,6 +77,34 @@ export class PcmFrameProcessor {
     return completedFrames;
   }
 
+  pushChannels(inputChannels: Float32Array[]): Int16Array[] {
+    if (inputChannels.length === 0) {
+      return [];
+    }
+
+    const firstChannel = inputChannels[0];
+    if (firstChannel === undefined) {
+      return [];
+    }
+
+    if (inputChannels.length === 1) {
+      return this.push(firstChannel);
+    }
+
+    const sampleCount = firstChannel.length;
+    const monoSamples = new Float32Array(sampleCount);
+
+    for (let sampleIndex = 0; sampleIndex < sampleCount; sampleIndex += 1) {
+      let sum = 0;
+      for (const channel of inputChannels) {
+        sum += channel[sampleIndex] ?? 0;
+      }
+      monoSamples[sampleIndex] = sum / inputChannels.length;
+    }
+
+    return this.push(monoSamples);
+  }
+
   reset(): void {
     this.frameBuffer.fill(0);
     this.frameOffset = 0;
@@ -85,33 +113,6 @@ export class PcmFrameProcessor {
     this.previousSample = null;
     this.previousSamplePosition = 0;
   }
-}
-
-export function mixChannelsToMono(inputChannels: Float32Array[]): Float32Array {
-  if (inputChannels.length === 0) {
-    return new Float32Array(0);
-  }
-
-  if (inputChannels.length === 1) {
-    const firstChannel = inputChannels[0];
-
-    return firstChannel === undefined ? new Float32Array(0) : new Float32Array(firstChannel);
-  }
-
-  const sampleCount = inputChannels[0]?.length ?? 0;
-  const output = new Float32Array(sampleCount);
-
-  for (const channel of inputChannels) {
-    for (let sampleIndex = 0; sampleIndex < sampleCount; sampleIndex += 1) {
-      output[sampleIndex] = (output[sampleIndex] ?? 0) + (channel[sampleIndex] ?? 0);
-    }
-  }
-
-  for (let sampleIndex = 0; sampleIndex < sampleCount; sampleIndex += 1) {
-    output[sampleIndex] = (output[sampleIndex] ?? 0) / inputChannels.length;
-  }
-
-  return output;
 }
 
 export function clearChannels(channels: Float32Array[] | undefined): void {

--- a/src/audio/pcm-recorder.worklet.ts
+++ b/src/audio/pcm-recorder.worklet.ts
@@ -1,5 +1,5 @@
 import { PCM_SAMPLE_RATE_HZ, PCM_SAMPLES_PER_FRAME } from '../shared/pcm-format';
-import { clearChannels, mixChannelsToMono, PcmFrameProcessor } from './pcm-frame-processor';
+import { clearChannels, PcmFrameProcessor } from './pcm-frame-processor';
 import { PCM_RECORDER_WORKLET_NAME } from './pcm-recorder-worklet-shared';
 
 declare abstract class AudioWorkletProcessor {
@@ -46,9 +46,7 @@ class PcmRecorderProcessor extends AudioWorkletProcessor {
       return true;
     }
 
-    const monoChunk = mixChannelsToMono(inputChannels);
-
-    for (const frame of this.frameProcessor.push(monoChunk)) {
+    for (const frame of this.frameProcessor.pushChannels(inputChannels)) {
       this.port.postMessage(frame.buffer, [frame.buffer]);
     }
 

--- a/test/pcm-frame-processor.test.ts
+++ b/test/pcm-frame-processor.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { PcmFrameProcessor } from '../src/audio/pcm-frame-processor';
+
+describe('PcmFrameProcessor', () => {
+  it('mixes input channels and emits complete PCM frames', () => {
+    const processor = new PcmFrameProcessor({
+      samplesPerFrame: 2,
+      sourceSampleRate: 16_000,
+      targetSampleRate: 16_000,
+    });
+
+    const frames = processor.pushChannels([
+      new Float32Array([0.5, -0.5]),
+      new Float32Array([1, -1]),
+    ]);
+
+    expect(frames).toHaveLength(1);
+    expect(Array.from(frames[0] ?? [])).toEqual([24_575, -24_576]);
+  });
+
+  it('returns no frames when no input channels are present', () => {
+    const processor = new PcmFrameProcessor({
+      samplesPerFrame: 2,
+      sourceSampleRate: 16_000,
+      targetSampleRate: 16_000,
+    });
+
+    expect(processor.pushChannels([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Moves channel mixing responsibility into PcmFrameProcessor
- Simplifies the AudioWorklet to pass input channels directly into the processor
- Adds focused tests for channel mixing and empty input behavior

## TypeScript impact
- Production audio TypeScript is essentially flat by line count, but the worklet owns less audio-processing logic
- Adds focused coverage for the audio processor boundary

## Verification
- npm run typecheck
- npm run lint
- npm test