### PR TITLE
feat(audio): add microphone input device picker

### DIFF
--- a/src/audio/audio-capture-stream.ts
+++ b/src/audio/audio-capture-stream.ts
@@ -147,8 +147,15 @@ export class AudioCaptureStream {
         'saved microphone unavailable; falling back to the default input device',
         error,
       );
+      // Only fire the fallback notice if the retry actually succeeds. If it
+      // also rejects, the outer error path will surface a single "Failed to
+      // start dictation" notice rather than two contradictory ones.
+      const mediaStream = await mediaDevices.getUserMedia({
+        audio: baseConstraints,
+        video: false,
+      });
       this.options.onDeviceFallback?.();
-      return mediaDevices.getUserMedia({ audio: baseConstraints, video: false });
+      return mediaStream;
     }
   }
 

--- a/src/audio/audio-capture-stream.ts
+++ b/src/audio/audio-capture-stream.ts
@@ -9,7 +9,16 @@ type AudioFrameListener = (sessionId: string, frameBytes: Uint8Array) => void;
 
 interface AudioCaptureStreamOptions {
   logger?: PluginLogger;
+  // Invoked when a saved deviceId is unavailable and we transparently fall back
+  // to the OS default. Lets the wiring layer (main.ts) surface a Notice without
+  // pulling Obsidian UI imports into this module.
+  onDeviceFallback?: () => void;
   visualizer?: AudioVisualizerAttachable;
+}
+
+export interface AudioCaptureStartOptions {
+  audioInputDeviceId?: string | null;
+  sessionId: string;
 }
 
 export class AudioCaptureStream {
@@ -26,7 +35,9 @@ export class AudioCaptureStream {
     return this.mediaStream !== null;
   }
 
-  async start(sessionId: string, frameListener: AudioFrameListener): Promise<void> {
+  async start(options: AudioCaptureStartOptions, frameListener: AudioFrameListener): Promise<void> {
+    const { sessionId, audioInputDeviceId } = options;
+
     if (this.isCapturing()) {
       throw new Error('Audio capture is already active.');
     }
@@ -37,15 +48,7 @@ export class AudioCaptureStream {
       throw new Error('Microphone capture is not available in this Obsidian runtime.');
     }
 
-    const mediaStream = await mediaDevices.getUserMedia({
-      audio: {
-        autoGainControl: false,
-        channelCount: PCM_CHANNEL_COUNT,
-        echoCancellation: false,
-        noiseSuppression: false,
-      },
-      video: false,
-    });
+    const mediaStream = await this.requestUserMedia(mediaDevices, audioInputDeviceId);
 
     let audioContext: AudioContext | null = null;
 
@@ -114,6 +117,41 @@ export class AudioCaptureStream {
     this.options.logger?.debug('audio', 'capture stopped');
   }
 
+  private async requestUserMedia(
+    mediaDevices: MediaDevices,
+    audioInputDeviceId: string | null | undefined,
+  ): Promise<MediaStream> {
+    const baseConstraints: MediaTrackConstraints = {
+      autoGainControl: false,
+      channelCount: PCM_CHANNEL_COUNT,
+      echoCancellation: false,
+      noiseSuppression: false,
+    };
+
+    if (typeof audioInputDeviceId !== 'string' || audioInputDeviceId.length === 0) {
+      return mediaDevices.getUserMedia({ audio: baseConstraints, video: false });
+    }
+
+    try {
+      return await mediaDevices.getUserMedia({
+        audio: { ...baseConstraints, deviceId: { exact: audioInputDeviceId } },
+        video: false,
+      });
+    } catch (error) {
+      if (!isDeviceConstraintError(error)) {
+        throw error;
+      }
+
+      this.options.logger?.warn(
+        'audio',
+        'saved microphone unavailable; falling back to the default input device',
+        error,
+      );
+      this.options.onDeviceFallback?.();
+      return mediaDevices.getUserMedia({ audio: baseConstraints, video: false });
+    }
+  }
+
   private async releaseCapture(): Promise<void> {
     const audioContext = this.audioContext;
     const mediaStream = this.mediaStream;
@@ -153,6 +191,19 @@ export class AudioCaptureStream {
       await closeAudioContext(audioContext);
     }
   }
+}
+
+// OverconstrainedError is the spec-defined rejection when `deviceId: { exact }`
+// matches nothing. We only treat that exact case as a "fall back to default"
+// signal — other DOMExceptions (NotAllowed, NotFound, NotReadable) propagate so
+// the existing top-level error path can surface them.
+function isDeviceConstraintError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  const named = error as { constraint?: unknown; name?: unknown };
+  return named.name === 'OverconstrainedError' && named.constraint === 'deviceId';
 }
 
 function getAudioContextConstructor(): typeof AudioContext {

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -262,27 +262,34 @@ export class DictationSessionController {
       }
       entry.phase = 'active';
 
-      await this.dependencies.captureStream.start(sessionId, (frameSessionId, frameBytes) => {
-        if (this.activeSessionId !== frameSessionId) {
-          return;
-        }
+      // Read the saved deviceId at session-start time so a settings change
+      // applies on the next dictation rather than mid-session.
+      const audioInputDeviceId = this.dependencies.getSettings().audioInputDevice?.deviceId ?? null;
 
-        const activeEntry = this.sessions.get(frameSessionId);
-        if (activeEntry === undefined || activeEntry.phase !== 'active') {
-          return;
-        }
+      await this.dependencies.captureStream.start(
+        { sessionId, audioInputDeviceId },
+        (frameSessionId, frameBytes) => {
+          if (this.activeSessionId !== frameSessionId) {
+            return;
+          }
 
-        try {
-          this.dependencies.sidecarConnection.sendAudioFrame(frameSessionId, frameBytes);
-        } catch (error) {
-          this.dependencies.logger?.warn(
-            'session',
-            'stopping audio capture: sidecar rejected an audio frame',
-            error,
-          );
-          void this.cancelSession(frameSessionId);
-        }
-      });
+          const activeEntry = this.sessions.get(frameSessionId);
+          if (activeEntry === undefined || activeEntry.phase !== 'active') {
+            return;
+          }
+
+          try {
+            this.dependencies.sidecarConnection.sendAudioFrame(frameSessionId, frameBytes);
+          } catch (error) {
+            this.dependencies.logger?.warn(
+              'session',
+              'stopping audio capture: sidecar rejected an audio frame',
+              error,
+            );
+            void this.cancelSession(frameSessionId);
+          }
+        },
+      );
 
       if (this.activeSessionId === sessionId) {
         this.applyUiState('listening');

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,6 +57,9 @@ export default class LocalSttPlugin extends Plugin {
     this.audioVisualizerTap = new AudioVisualizerTap();
     this.audioCaptureStream = new AudioCaptureStream({
       logger: this.logger,
+      onDeviceFallback: () => {
+        new Notice('Saved microphone unavailable. Using the default input device.');
+      },
       visualizer: this.audioVisualizerTap,
     });
     const ollamaClient = createOllamaClient();

--- a/src/settings/microphone-picker.ts
+++ b/src/settings/microphone-picker.ts
@@ -1,0 +1,216 @@
+import { Notice, Setting } from 'obsidian';
+
+import type { PluginLogger } from '../shared/plugin-logger';
+import type { AudioInputDevice } from './plugin-settings';
+import type { SettingAccess } from './setting-helpers';
+
+const DEFAULT_OPTION_VALUE = '__default__';
+const MISSING_OPTION_VALUE = '__missing__';
+const UNLABELED_OPTION_TEXT = 'Microphone (label unavailable)';
+// Windows fires `devicechange` once per HID interface on a single plug action;
+// 300 ms collapses those into a single re-enumeration.
+const DEVICE_CHANGE_DEBOUNCE_MS = 300;
+
+export interface MicrophonePickerDependencies {
+  access: SettingAccess;
+  isDictationBusy: () => boolean;
+  logger?: PluginLogger | undefined;
+}
+
+export function renderMicrophonePicker(
+  parent: HTMLElement,
+  deps: MicrophonePickerDependencies,
+): () => void {
+  const setting = new Setting(parent)
+    .setName('Microphone')
+    .setDesc('Which microphone to use for dictation. Changes apply on the next dictation session.');
+
+  let devices: MediaDeviceInfo[] = [];
+  let selectEl: HTMLSelectElement | null = null;
+  let detectButtonEl: HTMLElement | null = null;
+  let disposed = false;
+
+  function getSaved(): AudioInputDevice | null {
+    return deps.access.getSettings().audioInputDevice;
+  }
+
+  function repopulate(): void {
+    if (selectEl === null) {
+      return;
+    }
+
+    const saved = getSaved();
+    selectEl.empty();
+
+    appendOption(selectEl, DEFAULT_OPTION_VALUE, 'Default microphone');
+
+    let savedIsPresent = false;
+    for (const device of devices) {
+      const enumeratedLabel = device.label.trim();
+      // If a saved device is enumerated but came back with an empty label
+      // (permission revoked between sessions), keep the friendly persisted
+      // name so the row isn't blank.
+      const isSaved = saved !== null && saved.deviceId === device.deviceId;
+      if (isSaved) {
+        savedIsPresent = true;
+      }
+      const display =
+        enumeratedLabel.length > 0
+          ? enumeratedLabel
+          : isSaved
+            ? saved.label
+            : UNLABELED_OPTION_TEXT;
+      appendOption(selectEl, device.deviceId, display);
+    }
+
+    if (saved !== null && !savedIsPresent) {
+      appendOption(selectEl, MISSING_OPTION_VALUE, `${saved.label} (not connected)`);
+      selectEl.value = MISSING_OPTION_VALUE;
+    } else if (saved !== null) {
+      selectEl.value = saved.deviceId;
+    } else {
+      selectEl.value = DEFAULT_OPTION_VALUE;
+    }
+
+    refreshDetectButton();
+  }
+
+  function refreshDetectButton(): void {
+    if (detectButtonEl === null) {
+      return;
+    }
+    const needsPriming = devices.length > 0 && devices.every((device) => device.label === '');
+    detectButtonEl.style.display = needsPriming ? '' : 'none';
+  }
+
+  async function enumerate(): Promise<void> {
+    const mediaDevices = globalThis.navigator?.mediaDevices;
+    if (mediaDevices?.enumerateDevices === undefined) {
+      devices = [];
+      repopulate();
+      return;
+    }
+
+    try {
+      const all = await mediaDevices.enumerateDevices();
+      if (disposed) {
+        return;
+      }
+      devices = all.filter((device) => device.kind === 'audioinput');
+      repopulate();
+    } catch (error) {
+      deps.logger?.warn('audio', 'enumerateDevices failed', error);
+      devices = [];
+      repopulate();
+    }
+  }
+
+  setting.addDropdown((dropdown) => {
+    selectEl = dropdown.selectEl;
+    dropdown.onChange((value) => {
+      void handleChange(value);
+    });
+  });
+
+  setting.addExtraButton((button) => {
+    button
+      .setIcon('refresh-cw')
+      .setTooltip('Detect microphones (asks for permission)')
+      .onClick(() => {
+        void primePermission();
+      });
+    detectButtonEl = button.extraSettingsEl;
+    refreshDetectButton();
+  });
+
+  async function handleChange(value: string): Promise<void> {
+    if (value === DEFAULT_OPTION_VALUE) {
+      await deps.access.persistOne('audioInputDevice', null);
+      return;
+    }
+
+    if (value === MISSING_OPTION_VALUE) {
+      // The disconnected row is selected by default when the saved device is
+      // absent — no-op on re-selection.
+      return;
+    }
+
+    const picked = devices.find((device) => device.deviceId === value);
+    if (picked === undefined) {
+      return;
+    }
+
+    const label = picked.label.trim();
+    if (label.length === 0) {
+      // Shouldn't happen — the user can only pick an unlabeled row before
+      // priming permission, and we don't want to persist a blank label.
+      new Notice('Allow microphone access first to save this device.');
+      const saved = getSaved();
+      if (selectEl !== null) {
+        selectEl.value = saved?.deviceId ?? DEFAULT_OPTION_VALUE;
+      }
+      return;
+    }
+
+    await deps.access.persistOne('audioInputDevice', { deviceId: picked.deviceId, label });
+  }
+
+  async function primePermission(): Promise<void> {
+    if (deps.isDictationBusy()) {
+      new Notice('Stop dictation to detect microphones.');
+      return;
+    }
+
+    const mediaDevices = globalThis.navigator?.mediaDevices;
+    if (mediaDevices?.getUserMedia === undefined) {
+      new Notice('Microphone access is not available in this runtime.');
+      return;
+    }
+
+    try {
+      const stream = await mediaDevices.getUserMedia({ audio: true });
+      for (const track of stream.getTracks()) {
+        track.stop();
+      }
+      await enumerate();
+    } catch (error) {
+      const name = (error as { name?: unknown }).name;
+      if (name === 'NotAllowedError') {
+        new Notice('Microphone permission denied. Grant access in your OS settings and try again.');
+      } else {
+        new Notice('Could not detect microphones. Check your system audio settings.');
+      }
+      deps.logger?.warn('audio', 'priming microphone permission failed', error);
+    }
+  }
+
+  let debounceHandle: ReturnType<typeof setTimeout> | null = null;
+  const onDeviceChange = (): void => {
+    if (debounceHandle !== null) {
+      clearTimeout(debounceHandle);
+    }
+    debounceHandle = setTimeout(() => {
+      debounceHandle = null;
+      void enumerate();
+    }, DEVICE_CHANGE_DEBOUNCE_MS);
+  };
+
+  const mediaDevices = globalThis.navigator?.mediaDevices;
+  mediaDevices?.addEventListener?.('devicechange', onDeviceChange);
+
+  void enumerate();
+
+  return () => {
+    disposed = true;
+    if (debounceHandle !== null) {
+      clearTimeout(debounceHandle);
+      debounceHandle = null;
+    }
+    mediaDevices?.removeEventListener?.('devicechange', onDeviceChange);
+  };
+}
+
+function appendOption(selectEl: HTMLSelectElement, value: string, text: string): void {
+  const option = selectEl.createEl('option', { text });
+  option.value = value;
+}

--- a/src/settings/microphone-picker.ts
+++ b/src/settings/microphone-picker.ts
@@ -39,6 +39,11 @@ export function renderMicrophonePicker(
   let selectEl: HTMLSelectElement | null = null;
   let detectButtonEl: HTMLElement | null = null;
   let disposed = false;
+  // Bumped on every enumerate() call. Out-of-order resolutions (initial
+  // enumerate vs a devicechange-debounced one) compare against this and drop
+  // their result if a newer call has already started, so a stale response
+  // cannot overwrite a fresher device list.
+  let enumerateVersion = 0;
 
   function getSaved(): AudioInputDevice | null {
     return deps.access.getSettings().audioInputDevice;
@@ -89,11 +94,21 @@ export function renderMicrophonePicker(
     if (detectButtonEl === null) {
       return;
     }
-    const needsPriming = devices.length > 0 && devices.every((device) => device.label === '');
-    detectButtonEl.style.display = needsPriming ? '' : 'none';
+    const mediaDevices = globalThis.navigator?.mediaDevices;
+    if (mediaDevices?.getUserMedia === undefined) {
+      detectButtonEl.style.display = 'none';
+      return;
+    }
+    // Show the button whenever no enumerated device has a usable label. That
+    // covers the empty list (locked-down OS permission, no inputs visible) and
+    // the labels-look-empty cases (permission not yet granted, or label is
+    // only a VID:PID suffix that formatDeviceLabel strips to '').
+    const hasLabeledDevice = devices.some((device) => formatDeviceLabel(device.label).length > 0);
+    detectButtonEl.style.display = hasLabeledDevice ? 'none' : '';
   }
 
   async function enumerate(): Promise<void> {
+    const version = ++enumerateVersion;
     const mediaDevices = globalThis.navigator?.mediaDevices;
     if (mediaDevices?.enumerateDevices === undefined) {
       devices = [];
@@ -103,7 +118,7 @@ export function renderMicrophonePicker(
 
     try {
       const all = await mediaDevices.enumerateDevices();
-      if (disposed) {
+      if (disposed || version !== enumerateVersion) {
         return;
       }
       devices = all.filter(
@@ -111,6 +126,9 @@ export function renderMicrophonePicker(
       );
       repopulate();
     } catch (error) {
+      if (disposed || version !== enumerateVersion) {
+        return;
+      }
       deps.logger?.warn('audio', 'enumerateDevices failed', error);
       devices = [];
       repopulate();
@@ -138,12 +156,16 @@ export function renderMicrophonePicker(
   async function handleChange(value: string): Promise<void> {
     if (value === DEFAULT_OPTION_VALUE) {
       await deps.access.persistOne('audioInputDevice', null);
+      repopulate();
       return;
     }
 
     if (value === MISSING_OPTION_VALUE) {
-      // The disconnected row is selected by default when the saved device is
-      // absent — no-op on re-selection.
+      // Re-selecting the disconnected row is normally a no-op, but if the user
+      // previously switched to Default in this session the saved state is null
+      // and the MISSING row is an orphan. Repopulate to drop it and re-sync
+      // the dropdown with saved state.
+      repopulate();
       return;
     }
 
@@ -165,6 +187,7 @@ export function renderMicrophonePicker(
     }
 
     await deps.access.persistOne('audioInputDevice', { deviceId: picked.deviceId, label });
+    repopulate();
   }
 
   async function primePermission(): Promise<void> {

--- a/src/settings/microphone-picker.ts
+++ b/src/settings/microphone-picker.ts
@@ -7,6 +7,16 @@ import type { SettingAccess } from './setting-helpers';
 const DEFAULT_OPTION_VALUE = '__default__';
 const MISSING_OPTION_VALUE = '__missing__';
 const UNLABELED_OPTION_TEXT = 'Microphone (label unavailable)';
+// Chromium on Windows suffixes USB device labels with a `(VID:PID)` tuple
+// (e.g. " (03f0:098d)"). It's stable but noise in a settings UI — strip it
+// for display and persistence so the dropdown matches what the user sees in
+// the OS sound control panel.
+const VID_PID_SUFFIX = /\s*\(([0-9a-f]{4}):([0-9a-f]{4})\)\s*$/i;
+// Chromium synthesizes two alias entries with these literal deviceIds that
+// track whichever physical device is currently the OS default for general /
+// communications routing. They duplicate real devices already in the list
+// and we expose our own "Default microphone" row at the top, so hide them.
+const SYNTHETIC_ALIAS_IDS = new Set(['default', 'communications']);
 // Windows fires `devicechange` once per HID interface on a single plug action;
 // 300 ms collapses those into a single re-enumeration.
 const DEVICE_CHANGE_DEBOUNCE_MS = 300;
@@ -46,7 +56,7 @@ export function renderMicrophonePicker(
 
     let savedIsPresent = false;
     for (const device of devices) {
-      const enumeratedLabel = device.label.trim();
+      const enumeratedLabel = formatDeviceLabel(device.label);
       // If a saved device is enumerated but came back with an empty label
       // (permission revoked between sessions), keep the friendly persisted
       // name so the row isn't blank.
@@ -96,7 +106,9 @@ export function renderMicrophonePicker(
       if (disposed) {
         return;
       }
-      devices = all.filter((device) => device.kind === 'audioinput');
+      devices = all.filter(
+        (device) => device.kind === 'audioinput' && !SYNTHETIC_ALIAS_IDS.has(device.deviceId),
+      );
       repopulate();
     } catch (error) {
       deps.logger?.warn('audio', 'enumerateDevices failed', error);
@@ -140,7 +152,7 @@ export function renderMicrophonePicker(
       return;
     }
 
-    const label = picked.label.trim();
+    const label = formatDeviceLabel(picked.label);
     if (label.length === 0) {
       // Shouldn't happen — the user can only pick an unlabeled row before
       // priming permission, and we don't want to persist a blank label.
@@ -213,4 +225,8 @@ export function renderMicrophonePicker(
 function appendOption(selectEl: HTMLSelectElement, value: string, text: string): void {
   const option = selectEl.createEl('option', { text });
   option.value = value;
+}
+
+function formatDeviceLabel(raw: string): string {
+  return raw.replace(VID_PID_SUFFIX, '').trim();
 }

--- a/src/settings/plugin-settings.ts
+++ b/src/settings/plugin-settings.ts
@@ -74,8 +74,14 @@ export const LLM_USER_PRESET_MAX_LABEL_CHARS = 60;
 export const LLM_USER_PRESET_MAX_DESCRIPTION_CHARS = 240;
 export const LLM_USER_PRESET_MAX_COUNT = 25;
 
+export interface AudioInputDevice {
+  deviceId: string;
+  label: string;
+}
+
 export interface PluginSettings {
   accelerationPreference: AccelerationPreference;
+  audioInputDevice: AudioInputDevice | null;
   cudaLibraryPath: string;
   developerMode: boolean;
   dictationAnchor: DictationAnchor;
@@ -113,6 +119,7 @@ export interface PluginSettings {
 
 export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
   accelerationPreference: 'auto',
+  audioInputDevice: null,
   cudaLibraryPath: '',
   developerMode: false,
   dictationAnchor: 'at_cursor',
@@ -160,6 +167,7 @@ export function resolvePluginSettings(data: unknown): PluginSettings {
 
   return {
     accelerationPreference: readAccelerationPreference(raw.accelerationPreference),
+    audioInputDevice: readAudioInputDevice(raw.audioInputDevice),
     cudaLibraryPath: readString(raw.cudaLibraryPath, DEFAULT_PLUGIN_SETTINGS.cudaLibraryPath),
     developerMode: readBoolean(raw.developerMode, DEFAULT_PLUGIN_SETTINGS.developerMode),
     dictationAnchor: isDictationAnchor(raw.dictationAnchor)
@@ -283,6 +291,21 @@ export function resetLlmPostprocessDefaults(settings: PluginSettings): PluginSet
     llmPostprocessTotalContextCap: DEFAULT_PLUGIN_SETTINGS.llmPostprocessTotalContextCap,
     useLlmNoteContext: DEFAULT_PLUGIN_SETTINGS.useLlmNoteContext,
   };
+}
+
+function readAudioInputDevice(value: unknown): AudioInputDevice | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const deviceId = typeof value.deviceId === 'string' ? value.deviceId.trim() : '';
+  const label = typeof value.label === 'string' ? value.label.trim() : '';
+
+  if (deviceId.length === 0 || label.length === 0) {
+    return null;
+  }
+
+  return { deviceId, label };
 }
 
 function readAccelerationPreference(value: unknown): AccelerationPreference {

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -16,6 +16,7 @@ import {
 } from '../sidecar/sidecar-install-manager';
 import { readInstallManifest, variantDirectoryPath } from '../sidecar/sidecar-installer';
 import { renderActiveInstallCard } from './install-progress-row';
+import { renderMicrophonePicker } from './microphone-picker';
 import { renderModelSection } from './model-settings-section';
 import {
   type DictationAnchor,
@@ -99,6 +100,7 @@ export class LocalSttSettingTab extends PluginSettingTab {
 
   private readonly access: SettingAccess;
   private disposeEngineSection: (() => void) | null = null;
+  private disposeMicrophoneSection: (() => void) | null = null;
   private disposeMissingSidecarBanner: (() => void) | null = null;
   private disposeModelSection: (() => void) | null = null;
   private disposeSidecarSection: (() => void) | null = null;
@@ -162,6 +164,12 @@ export class LocalSttSettingTab extends PluginSettingTab {
 
     // --- Transcription ---
     const transcriptionCard = createSettingGroup(containerEl, 'Transcription');
+
+    this.disposeMicrophoneSection = renderMicrophonePicker(transcriptionCard, {
+      access: this.access,
+      isDictationBusy: this.dependencies.isDictationBusy,
+      logger: this.dependencies.logger,
+    });
 
     addEnumSetting(transcriptionCard, this.access, {
       name: 'Listening mode',
@@ -275,6 +283,8 @@ export class LocalSttSettingTab extends PluginSettingTab {
     this.disposeModelSection = null;
     this.disposeEngineSection?.();
     this.disposeEngineSection = null;
+    this.disposeMicrophoneSection?.();
+    this.disposeMicrophoneSection = null;
     this.disposeSidecarSection?.();
     this.disposeSidecarSection = null;
     this.disposeMissingSidecarBanner?.();

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -20,9 +20,12 @@ class FakeCaptureStream {
   public frameListener: ((sessionId: string, frameBytes: Uint8Array) => void) | null = null;
   public sessionId: string | null = null;
   public start = vi.fn(
-    async (sessionId: string, listener: (sessionId: string, frameBytes: Uint8Array) => void) => {
+    async (
+      options: { sessionId: string; audioInputDeviceId?: string | null },
+      listener: (sessionId: string, frameBytes: Uint8Array) => void,
+    ) => {
       this.capturing = true;
-      this.sessionId = sessionId;
+      this.sessionId = options.sessionId;
       this.frameListener = listener;
     },
   );

--- a/test/plugin-settings.test.ts
+++ b/test/plugin-settings.test.ts
@@ -377,6 +377,25 @@ describe('resolvePluginSettings', () => {
     ).toEqual([]);
   });
 
+  it('reads a valid audioInputDevice and trims whitespace', () => {
+    expect(
+      resolvePluginSettings({
+        audioInputDevice: { deviceId: '  abc123  ', label: '  Plantronics Headset  ' },
+      }).audioInputDevice,
+    ).toEqual({ deviceId: 'abc123', label: 'Plantronics Headset' });
+  });
+
+  it.each([
+    ['missing field', { audioInputDevice: { deviceId: 'abc' } }],
+    ['empty deviceId', { audioInputDevice: { deviceId: '', label: 'Mic' } }],
+    ['empty label', { audioInputDevice: { deviceId: 'abc', label: '' } }],
+    ['whitespace-only label', { audioInputDevice: { deviceId: 'abc', label: '   ' } }],
+    ['wrong types', { audioInputDevice: { deviceId: 42, label: 'Mic' } }],
+    ['not an object', { audioInputDevice: 'abc123' }],
+  ])('coerces invalid audioInputDevice to null (%s)', (_label, raw) => {
+    expect(resolvePluginSettings(raw).audioInputDevice).toBeNull();
+  });
+
   it('resets editable LLM defaults without touching visibility, model, raw display, or styles', () => {
     const presets = [makeUserPreset({ id: 'a', label: 'Keep me' })];
     const reset = resetLlmPostprocessDefaults({


### PR DESCRIPTION
## Summary
- Adds a microphone picker as the first row of the Transcription settings card. Default is the OS default mic (preserves current behavior); user-picked devices persist across sessions and apply on the next dictation session, not mid-session.
- Saved device gone at start time → `getUserMedia` retries without the deviceId constraint, logs a warning, and surfaces a Notice. Tightly scoped to `OverconstrainedError`/`constraint === 'deviceId'`; other errors propagate as today.
- Settings tab listens for `devicechange` while open (debounced 300 ms to collapse Windows' multi-fire) so hot-plugged mics appear without reopening the tab. A "Detect devices" extra-button (icon-only, visible only when labels are empty) primes mic permission so labels resolve on first use.
- Disconnected saved devices show as `"<label> (not connected)"` and remain selected — fallback happens at start time, not silently in the dropdown. Persisted shape is `{deviceId, label}` so the row keeps the friendly name when the device is gone.

## Implementation notes
- Picker lives in a focused new module `src/settings/microphone-picker.ts` that owns its enumerate / repopulate / devicechange lifecycle and returns a dispose function (same shape as `model-settings-section.ts`).
- `AudioCaptureStream.start()` now takes an options object `{ sessionId, audioInputDeviceId }` and an `onDeviceFallback` constructor callback so the audio layer stays UI-free (`main.ts` supplies the `Notice`).
- Validator in `plugin-settings.ts` rejects empty / non-string deviceId or label, so a corrupt persist round-trips back to "use OS default" rather than rendering a blank row.
- No sidecar changes; this is a TypeScript-only feature.

## Out of scope (deferred by user)
- System-audio capture (separate future change).
- `groupId`-based recovery from `deviceId` rotation across USB-port changes — speculative; revisit if real reports come in.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` — 374 pass (367 baseline + 7 new validator tests in `test/plugin-settings.test.ts`)
- [x] `npm run build:frontend`
- [x] `npm run install:dev -- --vault <dev-vault>`
- [ ] **Manual (please verify in dev vault):**
  - [ ] Settings → Local Dictation → Transcription shows "Microphone" as the first row, above "Listening mode"
  - [ ] First-open with no permission: dropdown labels empty + Detect button visible → click → labels populate, button hides
  - [ ] Pick a non-default device, restart dictation, confirm OS-level "apps in use" shows the right mic
  - [ ] Unplug the selected USB mic → reopen settings → see "MyMic (not connected)" row; start dictation → falls back to default + Notice + warning in log
  - [ ] Plug a new USB mic while settings is open → appears within ~300 ms
  - [ ] macOS NotAllowedError path (untested locally — Windows-only dev env): denying mic in System Settings then clicking Detect should show the System-Settings Notice

Closes #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)