### PR TITLE
fix(native): pin shutdown and stage duration contracts

### DIFF
--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -153,7 +153,7 @@ sequenceDiagram
 | `stop_session` | Graceful stop (drain pending transcriptions) |
 | `cancel_session` | Immediate cancel (discard pending) |
 | `context_response` | Reply to a `context_request` with the plugin-assembled `ContextWindow` (or `null`); correlated by `correlationId` |
-| `shutdown` | Request sidecar exit |
+| `shutdown` | Hard process-level cancel and sidecar exit; call `stop_session` first when final transcripts must drain |
 | `get_model_store` | Query model store path |
 | `list_model_catalog` | Fetch built-in model catalog |
 | `list_installed_models` | List locally installed models |

--- a/native/src/app.rs
+++ b/native/src/app.rs
@@ -28,11 +28,10 @@ use crate::stages::StageEnablement;
 use crate::transcription::GpuConfig;
 use crate::worker::{SessionMetadata, TranscriptionWorker, WorkerCommand, WorkerEvent};
 
-/// Hard cap on waiting utterances behind the active worker item. Reaching
-/// this depth marks the session as `saturated` and triggers an overload
+/// Queue depth that marks a session as `saturated` and triggers an overload
 /// drain (capture stops; queued work finishes; session ends with
 /// `SessionStopReason::QueueOverload`).
-const MAX_QUEUED_UTTERANCES: usize = 30;
+const QUEUE_OVERLOAD_DEPTH: usize = 30;
 // Whisper's `initial_prompt` is hard-capped at 224 tokens (silently truncated
 // to the final 224 — see OpenAI's Whisper Prompting Guide). 384 chars of
 // glossary content (mostly short identifiers) lands comfortably under that
@@ -563,6 +562,9 @@ impl AppState {
 
                 (ControlFlow::Continue, events)
             }
