### PR TITLE
test: cover context cap and sidecar reinstall paths

### DIFF
--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -977,7 +977,7 @@ function shouldAppendRawLlmPostprocessCallout(
   );
 }
 
-function enforceLlmContextCap(
+export function enforceLlmContextCap(
   sources: ContextWindowSource[],
   totalContextCap: number,
 ): ContextWindowSource[] {

--- a/test/enforce-llm-context-cap.test.ts
+++ b/test/enforce-llm-context-cap.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { enforceLlmContextCap } from '../src/dictation/dictation-session-controller';
+import type { ContextWindowSource } from '../src/sidecar/protocol';
+
+function source(
+  kind: ContextWindowSource['kind'],
+  text: string,
+  truncated = false,
+): ContextWindowSource {
+  return { kind, text, truncated } as ContextWindowSource;
+}
+
+describe('enforceLlmContextCap', () => {
+  it('leaves sources unchanged when total text already fits the cap', () => {
+    const sources = [
+      source('note_text', 'note'),
+      source('prior_utterance', 'prior'),
+      source('note_glossary', 'term'),
+    ];
+
+    expect(enforceLlmContextCap(sources, 100)).toEqual(sources);
+  });
+
+  it('trims note text first when the cap is exceeded', () => {
+    expect(
+      enforceLlmContextCap([source('note_text', 'abcdef'), source('prior_utterance', 'ghij')], 7),
+    ).toEqual([source('note_text', 'abc', true), source('prior_utterance', 'ghij')]);
+  });
+
+  it('trims prior utterances after note text is exhausted', () => {
+    expect(
+      enforceLlmContextCap([source('note_text', 'abcdef'), source('prior_utterance', 'ghij')], 2),
+    ).toEqual([source('prior_utterance', 'gh', true)]);
+  });
+
+  it('returns no sources when the cap is zero', () => {
+    expect(
+      enforceLlmContextCap(
+        [source('note_glossary', 'terms'), source('prior_utterance', 'prior')],
+        0,
+      ),
+    ).toEqual([]);
+  });
+
+  it('does not mutate the input source array or source objects', () => {
+    const note = source('note_text', 'abcdef');
+    const prior = source('prior_utterance', 'ghij');
+    const sources = [note, prior];
+
+    const capped = enforceLlmContextCap(sources, 7);
+
+    expect(sources).toEqual([source('note_text', 'abcdef'), source('prior_utterance', 'ghij')]);
+    expect(sources[0]).toBe(note);
+    expect(sources[1]).toBe(prior);
+    expect(capped[0]).not.toBe(note);
+  });
+});

--- a/test/sidecar-install-manager.test.ts
+++ b/test/sidecar-install-manager.test.ts
@@ -32,6 +32,18 @@ function defaultInstallOptions() {
   };
 }
 
+function successfulInstallResult(variant: 'cpu' | 'cuda' = 'cpu') {
+  return {
+    manifest: {
+      installedAt: '2026-05-03T00:00:00.000Z',
+      sha256: 'abc',
+      variant,
+      version: '2026.5.16',
+    },
+    variantDirectory: `/plugin/bin/${variant}`,
+  };
+}
+
 describe('SidecarInstallManager', () => {
   it('rejects concurrent installs while one is in flight', () => {
     installSidecarMock.mockImplementationOnce(() => new Promise(() => {}));
@@ -57,15 +69,7 @@ describe('SidecarInstallManager', () => {
   });
 
   it('clears state, invokes the onInstalled hook, and shows the success notice', async () => {
-    installSidecarMock.mockResolvedValueOnce({
-      manifest: {
-        installedAt: '2026-05-03T00:00:00.000Z',
-        sha256: 'abc',
-        variant: 'cpu',
-        version: '2026.5.16',
-      },
-      variantDirectory: '/plugin/bin/cpu',
-    });
+    installSidecarMock.mockResolvedValueOnce(successfulInstallResult());
     const notice = vi.fn();
     const onInstalled = vi.fn(async () => {});
     const manager = new SidecarInstallManager({ notice });
@@ -75,6 +79,39 @@ describe('SidecarInstallManager', () => {
 
     expect(onInstalled).toHaveBeenCalledOnce();
     expect(notice).toHaveBeenCalledWith('Installed.');
+    expect(manager.getState().lastError).toBeNull();
+  });
+
+  it('allows a second install after the first completes successfully', async () => {
+    installSidecarMock
+      .mockResolvedValueOnce(successfulInstallResult('cpu'))
+      .mockResolvedValueOnce(successfulInstallResult('cuda'));
+    const notice = vi.fn();
+    const firstInstalled = vi.fn(async () => {});
+    const secondInstalled = vi.fn(async () => {});
+    const manager = new SidecarInstallManager({ notice });
+
+    manager.install({
+      ...defaultInstallOptions(),
+      onInstalled: firstInstalled,
+      successNotice: 'CPU installed.',
+      variant: 'cpu',
+    });
+    await vi.waitFor(() => expect(manager.getState().activeInstall).toBeNull());
+
+    manager.install({
+      ...defaultInstallOptions(),
+      onInstalled: secondInstalled,
+      successNotice: 'CUDA installed.',
+      variant: 'cuda',
+    });
+    await vi.waitFor(() => expect(manager.getState().activeInstall).toBeNull());
+
+    expect(installSidecarMock).toHaveBeenCalledTimes(2);
+    expect(firstInstalled).toHaveBeenCalledOnce();
+    expect(secondInstalled).toHaveBeenCalledOnce();
+    expect(notice).toHaveBeenNthCalledWith(1, 'CPU installed.');
+    expect(notice).toHaveBeenNthCalledWith(2, 'CUDA installed.');
     expect(manager.getState().lastError).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

This PR adds direct coverage for two small but important state boundaries: LLM context cap enforcement and the sidecar install manager's successful reinstall path.

## What's covered now

**LLM context cap enforcement.** The context cap helper is exported for direct unit tests, and the new tests pin the existing contract:

- sources are unchanged when already under the cap
- `note_text` is trimmed before `prior_utterance`
- prior utterances are trimmed after note text is exhausted
- cap zero returns no sources
- the input source array and source objects are not mutated

**Sidecar reinstall flow.** The sidecar install manager now has a regression test for the successful install → state cleared → second install succeeds path. The test verifies both installs run, each `onInstalled` hook fires, success notices are emitted in order, and `lastError` remains clear.

## Why this matters

The context cap is the only guard keeping LLM context windows within the configured budget, and the reinstall path is where stale `activeInstall` state would show up. Both are small enough to test directly without broader UI setup.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` — exits 0; reports the existing Biome schema-version info
- [x] `npm test` — 359/359 with the new coverage
- [x] `npm run build:frontend`