### PR TITLE
fix(types): stay type-resolvable under the Obsidian scanner's TypeScript 5.4

### DIFF
--- a/src/audio/audio-visualizer-tap.ts
+++ b/src/audio/audio-visualizer-tap.ts
@@ -64,7 +64,7 @@ export class AudioVisualizerTap implements AudioBandReader, AudioVisualizerAttac
 
   private analyser: AnalyserNode | null = null;
   private bandRanges: readonly BandRange[] = [];
-  private frequencyBuffer: Uint8Array<ArrayBuffer> | null = null;
+  private frequencyBuffer: ReturnType<typeof allocFrequencyBuffer> | null = null;
   private readonly smoothed: Float32Array = new Float32Array(BAND_COUNT);
   private readonly peaks: Float32Array = new Float32Array(BAND_COUNT);
 
@@ -81,7 +81,7 @@ export class AudioVisualizerTap implements AudioBandReader, AudioVisualizerAttac
     sourceNode.connect(analyser);
 
     this.analyser = analyser;
-    this.frequencyBuffer = new Uint8Array(analyser.frequencyBinCount);
+    this.frequencyBuffer = allocFrequencyBuffer(analyser.frequencyBinCount);
     this.bandRanges = computeBandRanges(audioContext.sampleRate, analyser.frequencyBinCount);
     this.smoothed.fill(0);
     this.peaks.fill(PEAK_FLOOR);
@@ -132,7 +132,17 @@ export class AudioVisualizerTap implements AudioBandReader, AudioVisualizerAttac
   }
 }
 
-function meanNormalized(buffer: Uint8Array<ArrayBuffer>, lo: number, hi: number): number {
+/**
+ * `frequencyBuffer` borrows this return type instead of being annotated
+ * `Uint8Array<ArrayBuffer>` (required by `getByteFrequencyData`): generic
+ * typed-array syntax needs TS >= 5.7, and the Obsidian code scanner lints
+ * with an older TypeScript that would turn it into an unresolved type.
+ */
+function allocFrequencyBuffer(length: number) {
+  return new Uint8Array(length);
+}
+
+function meanNormalized(buffer: Uint8Array, lo: number, hi: number): number {
   if (hi <= lo) {
     return 0;
   }

--- a/src/sidecar/protocol.ts
+++ b/src/sidecar/protocol.ts
@@ -443,7 +443,7 @@ export interface JsonFrame<TEnvelope> {
 }
 
 export interface AudioFrame {
-  frameBytes: Uint8Array<ArrayBufferLike>;
+  frameBytes: Uint8Array;
   kind: typeof AUDIO_FRAME_KIND;
   sessionId: string;
 }
@@ -483,7 +483,7 @@ export interface PushChunkResult<TEnvelope> {
 }
 
 export class FramedMessageParser<TEnvelope> {
-  private buffered: Uint8Array<ArrayBufferLike> = new Uint8Array(0);
+  private buffered: Uint8Array = new Uint8Array(0);
 
   constructor(private readonly parseJsonEnvelope: (jsonText: string) => TEnvelope) {}
 
@@ -491,7 +491,7 @@ export class FramedMessageParser<TEnvelope> {
     this.buffered = new Uint8Array(0);
   }
 
-  pushChunk(chunk: Uint8Array<ArrayBufferLike>): PushChunkResult<TEnvelope> {
+  pushChunk(chunk: Uint8Array): PushChunkResult<TEnvelope> {
     this.buffered = concatBytes(this.buffered, chunk);
 
     const frames: ParsedFrame<TEnvelope>[] = [];
@@ -591,10 +591,7 @@ function encodeFrame(kind: number, payload: Uint8Array): Uint8Array {
   return frame;
 }
 
-function concatBytes(
-  left: Uint8Array<ArrayBufferLike>,
-  right: Uint8Array<ArrayBufferLike>,
-): Uint8Array<ArrayBufferLike> {
+function concatBytes(left: Uint8Array, right: Uint8Array): Uint8Array {
   const concatenated = new Uint8Array(left.byteLength + right.byteLength);
   concatenated.set(left, 0);
   concatenated.set(right, left.byteLength);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "strict": true,


### PR DESCRIPTION
## Summary
- Lower tsconfig `lib` from ES2024 to ES2022 (no ES2023+ APIs are used anywhere in src/ or test/) so the standard library loads under the TypeScript 5.4.5 pinned by eslint-plugin-obsidianmd, which the Obsidian community scanner lints with.
- Replace generic typed-array syntax (`Uint8Array<ArrayBufferLike>` in src/sidecar/protocol.ts, `Uint8Array<ArrayBuffer>` in src/audio/audio-visualizer-tap.ts) — TS 5.7+ syntax that turns into unresolved error types under TS 5.4, flooding the scan with `no-unsafe-*` "type that could not be resolved" warnings. Where `Uint8Array<ArrayBuffer>` is genuinely required (`getByteFrequencyData`), the type is borrowed via inference from an `allocFrequencyBuffer` helper instead of written out.

## Test Plan
- [x] 434/434 vitest tests pass
- [x] `npm run typecheck` clean under TS 6.0.3
- [x] `npm run lint:obsidian` clean under both TS 6.0.3 and a scanner-matching `typescript@5.4.5` install (was 35 errors before the fix)

Note: the preview scan on this commit still reports ~2,089 warnings, but those all trace to the scan sandbox failing to install repo dependencies (obsidian / @codemirror/* / @types/node unresolvable) — an Obsidian-side issue reported to their team, not fixable in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)