+            // Shutdown is a hard process-level cancel, not a graceful session
+            // drain. Hosts that need final transcripts must stop sessions
+            // first, wait for `session_stopped`, then terminate the process.
             Command::Shutdown => {
                 for (_, active_session) in self.active_sessions.drain() {
                     let _ = active_session.cancel_tx.send(true);
@@ -933,14 +935,14 @@ impl AppState {
         if let Some(active_session) = self.active_sessions.get_mut(&session_id) {
             emit_queue_tier_if_changed(active_session, events);
 
-            if active_session.queued_utterances >= MAX_QUEUED_UTTERANCES
+            if active_session.queued_utterances >= QUEUE_OVERLOAD_DEPTH
                 && !active_session.overload_draining
             {
                 active_session.overload_draining = true;
                 events.push(Event::Error {
                     code: "utterance_queue_overload".to_string(),
                     details: Some(format!(
-                        "queue depth reached saturation at {MAX_QUEUED_UTTERANCES}"
+                        "queue depth reached saturation at {QUEUE_OVERLOAD_DEPTH}"
                     )),
                     message: "Local Dictation stopped because the transcription backlog reached capacity. Already accepted utterances will finish processing.".to_string(),
                     session_id: Some(session_id),
@@ -2234,6 +2236,36 @@ mod tests {
             active.pending_context_requests.len(),
             31,
             "all accepted utterances should still be tracked through their context flow"
+        );
+    }
+
+    #[test]
+    fn shutdown_hard_cancels_sessions_and_ignores_late_worker_output() {
+        let model_file_path = create_model_file();
+        let mut app = test_app();
+        let _ = app.handle_command(start_session_command("session-1", &model_file_path));
+        let _ = enqueue_n_utterances(&mut app, 1);
+
+        let (control_flow, shutdown_events) = app.handle_command(Command::Shutdown);
+        assert_eq!(control_flow, ControlFlow::Shutdown);
+        assert!(
+            shutdown_events.is_empty(),
+            "shutdown is a hard cancel and must not emit graceful stop events"
+        );
+        assert!(
+            !app.active_sessions.contains_key("session-1"),
+            "shutdown must drop active sessions immediately"
+        );
+
+        let mut late_events = Vec::new();
+        app.handle_worker_event(
+            fake_worker_transcript_ready("session-1", None),
+            &mut late_events,
+        );
+
+        assert!(
+            late_events.is_empty(),
+            "late worker output after shutdown must be ignored"
         );
     }
 

--- a/native/src/stages/mod.rs
+++ b/native/src/stages/mod.rs
@@ -179,17 +179,15 @@ pub fn run_post_engine(
     }
 }
 
-/// Stages emit `durationMs: 0` placeholders in their payload; the loop
-/// overwrites with the measured wall-clock duration after the stage returns.
+/// Object payloads always receive the measured wall-clock duration after the
+/// stage returns. Stages do not need to emit a `durationMs` placeholder.
 fn stage_payload_with_duration(
     payload: Option<serde_json::Value>,
     duration_ms: u64,
 ) -> Option<serde_json::Value> {
     let mut payload = payload?;
 
-    if let serde_json::Value::Object(ref mut object) = payload
-        && object.contains_key("durationMs")
-    {
+    if let serde_json::Value::Object(ref mut object) = payload {
         object.insert("durationMs".to_string(), serde_json::json!(duration_ms));
     }
 
@@ -437,7 +435,13 @@ mod tests {
         assert_eq!(outcome.status, StageStatus::Ok);
         assert_eq!(outcome.revision_in, 0);
         assert_eq!(outcome.revision_out, Some(1));
-        assert_eq!(outcome.payload, Some(json!({ "rule": "test" })));
+        let payload = outcome.payload.as_ref().expect("payload");
+        assert_eq!(payload.get("rule"), Some(&json!("test")));
+        assert!(
+            payload
+                .get("durationMs")
+                .is_some_and(|value| value.is_u64())
+        );
     }
 
     #[test]
@@ -625,7 +629,20 @@ mod tests {
         assert!(
             matches!(&outcome.status, StageStatus::Failed { error } if error.contains("utterance duration"))
         );
-        assert_eq!(outcome.payload, Some(json!({ "tried": "overrun" })));
+        let payload = outcome.payload.as_ref().expect("payload");
+        assert_eq!(payload.get("tried"), Some(&json!("overrun")));
+        assert!(
+            payload
+                .get("durationMs")
+                .is_some_and(|value| value.is_u64())
+        );
+    }
+
+    #[test]
+    fn stage_payload_with_duration_inserts_duration_without_placeholder() {
+        let payload = stage_payload_with_duration(Some(json!({ "rule": "test" })), 42);
+
+        assert_eq!(payload, Some(json!({ "durationMs": 42, "rule": "test" })));
     }
 
     #[test]

--- a/native/src/worker.rs
+++ b/native/src/worker.rs
@@ -625,6 +625,7 @@ mod tests {
             transcript.stage_history[1].payload,
             Some(serde_json::json!({
                 "audioStartMs": voice_activity.audio_start_ms,
+                "durationMs": 0,
                 "voicedMs": voice_activity.voiced_ms,
             }))
         );
@@ -690,7 +691,7 @@ mod tests {
 
         assert_eq!(
             transcript.stage_history[1].payload,
-            Some(serde_json::json!({ "pauseMsBeforeUtterance": 150 }))
+            Some(serde_json::json!({ "durationMs": 0, "pauseMsBeforeUtterance": 150 }))
         );
     }
 
@@ -727,7 +728,10 @@ mod tests {
             .as_ref()
             .expect("processor should emit payload")
             .clone();
-        assert_eq!(payload, serde_json::json!({ "voicedFraction": 0.7_f32 }));
+        assert_eq!(
+            payload,
+            serde_json::json!({ "durationMs": 0, "voicedFraction": 0.7_f32 })
+        );
     }
 
     fn engine_output() -> EngineTranscriptOutput {


### PR DESCRIPTION
## Summary

This PR makes two native-side contracts explicit and test-backed: process shutdown is a hard cancel, and object stage payloads always receive measured duration metadata.

## What changed

**Shutdown contract.** `Command::Shutdown` is documented in code and architecture docs as a hard process-level cancel, not a graceful session drain. Hosts that need final transcripts should stop sessions first, wait for `session_stopped`, then terminate the process.

A new app-state test starts a session, enqueues work, sends `shutdown`, and verifies that active session state is dropped immediately and late worker output is ignored instead of producing a final transcript.

**Queue saturation naming.** The queue threshold constant is renamed from `MAX_QUEUED_UTTERANCES` to `QUEUE_OVERLOAD_DEPTH` to match the existing behavior: reaching that depth marks the session saturated and starts overload drain. This is a naming/docstring alignment only; the threshold and behavior stay the same.

**Stage duration payloads.** The stage runner now inserts `durationMs` into every object payload, even when a stage did not predeclare a placeholder. This removes a fragile stage-authoring requirement and makes duration reporting a runner-level contract. Existing worker/stage tests were updated to assert the new payload shape, and a direct helper test covers payloads without a placeholder.

## Test plan
- [x] `cargo fmt`
- [x] `cargo test` from `native/`
- [x] `npm run check:rust`