### PR TITLE
fix(sidecar): detect version drift and report the real sidecar version

### DIFF
--- a/docs/release/release-planning.md
+++ b/docs/release/release-planning.md
@@ -34,7 +34,7 @@ Deferred: macOS x86_64, Linux arm64, Windows arm64. Add a runner only if real us
 
 ## Versioning And Install Layout
 
-The release git tag equals `manifest.version`. The sidecar binary reports its own version via `system_info`; the plugin compares `system_info.sidecarVersion` against `manifest.version` and offers to install the matching sidecar when they differ.
+The release git tag equals `manifest.version`. The sidecar binary reports its own compiled version (`CARGO_PKG_VERSION`) via `health_ok`/`system_info`. Because Obsidian's updater replaces only the plugin files and never the separately-installed sidecar, the plugin detects drift on startup by comparing the installed sidecar's recorded version (`bin/<variant>/install.json`) against `manifest.version`, and offers a one-click reinstall of the matching sidecar when they differ.
 
 The installer fetches `checksums.txt` at runtime alongside the selected sidecar archive and verifies the downloaded archive's SHA-256 before unpacking. Checksums are not embedded into `main.js`; the release manifest remains authoritative.
 

--- a/native/src/main.rs
+++ b/native/src/main.rs
@@ -3,7 +3,7 @@ use std::sync::mpsc::{self, Receiver};
 use std::thread;
 use std::time::Duration;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result};
 use local_dictation_sidecar::app::{AppState, ControlFlow};
 use local_dictation_sidecar::catalog::ModelCatalog;
 use local_dictation_sidecar::protocol::{Event, IncomingFrame, read_frame, write_event_frame};
