### PR TITLE
chore(release): sync sidecar and lockfile versions to 2026.6.7

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -723,7 +723,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "local-dictation-sidecar"
-version = "2026.5.24"
+version = "2026.6.7"
 dependencies = [
  "anyhow",
  "directories",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-dictation-sidecar"
-version = "2026.5.24"
+version = "2026.6.7"
 edition = "2024"
 license = "MIT"
 rust-version = "1.94.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "local-dictation",
-  "version": "2026.5.24",
+  "version": "2026.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "local-dictation",
-      "version": "2026.5.24",
+      "version": "2026.6.7",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "2.4.16",


### PR DESCRIPTION
## Why

The `2026.6.7` cut (`112a248`, merged in #122) bumped `package.json`, `manifest.json`, and `versions.json` but missed three current-version sources, leaving them at `2026.5.24`:

- `native/Cargo.toml`
- `native/Cargo.lock`
- `package-lock.json` (root + `packages[""]`)

`scripts/read-release-version.mjs` (the release workflow's `metadata` gate) requires `manifest.json`, `package.json`, and `native/Cargo.toml` to match exactly. **Without this, pushing the `2026.6.7` tag would fail the release workflow before building anything.** Verified locally: the validator now resolves `2026.6.7` and accepts the tag.

## Scope

Version-string sync only — all current-version sources to `2026.6.7`. `versions.json`'s `2026.5.24 → 1.8.7` entry is left intact (historical app-compat ledger; the `2026.6.7` entry is already present).

Blocks the `2026.6.7` release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)