### PR TITLE
fix: cross-platform release polish for 2026.5.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ CPU works everywhere with no extra dependencies. CUDA acceleration requires an R
 
 > **Linux distro coverage.** macOS and Windows are the primary tested targets. On Linux, the plugin is regularly used on Fedora 44; other distributions (Arch, Ubuntu, Debian, etc.) should work but are not routinely verified. If you hit a problem on your distro, please open an issue with details.
 
+> **macOS Voice Isolation.** If transcription quality drops on macOS, open Control Center → Mic Mode and set it to **Standard**. Voice Isolation and Wide Spectrum are applied by Core Audio at the system level and can clip sibilants in ways the plugin can't override.
+
 ## 🚀 Quick Start
 
 Install Local Dictation from Obsidian's Community Plugins. On first run, a **setup wizard** walks you through downloading the speech engine and picking a transcription model — that's the easiest path.

--- a/src/audio/microphone-permission-message.ts
+++ b/src/audio/microphone-permission-message.ts
@@ -1,0 +1,11 @@
+import { Platform } from 'obsidian';
+
+// macOS TCC grants apply to Obsidian as the host process and don't take effect
+// until Obsidian restarts, so the macOS copy has to call that out — otherwise
+// users enable Microphone access and then keep seeing the same denial.
+export function formatMicrophonePermissionDeniedMessage(): string {
+  if (Platform.isMacOS) {
+    return 'Microphone permission denied. Open System Settings → Privacy & Security → Microphone, enable Obsidian, then restart Obsidian and try again.';
+  }
+  return 'Microphone permission denied. Grant access in your OS settings and try again.';
+}

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import type { AudioCaptureStream } from '../audio/audio-capture-stream';
+import { formatMicrophonePermissionDeniedMessage } from '../audio/microphone-permission-message';
 import type { NotePlacementOptions } from '../editor/note-surface';
 import { OLLAMA_KEEP_ALIVE } from '../llm/ollama-client';
 import { type LlmPostprocessMode, resolveStyleOption } from '../llm/presets';