@@ -18,16 +18,15 @@ enum InputMessage {
 fn main() -> Result<()> {
     install_logging_hooks();
 
-    let config = SidecarStartupConfig::from_args(std::env::args().skip(1))?;
     let catalog = ModelCatalog::load_bundled()?;
-    run_stdio(catalog, config.app_version)
+    run_stdio(catalog, env!("CARGO_PKG_VERSION").to_string())
 }
 
-fn run_stdio(catalog: ModelCatalog, app_version: String) -> Result<()> {
+fn run_stdio(catalog: ModelCatalog, sidecar_version: String) -> Result<()> {
     let stdout = io::stdout();
     let mut writer = io::BufWriter::new(stdout.lock());
     let input_rx = spawn_input_reader();
-    let mut app_state = AppState::new(app_version, catalog);
+    let mut app_state = AppState::new(sidecar_version, catalog);
 
     loop {
         write_events(&mut writer, app_state.drain_pending_outputs())?;
@@ -66,31 +65,6 @@ fn run_stdio(catalog: ModelCatalog, app_version: String) -> Result<()> {
     }
 
     Ok(())
-}
-
-#[derive(Debug)]
-struct SidecarStartupConfig {
-    app_version: String,
-}
-
-impl SidecarStartupConfig {
-    fn from_args(args: impl IntoIterator<Item = String>) -> Result<Self> {
-        let mut app_version = env!("CARGO_PKG_VERSION").to_string();
-        let mut args = args.into_iter();
-
-        while let Some(argument) = args.next() {
-            match argument.as_str() {
-                "--app-version" => {
-                    app_version = args
-                        .next()
-                        .ok_or_else(|| anyhow!("--app-version requires a version string"))?;
-                }
-                _ => return Err(anyhow!("unsupported sidecar argument: {argument}")),
-            }
-        }
-
-        Ok(Self { app_version })
-    }
 }
 
 fn spawn_input_reader() -> Receiver<InputMessage> {
@@ -132,25 +106,4 @@ fn write_events(writer: &mut impl Write, events: Vec<Event>) -> Result<()> {
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::SidecarStartupConfig;
-
-    #[test]
-    fn startup_config_accepts_app_version_override() {
-        let config =
-            SidecarStartupConfig::from_args(["--app-version".to_string(), "1.0.0".to_string()])
-                .expect("config should parse");
-
-        assert_eq!(config.app_version, "1.0.0");
-    }
-
-    #[test]
-    fn startup_config_uses_cargo_version_by_default() {
-        let config = SidecarStartupConfig::from_args([]).expect("config should parse");
-
-        assert_eq!(config.app_version, env!("CARGO_PKG_VERSION"));
-    }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,10 @@ import {
   resolvePluginSettings,
 } from './settings/plugin-settings';
 import { LocalSttSettingTab } from './settings/settings-tab';
+import {
+  openSidecarInstallModal,
+  type SidecarInstallActionDeps,
+} from './settings/sidecar-settings-section';
 import { SetupWizardModal } from './setup/setup-wizard-modal';
 import { formatErrorMessage } from './shared/format-utils';
 import { createPluginLogger, type PluginLogger } from './shared/plugin-logger';
@@ -27,8 +31,17 @@ import { assertSidecarExecutableIsFresh } from './sidecar/sidecar-build-state';
 import { SidecarConnection } from './sidecar/sidecar-connection';
 import { formatSidecarExecutableName } from './sidecar/sidecar-executable';
 import { SidecarInstallManager } from './sidecar/sidecar-install-manager';
-import { resolveSidecarExecutablePath, SidecarNotInstalledError } from './sidecar/sidecar-paths';
+import {
+  type ResolvedSidecarExecutable,
+  type ResolveSidecarExecutablePathOptions,
+  resolveSidecarExecutablePath,
+  SidecarNotInstalledError,
+} from './sidecar/sidecar-paths';
 import type { SidecarLaunchSpec } from './sidecar/sidecar-process';
+import {
+  detectSidecarVersionDrift,
+  type SidecarVersionDrift,
+} from './sidecar/sidecar-version-drift';
 import { DictationRibbonController } from './ui/dictation-ribbon';
 import { LOCAL_DICTATION_VIEW_TYPE, LocalDictationView } from './ui/local-dictation-view';
 
@@ -176,6 +189,11 @@ export default class LocalSttPlugin extends Plugin {
 
   private async runPostLayoutStartup(): Promise<void> {
     await this.bootstrapLocalDictationSidebar();
+
+    // Surface sidecar/plugin version drift before the health handshake. An
+    // Obsidian update swaps the plugin files but never the separately-installed
+    // sidecar, so a stale sidecar may even be the reason the handshake fails.
+    await this.checkSidecarVersionDrift();
 
     try {
       await this.checkSidecarHealth({ showNotice: false });
@@ -419,24 +437,29 @@ export default class LocalSttPlugin extends Plugin {
         : undefined;
 
     return {
-      args: ['--app-version', this.manifest.version],
       command: executablePath,
       cwd: dirname(executablePath),
       ...(env ? { env } : {}),
     };
   }
 
-  private async resolveSidecarExecutablePath(): Promise<string> {
-    const pluginDirectory = await this.resolvePluginDirectoryPath();
-    const sidecarProjectDirectory = join(pluginDirectory, 'native');
-    const resolved = await resolveSidecarExecutablePath({
+  private buildSidecarResolutionOptions(
+    pluginDirectory: string,
+  ): ResolveSidecarExecutablePathOptions {
+    return {
       accelerationPreference: this.settings.accelerationPreference,
       executableName: getSidecarExecutableName(),
       pluginDirectory,
       sidecarPathOverride: this.settings.sidecarPathOverride,
-      sidecarProjectDirectory,
+      sidecarProjectDirectory: join(pluginDirectory, 'native'),
       supportsCuda: !Platform.isMacOS,
-    });
+    };
+  }
+
+  private async resolveSidecarExecutablePath(): Promise<string> {
+    const pluginDirectory = await this.resolvePluginDirectoryPath();
+    const options = this.buildSidecarResolutionOptions(pluginDirectory);
+    const resolved = await resolveSidecarExecutablePath(options);
 
     if (resolved.source === 'installed' && resolved.variant !== null) {
       this.logger.debug(
@@ -447,10 +470,104 @@ export default class LocalSttPlugin extends Plugin {
       if (resolved.variant === 'cuda') {
         this.logger.debug('sidecar', `using CUDA sidecar build at ${resolved.path}`);
       }
-      await assertSidecarExecutableIsFresh(resolved.path, sidecarProjectDirectory);
+      await assertSidecarExecutableIsFresh(resolved.path, options.sidecarProjectDirectory);
     }
 
     return resolved.path;
+  }
+
+  /**
+   * On startup, compare the installed sidecar's recorded version against the
+   * current plugin version and prompt for a one-click reinstall when they
+   * differ. Obsidian updates the plugin files but never the separately-
+   * installed sidecar, so the two silently fall out of sync after an update.
+   * Self-contained: every failure path (including no sidecar installed) is
+   * swallowed so this can never disrupt startup.
+   */
+  private async checkSidecarVersionDrift(): Promise<void> {
+    let pluginDirectory: string;
+    let resolved: ResolvedSidecarExecutable;
+
+    try {
+      pluginDirectory = await this.resolvePluginDirectoryPath();
+      resolved = await resolveSidecarExecutablePath(
+        this.buildSidecarResolutionOptions(pluginDirectory),
+      );
+    } catch (error) {
+      // No installed sidecar (or an unreadable plugin dir): the setup and
+      // health paths own that case — there is no installed version to compare.
+      if (!(error instanceof SidecarNotInstalledError)) {
+        this.logger.error('sidecar', 'version drift check could not resolve sidecar', error);
+      }
+      return;
+    }
+
+    // Only a release-installed sidecar carries an install.json version. Dev
+    // builds and explicit path overrides are intentionally exempt.
+    if (resolved.source !== 'installed' || resolved.variant === null) return;
+
+    let drift: SidecarVersionDrift | null;
+    try {
+      drift = await detectSidecarVersionDrift({
+        pluginDirectory,
+        pluginVersion: this.manifest.version,
+        variant: resolved.variant,
+      });
+    } catch (error) {
+      this.logger.error('sidecar', 'version drift check failed', error);
+      return;
+    }
+
+    if (drift === null) return;
+
+    this.logger.debug(
+      'sidecar',
+      `sidecar version drift: installed ${drift.installedVersion}, plugin ${drift.pluginVersion}`,
+    );
+    this.notifySidecarVersionDrift(drift, pluginDirectory);
+  }
+
+  private notifySidecarVersionDrift(drift: SidecarVersionDrift, pluginDirectory: string): void {
+    const notice = new Notice(
+      createFragment((fragment) => {
+        fragment.createDiv({
+          text: `Local Dictation updated to ${drift.pluginVersion}, but its speech engine is still ${drift.installedVersion}. Reinstall to keep them in sync.`,
+        });
+        fragment
+          .createEl('a', { href: '#', text: 'Reinstall speech engine' })
+          .addEventListener('click', (event) => {
+            event.preventDefault();
+            notice.hide();
+            openSidecarInstallModal(this.buildSidecarInstallActionDeps(), {
+              intent: 'reinstall',
+              pluginDirectory,
+              variant: drift.variant,
+            });
+          });
+      }),
+      0,
+    );
+  }
+
+  private buildSidecarInstallActionDeps(): SidecarInstallActionDeps {
+    return {
+      app: this.app,
+      isDictationBusy: () => this.dictationController?.isBusy() ?? false,
+      logger: this.logger,
+      modelInstallManager: this.requireModelInstallManager(),
+      pluginVersion: this.manifest.version,
+      refreshSettingsTab: () => {
+        // No-op: the settings tab re-reads install manifests on each render, so
+        // a reinstall from this startup notice needs no explicit refresh.
+      },
+      restartSidecar: async () => {
+        await this.requireSidecarConnection().restart(
+          this.settings.sidecarStartupTimeoutSeconds * 1000,
+        );
+      },
+      sidecarConnection: this.requireSidecarConnection(),
+      sidecarInstallManager: this.requireSidecarInstallManager(),
+    };
   }
 
   private async resolvePluginDirectoryPath(): Promise<string> {

--- a/src/sidecar/sidecar-version-drift.ts
+++ b/src/sidecar/sidecar-version-drift.ts
@@ -1,0 +1,50 @@
+import {
+  readInstallManifest,
+  type SidecarInstallVariant,
+  variantDirectoryPath,
+} from './sidecar-installer';
+
+export interface SidecarVersionDrift {
+  installedVersion: string;
+  pluginVersion: string;
+  variant: SidecarInstallVariant;
+}
+
+/**
+ * True when the on-disk sidecar was installed by a different plugin version.
+ *
+ * Obsidian's updater replaces only `main.js`/`manifest.json`/`styles.css`; the
+ * separately-installed sidecar under `bin/<variant>/` is never touched. So a
+ * plugin update silently leaves a stale sidecar behind. We compare the version
+ * recorded in `install.json` (what the installer downloaded) against the
+ * current plugin version. Versions are exact release tags, so a trimmed
+ * string inequality is the right test.
+ */
+export function isSidecarVersionDrifted(installedVersion: string, pluginVersion: string): boolean {
+  return installedVersion.trim() !== pluginVersion.trim();
+}
+
+/**
+ * Reads the install manifest for `variant` and reports version drift against
+ * `pluginVersion`. Returns `null` when there is nothing to prompt about: no
+ * manifest on disk (sidecar not installed for this variant), or the installed
+ * version already matches the plugin.
+ */
+export async function detectSidecarVersionDrift(params: {
+  pluginDirectory: string;
+  pluginVersion: string;
+  variant: SidecarInstallVariant;
+}): Promise<SidecarVersionDrift | null> {
+  const manifest = await readInstallManifest(
+    variantDirectoryPath(params.pluginDirectory, params.variant),
+  );
+
+  if (manifest === null) return null;
+  if (!isSidecarVersionDrifted(manifest.version, params.pluginVersion)) return null;
+
+  return {
+    installedVersion: manifest.version,
+    pluginVersion: params.pluginVersion,
+    variant: params.variant,
+  };
+}

--- a/test/sidecar-version-drift.test.ts
+++ b/test/sidecar-version-drift.test.ts
@@ -1,0 +1,90 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { type SidecarInstallVariant, variantDirectoryPath } from '../src/sidecar/sidecar-installer';
+import {
+  detectSidecarVersionDrift,
+  isSidecarVersionDrifted,
+} from '../src/sidecar/sidecar-version-drift';
+
+const tempDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirectories.splice(0).map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+describe('isSidecarVersionDrifted', () => {
+  it('treats identical versions as in sync', () => {
+    expect(isSidecarVersionDrifted('2026.5.23', '2026.5.23')).toBe(false);
+  });
+
+  it('flags differing versions as drifted', () => {
+    expect(isSidecarVersionDrifted('2026.5.19', '2026.5.23')).toBe(true);
+  });
+
+  it('ignores surrounding whitespace', () => {
+    expect(isSidecarVersionDrifted(' 2026.5.23 ', '2026.5.23')).toBe(false);
+  });
+});
+
+describe('detectSidecarVersionDrift', () => {
+  it('returns null when the variant has no install manifest', async () => {
+    const pluginDirectory = await createTempDirectory();
+
+    await expect(
+      detectSidecarVersionDrift({ pluginDirectory, pluginVersion: '2026.5.23', variant: 'cpu' }),
+    ).resolves.toBeNull();
+  });
+
+  it('returns null when the installed version matches the plugin version', async () => {
+    const pluginDirectory = await createTempDirectory();
+    await writeInstallManifest(pluginDirectory, 'cpu', '2026.5.23');
+
+    await expect(
+      detectSidecarVersionDrift({ pluginDirectory, pluginVersion: '2026.5.23', variant: 'cpu' }),
+    ).resolves.toBeNull();
+  });
+
+  it('reports drift when the installed version differs from the plugin version', async () => {
+    const pluginDirectory = await createTempDirectory();
+    await writeInstallManifest(pluginDirectory, 'cuda', '2026.5.19');
+
+    await expect(
+      detectSidecarVersionDrift({ pluginDirectory, pluginVersion: '2026.5.23', variant: 'cuda' }),
+    ).resolves.toEqual({
+      installedVersion: '2026.5.19',
+      pluginVersion: '2026.5.23',
+      variant: 'cuda',
+    });
+  });
+});
+
+async function createTempDirectory(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), 'obsidian-local-stt-drift-'));
+  tempDirectories.push(path);
+  return path;
+}
+
+async function writeInstallManifest(
+  pluginDirectory: string,
+  variant: SidecarInstallVariant,
+  version: string,
+): Promise<void> {
+  const variantDir = variantDirectoryPath(pluginDirectory, variant);
+  await mkdir(variantDir, { recursive: true });
+  await writeFile(
+    join(variantDir, 'install.json'),
+    JSON.stringify({
+      installedAt: '2026-05-19T00:00:00.000Z',
+      sha256: '0'.repeat(64),
+      variant,
+      version,
+    }),
+    'utf8',
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #116. After an Obsidian plugin update, the separately-installed native sidecar (`bin/<variant>/`) is never replaced, so it silently drifts to an older version than the plugin. Nothing detected this, and the version the sidecar *reported* was misleading: the plugin launched it with `--app-version <manifest.version>` and the sidecar echoed that flag straight back, so `sidecarVersion` always equalled the plugin version and could never reveal a mismatch.

This implements scope **A (detect & prompt) + C (honest version)** from the issue.

## Changes

**Honest version (C)**
- `native/src/main.rs`: stop parsing `--app-version`; the sidecar now reports its true compiled `CARGO_PKG_VERSION` via `health_ok`/`system_info`. The flag is no longer parsed at all, so an older plugin that still passes it is ignored rather than rejected (keeps plugin/sidecar version skew working in both directions). Removed the now-obsolete `SidecarStartupConfig` and its two unit tests.
- `src/main.ts`: the plugin no longer sends `--app-version`. The existing "sidecar ready/restarted (vX)" notices now show the real binary version for free.

**Drift detection (A)**
- New `src/sidecar/sidecar-version-drift.ts`: a pure `isSidecarVersionDrifted()` predicate plus a thin `detectSidecarVersionDrift()` that composes the existing `readInstallManifest()`.
- `src/main.ts`: a self-contained `checkSidecarVersionDrift()` runs on startup, before the health handshake (a stale sidecar can be the reason the handshake fails). It resolves the active variant and, on a mismatch, shows a sticky `Notice` whose action reuses the existing `openSidecarInstallModal(..., intent: 'reinstall')` flow — same dictation-busy guard, same shutdown-before-replace, same post-install restart. No prompt when versions match, for dev builds, or for path overrides.

**Docs**
- `docs/release/release-planning.md` corrected to describe the implemented mechanism (compiled version reported via `health_ok`/`system_info`; drift detected by comparing `install.json` against `manifest.version`).

## Acceptance criteria

- [x] Sidecar reports its true compiled version (`CARGO_PKG_VERSION`) rather than the `--app-version` echo
- [x] On startup, the plugin compares `install.json.version` against `manifest.version`
- [x] On mismatch, the user is informed and offered a one-click reinstall of the matching sidecar
- [x] No prompt is shown when versions match
- [x] `docs/release/release-planning.md` corrected to match the implemented behavior
- [x] Tests cover the mismatch-detection logic

## Verification

- `npm run check:frontend` — typecheck, lint, and **386 tests pass** (including 6 new in `test/sidecar-version-drift.test.ts`: match -> no prompt, mismatch -> prompt, no manifest -> no prompt, plus the pure predicate). Bundle builds.
- `cargo fmt --check` and `cargo clippy --all-targets --features engine-cohere-transcribe,engine-whisper -- -D warnings` both pass (clippy type-checks every target, including the test code).
- `cargo test` (the third `check:rust` step) could not be exercised **locally**: building the bundled `whisper.cpp` aborts because this machine's Visual Studio 18 preview / CMake 4.2 toolchain fails CMake's "working C compiler" test on a trivial program. That is a pre-existing local-environment issue independent of this change (it fails identically on `main`); CI builds the sidecar on its standard runners, so the full suite runs there. `main.rs` is the only Rust change, and clippy already compiled all targets.

### Manual test
Edit `bin/<variant>/install.json` `version` to an older value and relaunch the plugin: a mismatch notice appears offering reinstall. Restore and relaunch: no prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
