### PR TITLE
fix(sidecar): make shutdown drain waiters

### DIFF
--- a/src/sidecar/sidecar-connection.ts
+++ b/src/sidecar/sidecar-connection.ts
@@ -237,16 +237,12 @@ export class SidecarConnection {
     );
   }
 
-  async cancelModelInstall(installId: string): Promise<void> {
+  cancelModelInstall(installId: string): void {
     if (!this.process.isRunning()) {
       return;
     }
 
-    try {
-      this.process.write(encodeJsonFrame(createCancelModelInstallCommand(installId)));
-    } catch (error) {
-      throw asError(error, 'Failed to write sidecar command: cancel_model_install');
-    }
+    this.process.write(encodeJsonFrame(createCancelModelInstallCommand(installId)));
   }
 
   async startSession(

--- a/src/sidecar/sidecar-connection.ts
+++ b/src/sidecar/sidecar-connection.ts
@@ -15,7 +15,6 @@ import {
   createProbeModelSelectionCommand,
   createRemoveModelCommand,
   createRunBatchCleanupCommand,
-  createShutdownCommand,
   createStartSessionCommand,
   createStopSessionCommand,
   type ErrorEvent,
@@ -239,7 +238,15 @@ export class SidecarConnection {
   }
 
   async cancelModelInstall(installId: string): Promise<void> {
-    await this.sendCommand(createCancelModelInstallCommand(installId));
+    if (!this.process.isRunning()) {
+      return;
+    }
+
+    try {
+      this.process.write(encodeJsonFrame(createCancelModelInstallCommand(installId)));
+    } catch (error) {
+      throw asError(error, 'Failed to write sidecar command: cancel_model_install');
+    }
   }
 
   async startSession(
@@ -298,11 +305,12 @@ export class SidecarConnection {
     }
 
     this.expectedStop = true;
-    try {
-      this.process.write(encodeJsonFrame(createShutdownCommand()));
-    } finally {
-      await this.process.stop();
-    }
+    this.rejectPendingWaiters(new Error('Sidecar is shutting down.'));
+
+    // Stdin EOF is the shutdown signal. Avoid writing the redundant wire-level
+    // shutdown command immediately before closing stdin; Node write() only
+    // guarantees buffering, not that bytes flushed to the OS pipe.
+    await this.process.stop();
   }
 
   sendAudioFrame(sessionId: string, frameBytes: Uint8Array): void {
@@ -359,16 +367,6 @@ export class SidecarConnection {
         reject(asError(error, `Failed to write sidecar command: ${command.type}`));
       }
     });
-  }
-
-  private async sendCommand(command: SidecarCommand): Promise<void> {
-    await this.ensureStarted();
-
-    try {
-      this.process.write(encodeJsonFrame(command));
-    } catch (error) {
-      throw asError(error, `Failed to write sidecar command: ${command.type}`);
-    }
   }
 
   private createPendingWaiter(

--- a/test/sidecar-connection.test.ts
+++ b/test/sidecar-connection.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   type ErrorEvent,
   encodeJsonFrame,
+  type HealthOkEvent,
   type ModelInstallUpdateEvent,
   type SidecarEvent,
   type WarningEvent,
@@ -32,6 +33,9 @@ class FakeSidecarProcess {
   }
 
   async start(): Promise<void> {
+    if (this.running) {
+      return;
+    }
     this.startCalls += 1;
     this.running = true;
   }
@@ -107,6 +111,15 @@ function errorEvent(overrides: Partial<ErrorEvent> = {}): ErrorEvent {
     code: 'invalid_frame',
     message: 'invalid frame',
     type: 'error',
+    ...overrides,
+  };
+}
+
+function healthOkEvent(overrides: Partial<HealthOkEvent> = {}): HealthOkEvent {
+  return {
+    sidecarVersion: '0.0.0-test',
+    status: 'ready',
+    type: 'health_ok',
     ...overrides,
   };
 }
@@ -201,5 +214,50 @@ describe('SidecarConnection', () => {
       message: 'Invalid frame (bad length)',
       name: 'SidecarError',
     } satisfies Partial<SidecarError>);
+  });
+
+  it('drains waiters during shutdown without writing a wire-level shutdown command', async () => {
+    const { connection, process } = createHarness();
+
+    const resultPromise = connection.healthCheck();
+    const assertion = expect(resultPromise).rejects.toThrow('Sidecar is shutting down.');
+    await flushMicrotasks();
+    expect(process.writtenFrames).toHaveLength(1);
+
+    await connection.shutdown();
+
+    await assertion;
+    expect(process.stopCalls).toBe(1);
+    expect(process.writtenFrames).toHaveLength(1);
+  });
+
+  it('keeps restart waiter cleanup isolated from the new process', async () => {
+    const { connection, process } = createHarness();
+
+    const stalePromise = connection.getSystemInfo();
+    const staleAssertion = expect(stalePromise).rejects.toThrow('Sidecar is shutting down.');
+    await flushMicrotasks();
+    expect(process.writtenFrames).toHaveLength(1);
+
+    const restartPromise = connection.restart();
+    await vi.waitFor(() => expect(process.writtenFrames).toHaveLength(2));
+    process.deliver(healthOkEvent());
+
+    await expect(restartPromise).resolves.toMatchObject({
+      status: 'ready',
+      type: 'health_ok',
+    });
+    await staleAssertion;
+    expect(process.startCalls).toBe(2);
+    expect(process.stopCalls).toBe(1);
+  });
+
+  it('does not start the sidecar just to cancel a stale model install', async () => {
+    const { connection, process } = createHarness();
+
+    await connection.cancelModelInstall('install-1');
+
+    expect(process.startCalls).toBe(0);
+    expect(process.writtenFrames).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

This PR tightens the TypeScript sidecar lifecycle path so shutdown and restart cannot leave stale waiters attached to the next process, and so shutdown no longer races a buffered wire command against immediate stdin close.

## What changed

**Shutdown uses stdin EOF only.** `SidecarConnection.shutdown()` no longer writes the redundant wire-level `shutdown` command immediately before closing stdin. The Rust side already treats stdin EOF as a clean shutdown signal, and dropping the extra frame avoids relying on Node's `write()` buffering semantics right before `stdin.end()`.

**Pending waiters drain before stop.** Shutdown now rejects all pending waiters with `Sidecar is shutting down.` before stopping the process. That makes restart behavior deterministic: old requests cannot survive long enough to be resolved or rejected by events from the replacement process.

**Stale model-install cancel is a no-op.** `cancelModelInstall()` no longer calls the auto-starting command path. If the sidecar is already stopped, cancelling an install from the previous process cannot spawn a fresh sidecar just to send a cancel for state that no longer exists.

## Tests added

The `SidecarConnection` fake-process harness now covers:

- shutdown rejects an in-flight waiter and does not write a wire-level `shutdown` frame
- restart rejects the stale waiter while a new `health_ok` resolves against the restarted process
- cancelling a stale model install does not start the sidecar

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` — exits 0; reports the existing Biome schema-version info
- [x] `npm test` — 361/361 with the added shutdown/restart cases
- [x] `npm run build:frontend`