@@ -830,8 +831,25 @@ export class DictationSessionController {
   private handleError(message: string, error: unknown): void {
     this.dependencies.logger?.error('session', message, error);
     this.applyUiState('error');
+
+    // The microphone-permission copy is a complete, actionable sentence on its
+    // own; prefixing it with the generic start-failure message just buries the
+    // instructions. The Settings mic picker shows it bare for the same reason.
+    if (isMicrophonePermissionDeniedError(error)) {
+      this.dependencies.notice(formatMicrophonePermissionDeniedMessage());
+      return;
+    }
+
     this.dependencies.notice(`${message}: ${formatErrorMessage(error)}`);
   }
+}
+
+function isMicrophonePermissionDeniedError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { name?: unknown }).name === 'NotAllowedError'
+  );
 }
 
 function createSessionId(): string {

--- a/src/settings/microphone-picker.ts
+++ b/src/settings/microphone-picker.ts
@@ -1,5 +1,6 @@
 import { Notice, Setting } from 'obsidian';
 
+import { formatMicrophonePermissionDeniedMessage } from '../audio/microphone-permission-message';
 import type { PluginLogger } from '../shared/plugin-logger';
 import type { AudioInputDevice } from './plugin-settings';
 import type { SettingAccess } from './setting-helpers';
@@ -211,7 +212,7 @@ export function renderMicrophonePicker(
     } catch (error) {
       const name = (error as { name?: unknown }).name;
       if (name === 'NotAllowedError') {
-        new Notice('Microphone permission denied. Grant access in your OS settings and try again.');
+        new Notice(formatMicrophonePermissionDeniedMessage());
       } else {
         new Notice('Could not detect microphones. Check your system audio settings.');
       }

--- a/src/setup/sidecar-install-modal.ts
+++ b/src/setup/sidecar-install-modal.ts
@@ -103,7 +103,17 @@ export class SidecarInstallModal extends Modal {
   }
 
   private renderPreInstall(): void {
-    const asset = detectPlatformAssetForCurrentEnv(this.options.variant);
+    let asset: string;
+    try {
+      asset = detectPlatformAssetForCurrentEnv(this.options.variant);
+    } catch (error) {
+      // Currently the only path here is Intel Mac (CUDA-on-macOS is unreachable
+      // because callers gate the variant on platform). The unsupported view
+      // gives the user a clear answer instead of a render-time crash that
+      // bubbles to a generic Notice.
+      this.renderUnsupported(formatErrorMessage(error));
+      return;
+    }
 
     this.contentEl.createEl('p', { text: this.options.copy.bodyText });
 
@@ -149,6 +159,18 @@ export class SidecarInstallModal extends Modal {
       text: active.phase === 'canceling' ? 'Cancelling...' : 'Downloading...',
     }).disabled = true;
     buttons.createEl('button', { text: 'Close' }).addEventListener('click', () => {
+      this.close();
+    });
+  }
+
+  private renderUnsupported(message: string): void {
+    this.contentEl.createEl('p', {
+      cls: 'local-stt-sidecar-install__status local-stt-sidecar-install__status--error',
+      text: message,
+    });
+
+    const buttons = this.contentEl.createDiv({ cls: 'local-stt-sidecar-install__buttons' });
+    buttons.createEl('button', { cls: 'mod-cta', text: 'Close' }).addEventListener('click', () => {
       this.close();
     });
   }

--- a/src/sidecar/sidecar-installer.ts
+++ b/src/sidecar/sidecar-installer.ts
@@ -63,7 +63,9 @@ export function detectPlatformAsset(
     }
 
     if (arch !== 'arm64') {
-      throw new Error(`Unsupported macOS architecture for sidecar: ${arch}.`);
+      throw new Error(
+        'Local Dictation requires an Apple Silicon Mac (M1 or newer). Intel Macs are not supported.',
+      );
     }
 
     return 'sidecar-macos-arm64.tar.gz';

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { formatMicrophonePermissionDeniedMessage } from '../src/audio/microphone-permission-message';
 import {
   type DictationControllerState,
   DictationSessionController,
@@ -161,6 +162,22 @@ describe('DictationSessionController', () => {
 
     expect(sidecarConnection.sendAudioFrame).toHaveBeenCalledWith(startPayload?.sessionId, frame);
     expect(controller.getState()).toBe('listening');
+  });
+
+  it('surfaces the bare microphone-permission message when capture is denied, without the generic start-failure prefix', async () => {
+    const captureStream = new FakeCaptureStream();
+    captureStream.start.mockRejectedValueOnce(
+      Object.assign(new Error('Permission denied'), { name: 'NotAllowedError' }),
+    );
+    const notice = vi.fn();
+    const controller = createController({ captureStream, notice });
+
+    await controller.startDictation();
+
+    expect(notice).toHaveBeenCalledWith(formatMicrophonePermissionDeniedMessage());
+    expect(notice).not.toHaveBeenCalledWith(
+      expect.stringContaining('Failed to start the dictation session'),
+    );
   });
 
   it('accepts late transcript events from a stopped session after a new session starts', async () => {

--- a/test/microphone-permission-message.test.ts
+++ b/test/microphone-permission-message.test.ts
@@ -1,0 +1,28 @@
+import { Platform } from 'obsidian';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { formatMicrophonePermissionDeniedMessage } from '../src/audio/microphone-permission-message';
+
+describe('formatMicrophonePermissionDeniedMessage', () => {
+  const originalIsMacOS = Platform.isMacOS;
+
+  afterEach(() => {
+    Platform.isMacOS = originalIsMacOS;
+  });
+
+  it('tells macOS users to enable Obsidian in Privacy & Security and restart', () => {
+    Platform.isMacOS = true;
+    const message = formatMicrophonePermissionDeniedMessage();
+
+    expect(message).toContain('System Settings');
+    expect(message).toContain('Microphone');
+    expect(message).toContain('restart Obsidian');
+  });
+
+  it('keeps the short generic copy on non-macOS platforms', () => {
+    Platform.isMacOS = false;
+    expect(formatMicrophonePermissionDeniedMessage()).toBe(
+      'Microphone permission denied. Grant access in your OS settings and try again.',
+    );
+  });
+});

--- a/test/sidecar-installer.test.ts
+++ b/test/sidecar-installer.test.ts
@@ -106,8 +106,11 @@ describe('detectPlatformAsset', () => {
     expect(() => detectPlatformAsset('darwin', 'arm64', 'cuda')).toThrow(/not available on macOS/i);
   });
 
-  it('rejects Intel Mac', () => {
-    expect(() => detectPlatformAsset('darwin', 'x64', 'cpu')).toThrow(/architecture/i);
+  it('rejects Intel Mac with an Apple Silicon requirement message', () => {
+    expect(() => detectPlatformAsset('darwin', 'x64', 'cpu')).toThrow(/Apple Silicon/);
+    expect(() => detectPlatformAsset('darwin', 'x64', 'cpu')).toThrow(
+      /Intel Macs are not supported/,
+    );
   });
 
   it('returns the Linux tarball variants', () => {


### PR DESCRIPTION
## Summary

Addresses the macOS/Windows findings from the 2026.5.23 cross-platform audit that warranted a code or doc change. Linux is out of scope (Fedora-only this release).

## Changes

**Microphone-permission copy (macOS-aware).** On a permission denial the Notice now tells macOS users to enable Obsidian under **System Settings → Privacy & Security → Microphone** *and restart Obsidian* — TCC grants don't apply to an already-running process. The message is surfaced **bare** by the dictation controller and the Settings mic picker, rather than buried behind a generic `Failed to start the dictation session:` prefix. The controller special-cases the raw `NotAllowedError` by name, so the original error still reaches the logs.

**Intel-Mac install handling.** `SidecarInstallModal` now renders a dedicated unsupported-platform view instead of crashing at render when `detectPlatformAsset` throws, and that throw is reworded from "Unsupported macOS architecture" to an explicit "Local Dictation requires an Apple Silicon Mac (M1 or newer)."

**README.** Troubleshooting note: set macOS Control Center → Mic Mode → **Standard** when Voice Isolation degrades transcription quality.

## Files

- `src/audio/microphone-permission-message.ts` (new) — platform-aware permission-denied message helper
- `src/dictation/dictation-session-controller.ts` — surface the bare mic-permission message on `NotAllowedError`
- `src/settings/microphone-picker.ts` — use the shared helper on the picker's Detect path
- `src/setup/sidecar-install-modal.ts` — `renderUnsupported` view when `detectPlatformAssetForCurrentEnv` throws
- `src/sidecar/sidecar-installer.ts` — reword the Intel-Mac throw to an Apple Silicon requirement
- `README.md` — Voice Isolation troubleshooting note
- `test/microphone-permission-message.test.ts` (new), `test/dictation-session-controller.test.ts`, `test/sidecar-installer.test.ts` — cover the above

## Test plan

- [x] `npm run check:frontend` — typecheck, lint (biome), 380 tests pass, build clean
- [ ] Manual smoke on macOS — deny mic in Privacy & Security, confirm the new copy appears in the Notice (not testable on this Windows dev box)
- [ ] Manual smoke on macOS Intel — open the install modal, confirm the "Apple Silicon required" view renders without crashing (no Intel Mac available; covered by test)

## Out of scope

- Notarization / hardened-runtime signing on macOS (CI does ad-hoc codesign only)
- Long-path warnings on Windows (audit flagged; deferred)
- CUDA-without-NVIDIA precheck UX improvements (audit flagged; deferred)