### PR TITLE
fix(dictation): keep the cursor visible until transcripts land

### DIFF
--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -313,8 +313,9 @@ export class DictationSessionController {
     const entry = this.sessions.get(sessionId);
     if (entry !== undefined) {
       entry.phase = 'stopping';
-      this.clearAnchorTimer(entry);
-      entry.session.setAnchorMode('hidden');
+      // Keep the cursor where text will land while queued transcripts drain.
+      // It is cleared when the session is finally disposed (after the drain),
+      // and the anchor timer is cleaned up there too.
     }
 
     await this.clearActiveSession(sessionId);
@@ -690,6 +691,9 @@ export class DictationSessionController {
         ? (entry.session.readNoteText(entry.snapshot.llmPostprocessNoteContextChars)?.text ?? null)
         : null;
 
+    // The flashing processing range is now the "working" indicator, so the
+    // cursor steps aside for the batch rewrite.
+    entry.session.setAnchorMode('hidden');
     entry.session.markSessionRangeAsProcessing();
     try {
       this.dependencies.sidecarConnection.requestBatchCleanup({

--- a/src/editor/note-surface.ts
+++ b/src/editor/note-surface.ts
@@ -1,4 +1,4 @@
-import type { Extension } from '@codemirror/state';
+import type { Extension, StateEffect } from '@codemirror/state';
 import { Annotation, Transaction } from '@codemirror/state';
 import { EditorView, type ViewUpdate } from '@codemirror/view';
 
@@ -151,8 +151,13 @@ export class NoteSurface {
     this.initialAnchorPos = this.computePinPosition();
     this.insertInitialPrefix();
     this.initialBoundaryPos = this.initialAnchorPos;
-    this.view.dispatch({ effects: setAnchorEffect.of(this.initialAnchorPos) });
+    // Register before pinning the anchor so the ownership check below sees this
+    // surface — a freshly created surface is always the newest, so it owns the
+    // shared cursor.
     registerNoteSurface(this);
+    if (this.isAnchorOwner()) {
+      this.view.dispatch({ effects: setAnchorEffect.of(this.initialAnchorPos) });
+    }
   }
 
   observeTransaction(update: ViewUpdate): void {
@@ -207,7 +212,7 @@ export class NoteSurface {
     this.view.dispatch({
       annotations: noteSurfaceInsertOrder.of(this.createdAt),
       changes: { from, insert: projection.projectedText },
-      effects: [setAnchorEffect.of(to), EditorView.scrollIntoView(to, { y: 'nearest' })],
+      effects: this.ownerAnchorEffects(to),
     });
 
     const span: ProjectedSpan = {
@@ -252,10 +257,7 @@ export class NoteSurface {
 
     this.view.dispatch({
       changes: { from: span.textStart, to: span.textEnd, insert: newText },
-      effects: [
-        setAnchorEffect.of(span.textStart + newText.length),
-        EditorView.scrollIntoView(span.textStart + newText.length, { y: 'nearest' }),
-      ],
+      effects: this.ownerAnchorEffects(span.textStart + newText.length),
     });
 
     const delta = newText.length - span.projectedText.length;
@@ -315,11 +317,14 @@ export class NoteSurface {
     }
 
     const end = range.from + newText.length;
+    const ownsAnchor = this.isAnchorOwner();
     this.view.dispatch({
       annotations: bypassSessionProcessingLock.of(true),
       changes: { from: range.from, to: range.to, insert: newText },
-      effects: [setAnchorEffect.of(end), EditorView.scrollIntoView(end, { y: 'nearest' })],
-      selection: { anchor: end },
+      effects: this.ownerAnchorEffects(end),
+      // Only move the real caret when this surface owns the cursor, so a batch
+      // rewrite from an older session can't yank focus from a newer session.
+      ...(ownsAnchor ? { selection: { anchor: end } } : {}),
     });
     for (const span of spansInRange) {
       this.spans.delete(span.utteranceId);
@@ -346,7 +351,7 @@ export class NoteSurface {
   }
 
   setAnchorMode(mode: DictationAnchorMode): void {
-    if (!this.disposed) {
+    if (this.isAnchorOwner()) {
       this.view.dispatch({ effects: setAnchorModeEffect.of(mode) });
     }
   }
@@ -382,11 +387,62 @@ export class NoteSurface {
 
   dispose(): void {
     this.trimPendingInitialPrefix();
-    this.view.dispatch({
-      effects: [clearAnchorEffect.of(null), setSessionProcessingEffect.of(null)],
-    });
     this.disposed = true;
     unregisterNoteSurface(this);
+    // The anchor is a single shared widget. Only clear it when no other live
+    // session is still using it — otherwise a draining older session would wipe
+    // the newer session's cursor. The processing-range flash is per-session, so
+    // always clear this surface's own mark.
+    const effects = [setSessionProcessingEffect.of(null)];
+    if (!this.hasOtherLiveSibling()) {
+      effects.push(clearAnchorEffect.of(null));
+    }
+    this.view.dispatch({ effects });
+  }
+
+  // The shared cursor belongs to the newest live surface for this view. With
+  // overlapping sessions (a new one started while a previous one still drains
+  // on a slow backend), this keeps a single session in control of the cursor.
+  private isAnchorOwner(): boolean {
+    if (this.disposed) {
+      return false;
+    }
+
+    const siblings = noteSurfacesByView.get(this.view);
+    if (siblings === undefined) {
+      return true;
+    }
+
+    for (const surface of siblings) {
+      if (surface !== this && !surface.disposed && surface.createdAt > this.createdAt) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private hasOtherLiveSibling(): boolean {
+    const siblings = noteSurfacesByView.get(this.view);
+    if (siblings === undefined) {
+      return false;
+    }
+
+    for (const surface of siblings) {
+      if (surface !== this && !surface.disposed) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private ownerAnchorEffects(pos: number): StateEffect<unknown>[] {
+    if (!this.isAnchorOwner()) {
+      return [];
+    }
+
+    return [setAnchorEffect.of(pos), EditorView.scrollIntoView(pos, { y: 'nearest' })];
   }
 
   getSpan(utteranceId: UtteranceId): ProjectedSpan | undefined {

--- a/src/editor/note-surface.ts
+++ b/src/editor/note-surface.ts
@@ -391,8 +391,9 @@ export class NoteSurface {
     unregisterNoteSurface(this);
     // The anchor is a single shared widget. Only clear it when no other live
     // session is still using it — otherwise a draining older session would wipe
-    // the newer session's cursor. The processing-range flash is per-session, so
-    // always clear this surface's own mark.
+    // the newer session's cursor. The processing range is a single shared field
+    // too, but only the session currently draining ever shows the flash, so the
+    // disposing session always clears it.
     const effects = [setSessionProcessingEffect.of(null)];
     if (!this.hasOtherLiveSibling()) {
       effects.push(clearAnchorEffect.of(null));

--- a/src/settings/sidecar-settings-section.ts
+++ b/src/settings/sidecar-settings-section.ts
@@ -289,7 +289,9 @@ export function openSidecarInstallModal(
   },
 ): void {
   if (deps.isDictationBusy()) {
-    new Notice('Stop dictation before installing a sidecar — the install restarts the engine.');
+    new Notice(
+      'Stop dictation before installing a sidecar — the install restarts the engine. If a transcript is still processing, run "Cancel dictation" to stop it now.',
+    );
     return;
   }
 
@@ -320,7 +322,9 @@ async function uninstallSidecarVariantWithUx(
   const userFacingName = Platform.isMacOS ? 'sidecar' : `${variantLabel} sidecar`;
 
   if (deps.isDictationBusy()) {
-    new Notice(`Stop dictation before uninstalling the ${userFacingName}.`);
+    new Notice(
+      `Stop dictation before uninstalling the ${userFacingName}. If a transcript is still processing, run "Cancel dictation" to stop it now.`,
+    );
     return;
   }
 

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -375,6 +375,68 @@ describe('DictationSessionController', () => {
     expect(captureStream.start).not.toHaveBeenCalled();
     expect(controller.getState()).toBe('idle');
   });
+
+  it('keeps the cursor through Stop and only releases it when the drained session is disposed', async () => {
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const controller = createController({
+      createSession: (session) => {
+        sessions.push(session);
+      },
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    const session = sessions[0];
+    if (session === undefined) {
+      throw new Error('expected session fixture');
+    }
+
+    session.setAnchorMode.mockClear();
+    await controller.stopDictation();
+
+    // Stop must not hide the cursor — queued transcripts still land at it.
+    expect(session.setAnchorMode).not.toHaveBeenCalled();
+    expect(session.dispose).not.toHaveBeenCalled();
+
+    // The drain completes; disposing the surface is what releases the cursor.
+    sidecarConnection.emit({ reason: 'user_stop', sessionId, type: 'session_stopped' });
+    expect(session.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the cursor when the batch-cleanup flash starts', async () => {
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const controller = createController({
+      createSession: (session) => {
+        sessions.push(session);
+      },
+      getSettings: () =>
+        createSettings({
+          llmFeaturesEnabled: true,
+          llmPostprocessMode: 'batch',
+          llmPostprocessModel: 'llama3.2:latest',
+          selectedModel: createExternalModelSelection(),
+        }),
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    const session = sessions[0];
+    if (session === undefined) {
+      throw new Error('expected session fixture');
+    }
+    sidecarConnection.emit(transcriptReady(sessionId, 'raw transcript'));
+    await controller.stopDictation();
+
+    session.setAnchorMode.mockClear();
+    sidecarConnection.emit({ reason: 'user_stop', sessionId, type: 'session_stopped' });
+
+    expect(session.markSessionRangeAsProcessing).toHaveBeenCalledTimes(1);
+    expect(session.setAnchorMode).toHaveBeenCalledWith('hidden');
+  });
 });
 
 function createController({

--- a/test/note-surface.test.ts
+++ b/test/note-surface.test.ts
@@ -228,6 +228,28 @@ describe('NoteSurface', () => {
     expect(surface.replaceAnchor('u1', 'FIRST', 'first').kind).toBe('denied');
   });
 
+  it('lets only the newest session drive the shared cursor and clears it on the last dispose', () => {
+    const view = new FakeEditorView('', 0, dictationAnchorExtension());
+    const earlier = new NoteSurface(view as unknown as EditorView, { anchor: 'at_cursor' });
+    const later = new NoteSurface(view as unknown as EditorView, { anchor: 'at_cursor' });
+
+    // The older (non-owner) session cannot move the shared cursor.
+    earlier.setAnchorMode('visible');
+    expect(view.state.field(dictationAnchorStateField).mode).toBe('hidden');
+
+    // The newest session owns it.
+    later.setAnchorMode('visible');
+    expect(view.state.field(dictationAnchorStateField).mode).toBe('visible');
+
+    // An older session finishing must not wipe the newer session's cursor.
+    earlier.dispose();
+    expect(view.state.field(dictationAnchorStateField).mode).toBe('visible');
+
+    // The last session to dispose clears it.
+    later.dispose();
+    expect(view.state.field(dictationAnchorStateField)).toEqual({ mode: 'hidden', pos: null });
+  });
+
   it('keeps the visible anchor marker on the locked note surface', () => {
     const { surface, view } = createSurface({ extensions: dictationAnchorExtension() });
 


### PR DESCRIPTION
## Context

On a slow CPU sidecar, the dictation **cursor** (the anchor widget marking where text will land) vanished while a phrase was still being transcribed, and the text then appeared seconds later "from nowhere." This was surfaced while verifying a release.

The cursor should behave like a writing caret: appear after ~2.5s of talking (unchanged) and stay put **until the text actually lands**, then disappear — across the Stop-and-drain window and across overlapping sessions. The ribbon remains the VAD/mic indicator.

## Root cause

Cursor visibility was bound to live VAD state (`applySessionStateToAnchor`) and force-hidden the moment `stopDictation` ran (`dictation-session-controller.ts:317`), even though queued transcripts keep inserting for seconds afterward via the graceful drain. (The sidecar already reports `Transcribing` while the queue drains, so in-session behaviour was already correct — the bug was concentrated in the Stop path.)

## Changes

- **`note-surface.ts`** — the single per-editor anchor is now a resource owned by the **newest live session**. Added `isAnchorOwner()`; gated `setAnchorMode` and the position effects on ownership; `dispose()` clears the shared anchor only when no other live sibling remains. This prevents an older draining session from wiping a newer session's cursor.
- **`dictation-session-controller.ts`** — removed the premature hide on Stop; the cursor persists through the drain and is released when the session is finally disposed. Hide the cursor when the batch-cleanup flash starts (the flash becomes the working indicator).
- **`sidecar-settings-section.ts`** — reworded the blocked install/uninstall notices to point at **Cancel dictation** as the way to stop an in-flight drain immediately.

### Deliberately not handled (verified impossible)

- Out-of-order completion across sessions — a single FIFO worker thread (`worker.rs`) guarantees session order.
- Swapping the sidecar mid-drain — installs are blocked while `isDictationBusy()` and restart the engine.

## Verification

- `npm run typecheck && npm run test && npm run lint` — green (**383 tests**, +3 new).
- New coverage: `note-surface.test.ts` (ownership + clear-on-last-dispose), `dictation-session-controller.test.ts` (cursor survives Stop, released on dispose; batch flash hides cursor).

Manual (for reviewer, CPU sidecar + Whisper Large):
1. Dictate, hit **Stop** before transcription finishes → cursor stays until text lands, then disappears.
2. Batch mode → text flashes on Stop and the cursor steps aside.
3. Overlap: dictate, Stop, immediately start a new session → one cursor owned by the new session; the old session's trailing text still lands cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)