### PR TITLE
fix(settings): harden setup state handling

### DIFF
--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -667,6 +667,12 @@ export class DictationSessionController {
     const transcriptText = entry.session.readCurrentSessionText();
 
     if (config === null || transcriptText.length === 0) {
+      if (config !== null) {
+        this.dependencies.logger?.warn(
+          'llm',
+          'batch cleanup skipped: locked note closed before transcript could be read',
+        );
+      }
       this.disposeLocalSession(sessionId);
       return;
     }

--- a/src/settings/plugin-settings.ts
+++ b/src/settings/plugin-settings.ts
@@ -221,8 +221,7 @@ export function resolvePluginSettings(data: unknown): PluginSettings {
       DEFAULT_PLUGIN_SETTINGS.modelStorePathOverride,
     ),
     // Bump `schemaVersion` and add a migration step when renaming a key or changing default semantics.
-    schemaVersion:
-      raw.schemaVersion === 1 ? raw.schemaVersion : DEFAULT_PLUGIN_SETTINGS.schemaVersion,
+    schemaVersion: 1,
     selectedModel: readSelectedModel(raw.selectedModel),
     setupCompletedAt: readSetupCompletedAt(raw.setupCompletedAt),
     sidecarPathOverride: readString(

--- a/src/settings/plugin-settings.ts
+++ b/src/settings/plugin-settings.ts
@@ -94,6 +94,7 @@ export interface PluginSettings {
   llmPostprocessUserPresets: LlmUserPreset[];
   localTranscriptSidebarBootstrapped: boolean;
   modelStorePathOverride: string;
+  schemaVersion: 1;
   selectedModel: SelectedModel | null;
   setupCompletedAt: string | null;
   sidecarPathOverride: string;
@@ -130,6 +131,7 @@ export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
   llmPostprocessUserPresets: [],
   localTranscriptSidebarBootstrapped: false,
   modelStorePathOverride: '',
+  schemaVersion: 1,
   selectedModel: null,
   setupCompletedAt: null,
   sidecarPathOverride: '',
@@ -218,8 +220,11 @@ export function resolvePluginSettings(data: unknown): PluginSettings {
       raw.modelStorePathOverride,
       DEFAULT_PLUGIN_SETTINGS.modelStorePathOverride,
     ),
+    // Bump `schemaVersion` and add a migration step when renaming a key or changing default semantics.
+    schemaVersion:
+      raw.schemaVersion === 1 ? raw.schemaVersion : DEFAULT_PLUGIN_SETTINGS.schemaVersion,
     selectedModel: readSelectedModel(raw.selectedModel),
-    setupCompletedAt: typeof raw.setupCompletedAt === 'string' ? raw.setupCompletedAt : null,
+    setupCompletedAt: readSetupCompletedAt(raw.setupCompletedAt),
     sidecarPathOverride: readString(
       raw.sidecarPathOverride,
       DEFAULT_PLUGIN_SETTINGS.sidecarPathOverride,
@@ -295,6 +300,19 @@ function readBoolean(value: unknown, fallback: boolean): boolean {
 
 function readString(value: unknown, fallback: string): string {
   return typeof value === 'string' ? value.trim() : fallback;
+}
+
+function readSetupCompletedAt(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  return new Date(parsed).toISOString() === value ? value : null;
 }
 
 function readPositiveInteger(value: unknown, fallback: number): number {

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -247,6 +247,44 @@ describe('DictationSessionController', () => {
     expect(sessions[0]?.dispose).toHaveBeenCalledTimes(1);
   });
 
+  it('warns when batch cleanup cannot read transcript text after the note closes', async () => {
+    const logger = new FakeLogger();
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const controller = createController({
+      createSession: (session) => {
+        sessions.push(session);
+      },
+      getSettings: () =>
+        createSettings({
+          llmFeaturesEnabled: true,
+          llmPostprocessMode: 'batch',
+          llmPostprocessModel: 'llama3.2:latest',
+          selectedModel: createExternalModelSelection(),
+        }),
+      logger,
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    sidecarConnection.emit(transcriptReady(sessionId, 'raw transcript'));
+    await controller.stopDictation();
+    const session = sessions[0];
+    if (session === undefined) {
+      throw new Error('expected session fixture');
+    }
+    session.currentSessionText = '';
+    sidecarConnection.emit({ reason: 'user_stop', sessionId, type: 'session_stopped' });
+
+    expect(sidecarConnection.requestBatchCleanup).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'llm',
+      'batch cleanup skipped: locked note closed before transcript could be read',
+    );
+    expect(session.dispose).toHaveBeenCalledTimes(1);
+  });
+
   it('cleans up silently when the sidecar rejects capacity as a backstop', async () => {
     const captureStream = new FakeCaptureStream();
     const logger = new FakeLogger();

--- a/test/plugin-settings.test.ts
+++ b/test/plugin-settings.test.ts
@@ -31,6 +31,10 @@ describe('resolvePluginSettings', () => {
     expect(resolvePluginSettings(undefined)).toEqual(DEFAULT_PLUGIN_SETTINGS);
   });
 
+  it('defaults missing schemaVersion to the current settings schema', () => {
+    expect(resolvePluginSettings({}).schemaVersion).toBe(1);
+  });
+
   it('defaults to visible per-utterance cleanup with the Clean up prompt', () => {
     expect(DEFAULT_PLUGIN_SETTINGS).toMatchObject({
       llmFeaturesEnabled: true,
@@ -158,6 +162,14 @@ describe('resolvePluginSettings', () => {
         useNoteAsContext: 'yes',
       }),
     ).toEqual(DEFAULT_PLUGIN_SETTINGS);
+  });
+
+  it('validates setupCompletedAt as the exact persisted ISO timestamp', () => {
+    const timestamp = '2026-05-22T10:00:00.000Z';
+
+    expect(resolvePluginSettings({ setupCompletedAt: timestamp }).setupCompletedAt).toBe(timestamp);
+    expect(resolvePluginSettings({ setupCompletedAt: 'corrupted' }).setupCompletedAt).toBeNull();
+    expect(resolvePluginSettings({ setupCompletedAt: '2026-05-22' }).setupCompletedAt).toBeNull();
   });
 
   it('clamps LLM postprocess numeric settings at the settings boundary', () => {


### PR DESCRIPTION
## Summary

This PR hardens a few small TypeScript settings/session boundaries: settings now carry an explicit schema version, persisted setup completion timestamps must be valid ISO timestamps, and skipped batch cleanup after a closed note is no longer silent.

## What changed

**Settings schema version.** `PluginSettings` now includes `schemaVersion: 1`, and the resolver defaults missing or unsupported versions back to the current schema. This gives future settings migrations a stable source-of-truth field without introducing migration framework code before it is needed.

**Setup timestamp validation.** `setupCompletedAt` now only survives resolution when it is an exact persisted ISO timestamp. Corrupt strings and loose date-only values resolve to `null`, so malformed settings cannot falsely mark setup as completed.

**Batch cleanup skip warning.** When batch cleanup is configured but the controller cannot read any transcript text at `session_stopped` time, it logs a warning before disposing the local session. This covers the note-closed-before-cleanup path so raw transcript cleanup is not skipped without a diagnostic.

## Tests added

- missing settings data defaults to `schemaVersion: 1`
- valid setup completion ISO timestamp is preserved
- corrupt and loose setup completion strings resolve to `null`
- closed-note batch cleanup skip logs the expected warning and does not call the sidecar cleanup command

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` — exits 0; reports the existing Biome schema-version info
- [x] `npm test` — 356/356 with the added settings/controller coverage
- [x] `npm run build:frontend`