### PR TITLE
fix(llm): routing follow-ups from the OpenRouter release

### DIFF
--- a/src/llm/ollama-client.ts
+++ b/src/llm/ollama-client.ts
@@ -25,12 +25,22 @@ export interface OllamaModelOption {
 }
 
 export class OllamaClientError extends Error {
+  readonly responseText?: string;
+  readonly status?: number;
+
   constructor(
     message: string,
     public readonly code: 'connection_failed' | 'http_error' | 'invalid_response' | 'timeout',
+    options: { responseText?: string | undefined; status?: number | undefined } = {},
   ) {
     super(message);
     this.name = 'OllamaClientError';
+    if (options.responseText !== undefined) {
+      this.responseText = options.responseText;
+    }
+    if (options.status !== undefined) {
+      this.status = options.status;
+    }
   }
 }
 
@@ -224,7 +234,12 @@ function requestText(
           if (exceeded) return;
           const statusCode = response.statusCode ?? 0;
           if (statusCode < 200 || statusCode >= 300) {
-            reject(new OllamaClientError(`Ollama returned HTTP ${statusCode}.`, 'http_error'));
+            reject(
+              new OllamaClientError(`Ollama returned HTTP ${statusCode}.`, 'http_error', {
+                responseText: Buffer.concat(chunks).toString('utf8'),
+                status: statusCode,
+              }),
+            );
             return;
           }
           resolve(Buffer.concat(chunks).toString('utf8'));

--- a/src/llm/ollama-provider.ts
+++ b/src/llm/ollama-provider.ts
@@ -44,6 +44,15 @@ export class OllamaProvider implements LlmProvider {
 
 function mapOllamaError(error: unknown): ProviderError {
   if (error instanceof OllamaClientError) {
+    // Ollama reports a missing/unpulled model as a 404 from /api/chat; surface
+    // it as unknown_model so the UI names the real problem (mirrors OpenRouter).
+    if (
+      error.code === 'http_error' &&
+      error.status === 404 &&
+      /model/i.test(error.responseText ?? error.message)
+    ) {
+      return new ProviderError('Ollama model was not found.', 'unknown_model');
+    }
     return new ProviderError(error.message, error.code);
   }
 

--- a/src/llm/openrouter-provider.ts
+++ b/src/llm/openrouter-provider.ts
@@ -1,5 +1,5 @@
 import { isRecord } from '../shared/type-guards';
-import { fetchJson, PROBE_TIMEOUT_MS } from './http-shared';
+import { CLEANUP_TIMEOUT_MS, fetchJson, PROBE_TIMEOUT_MS } from './http-shared';
 import { outputTokenBudget } from './output-budget';
 import type {
   CleanupOptions,
@@ -15,16 +15,19 @@ const OPENROUTER_API_BASE_URL = 'https://openrouter.ai/api/v1';
 interface OpenRouterProviderOptions {
   apiKey: string;
   baseUrl?: string;
+  timeoutMs?: number;
 }
 
 export class OpenRouterProvider implements LlmProvider {
   readonly id = 'openrouter' as const;
   private readonly apiKey: string;
   private readonly baseUrl: string;
+  private readonly timeoutMs: number;
 
   constructor(options: OpenRouterProviderOptions) {
     this.apiKey = options.apiKey.trim();
     this.baseUrl = options.baseUrl ?? OPENROUTER_API_BASE_URL;
+    this.timeoutMs = options.timeoutMs ?? CLEANUP_TIMEOUT_MS;
   }
 
   async cleanup(options: CleanupOptions): Promise<string> {
@@ -54,7 +57,7 @@ export class OpenRouterProvider implements LlmProvider {
           },
           method: 'POST',
         },
-        { abortSignal: options.abortSignal },
+        { abortSignal: options.abortSignal, timeoutMs: this.timeoutMs },
       );
 
       return parseChatContent(response);

--- a/src/llm/provider.ts
+++ b/src/llm/provider.ts
@@ -19,6 +19,7 @@ export type ProviderErrorCode =
   | 'connection_failed'
   | 'http_error'
   | 'invalid_response'
+  | 'model_not_configured'
   | 'rate_limited'
   | 'timeout'
   | 'unknown_model';
@@ -94,7 +95,10 @@ export function createProvider(providerId: LlmProviderId, settings: PluginSettin
     case 'ollama':
       return new OllamaProvider();
     case 'openrouter':
-      return new OpenRouterProvider({ apiKey: settings.llmOpenRouterApiKey });
+      return new OpenRouterProvider({
+        apiKey: settings.llmOpenRouterApiKey,
+        timeoutMs: settings.llmRemoteTimeoutSec * 1000,
+      });
   }
 }
 

--- a/src/llm/router.ts
+++ b/src/llm/router.ts
@@ -28,8 +28,8 @@ export interface LlmRouter {
 
 // Routes each cleanup call to a provider by message size (see
 // `selectRouteProviderId`), resolves that provider's configured model, and
-// raises a typed `unknown_model` error when it is missing so callers surface a
-// cleanup failure (keep raw + banner) instead of a malformed request.
+// raises a typed `model_not_configured` error when it is missing so callers
+// surface a cleanup failure (keep raw + banner) instead of a malformed request.
 export function createLlmRouter(
   settings: PluginSettings,
   createProviderFn = createProvider,
@@ -52,7 +52,7 @@ export function createLlmRouter(
       if (model.length === 0) {
         throw new ProviderError(
           `${formatLlmProviderName(providerId)} model is not configured.`,
-          'unknown_model',
+          'model_not_configured',
         );
       }
 

--- a/src/settings/plugin-settings.ts
+++ b/src/settings/plugin-settings.ts
@@ -106,6 +106,7 @@ export interface PluginSettings {
   llmPostprocessUserPresets: LlmUserPreset[];
   llmProviderModels: LlmProviderModels;
   llmRemoteThresholdChars: number;
+  llmRemoteTimeoutSec: number;
   llmRouting: LlmRouting;
   localTranscriptSidebarBootstrapped: boolean;
   modelStorePathOverride: string;
@@ -151,6 +152,7 @@ export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
     openrouter: '',
   },
   llmRemoteThresholdChars: DEFAULT_LLM_REMOTE_THRESHOLD_CHARS,
+  llmRemoteTimeoutSec: 60,
   llmRouting: 'local',
   localTranscriptSidebarBootstrapped: false,
   modelStorePathOverride: '',
@@ -249,6 +251,12 @@ export function resolvePluginSettings(data: unknown): PluginSettings {
       DEFAULT_PLUGIN_SETTINGS.llmRemoteThresholdChars,
       MIN_LLM_REMOTE_THRESHOLD_CHARS,
       MAX_LLM_REMOTE_THRESHOLD_CHARS,
+    ),
+    llmRemoteTimeoutSec: readClampedInteger(
+      raw.llmRemoteTimeoutSec,
+      DEFAULT_PLUGIN_SETTINGS.llmRemoteTimeoutSec,
+      5,
+      600,
     ),
     llmRouting: resolveLlmRouting(raw),
     localTranscriptSidebarBootstrapped: readBoolean(

--- a/src/ui/llm-provider-ui.ts
+++ b/src/ui/llm-provider-ui.ts
@@ -55,8 +55,10 @@ export function formatCleanupFailureBanner(failure: LlmCleanupFailure): string {
     case 'connection_failed':
     case 'timeout':
       return `Network error reaching ${providerName}.`;
+    case 'model_not_configured':
+      return `${providerName} model is not configured. Pick one under Where it runs.`;
     case 'unknown_model':
-      return 'Selected model not found.';
+      return `${providerName} model not found. Pick another under Where it runs.`;
     default:
       return 'LLM transform failed. See console.';
   }

--- a/src/ui/llm-routing-controls.ts
+++ b/src/ui/llm-routing-controls.ts
@@ -1,4 +1,11 @@
-import { AbstractInputSuggest, type App, Notice, Setting, setIcon } from 'obsidian';
+import {
+  AbstractInputSuggest,
+  type App,
+  type ExtraButtonComponent,
+  Notice,
+  Setting,
+  setIcon,
+} from 'obsidian';
 
 import {
   createProvider,
@@ -7,12 +14,14 @@ import {
   type LlmProviderId,
   type LlmRouting,
   type ModelOption,
+  ProviderError,
   type ProviderHealth,
   withProviderModel,
 } from '../llm/provider';
 import { isLlmRouting, type PluginSettings } from '../settings/plugin-settings';
+import { appendInfoTooltip } from '../settings/setting-helpers';
 import type { PluginLogger } from '../shared/plugin-logger';
-import { priceTier, providerHealthFromError } from './llm-provider-ui';
+import { formatCleanupFailureBanner, priceTier, providerHealthFromError } from './llm-provider-ui';
 import { deriveInlineStatus, INLINE_STATUS_PRESENTATION } from './llm-status';
 
 export interface LlmRoutingControlsDependencies {
@@ -33,6 +42,7 @@ const ROUTING_SEGMENTS: ReadonlyArray<{ label: string; value: LlmRouting }> = [
 // Rough chars-per-token ratio used only for the human-readable threshold hint.
 const CHARS_PER_TOKEN = 4;
 const API_KEY_REFRESH_DEBOUNCE_MS = 500;
+const TEST_RESULT_ICON_MS = 2500;
 
 interface ProviderState {
   health: ProviderHealth;
@@ -111,6 +121,7 @@ export class LlmRoutingControls {
   private apiKeyRefreshTimerId: number | null = null;
   private modelsRefreshInFlight: Partial<Record<LlmProviderId, boolean>> = {};
   private onModelInput: ((element: HTMLElement) => void) | null = null;
+  private openRouterTestInFlight = false;
 
   constructor(private readonly dependencies: LlmRoutingControlsDependencies) {}
 
@@ -127,24 +138,35 @@ export class LlmRoutingControls {
   }
 
   // Kick off background model loads for whichever providers the current routing
-  // needs, so the dropdowns are populated by the time the user looks.
+  // needs, so the dropdowns are populated by the time the user looks. Called on
+  // open, window focus, and routing changes — points where the outside world may
+  // have changed — so it also retries providers whose last load left them
+  // unhealthy (e.g. Ollama was started after the first probe).
   refreshActiveProviders(): void {
     const settings = this.dependencies.getSettings();
     if (!settings.llmRemoteFeaturesEnabled) {
-      this.warmModels('ollama');
+      this.recheckModels('ollama');
       return;
     }
     if (settings.llmRouting === 'local' || settings.llmRouting === 'auto') {
-      this.warmModels('ollama');
+      this.recheckModels('ollama');
     }
     if (settings.llmRouting === 'remote' || settings.llmRouting === 'auto') {
-      this.warmModels('openrouter');
+      this.recheckModels('openrouter');
     }
   }
 
-  // Background warm: load a provider's catalog once. Unlike the manual refresh
-  // button, this skips providers already loaded or in flight, so it is safe to
-  // call on every render and window focus without re-fetching the catalog.
+  private recheckModels(providerId: LlmProviderId): void {
+    const state = this.providers[providerId];
+    if (state.modelsLoaded && state.health.kind === 'ready') {
+      return;
+    }
+    void this.refreshModels(providerId, { silent: true });
+  }
+
+  // Background warm: load a provider's catalog once. Unlike `recheckModels`,
+  // this never retries a failed load — a failure triggers a re-render, and the
+  // render paths below call this, so retrying here would loop.
   private warmModels(providerId: LlmProviderId): void {
     const state = this.providers[providerId];
     if (state.modelsLoaded || this.modelsRefreshInFlight[providerId] === true) {
@@ -243,10 +265,10 @@ export class LlmRoutingControls {
         });
       });
 
-    parent.createEl('p', {
-      cls: 'local-dictation-muted',
-      text: 'Large transcripts can overflow a local model’s context or run slowly — Auto sends just those to OpenRouter.',
-    });
+    appendInfoTooltip(
+      setting,
+      'Large transcripts can overflow a local model’s context or run slowly — Auto sends just those to OpenRouter.',
+    );
   }
 
   private renderLeg(parent: HTMLElement, label: string): void {
@@ -354,6 +376,13 @@ export class LlmRoutingControls {
           );
           refreshStatus();
         });
+      })
+      .addExtraButton((button) => {
+        button.setIcon('plug-zap').setTooltip('Test API key and model');
+        button.extraSettingsEl.setAttribute('aria-label', 'Test OpenRouter API key and model');
+        button.onClick(() => {
+          void this.runOpenRouterTest(button);
+        });
       });
 
     refreshStatus = this.renderStatusRow(parent, 'openrouter');
@@ -388,6 +417,65 @@ export class LlmRoutingControls {
     };
     update();
     return update;
+  }
+
+  // Proves the whole remote path — key, credits, and the exact model id — with a
+  // minimal real completion. Returns null on success, or a user-facing failure
+  // message in the same vocabulary as the cleanup-failure banner.
+  async testOpenRouter(): Promise<string | null> {
+    const settings = this.dependencies.getSettings();
+    const model = getProviderModel(settings, 'openrouter').trim();
+    if (model.length === 0) {
+      return formatCleanupFailureBanner({
+        code: 'model_not_configured',
+        message: '',
+        providerId: 'openrouter',
+      });
+    }
+
+    try {
+      await createProvider('openrouter', settings).cleanup({
+        model,
+        prompt: 'Reply with the single word OK.',
+        temperature: 0,
+        userMessage: 'ping',
+      });
+      return null;
+    } catch (error) {
+      const providerError =
+        error instanceof ProviderError
+          ? error
+          : new ProviderError(
+              error instanceof Error ? error.message : String(error),
+              'connection_failed',
+            );
+      return formatCleanupFailureBanner({
+        code: providerError.code,
+        message: providerError.message,
+        providerId: 'openrouter',
+      });
+    }
+  }
+
+  private async runOpenRouterTest(button: ExtraButtonComponent): Promise<void> {
+    if (this.openRouterTestInFlight) {
+      return;
+    }
+    this.openRouterTestInFlight = true;
+    button.setDisabled(true);
+    try {
+      const failure = await this.testOpenRouter();
+      button.setIcon(failure === null ? 'check' : 'x');
+      if (failure !== null) {
+        this.notice(`Local Dictation: ${failure}`);
+      }
+      window.setTimeout(() => {
+        button.setIcon('plug-zap');
+      }, TEST_RESULT_ICON_MS);
+    } finally {
+      this.openRouterTestInFlight = false;
+      button.setDisabled(false);
+    }
   }
 
   private prewarm(providerId: LlmProviderId, modelId: string): void {

--- a/src/ui/local-dictation-view.ts
+++ b/src/ui/local-dictation-view.ts
@@ -496,23 +496,25 @@ export class LocalDictationView extends ItemView {
       'Bounds on the context fed to the model, plus a word floor for skipping the transform.',
     );
 
-    this.addNumberSetting(
-      items,
-      'Total context cap',
-      'Hard cap on context chars',
-      settings.llmPostprocessTotalContextCap,
-      (value) => this.saveField('llmPostprocessTotalContextCap', value, { rerender: false }),
-      'Hard cap on total context characters across note and prior utterances.',
-    );
-
-    if (Math.ceil(settings.llmPostprocessTotalContextCap / 4) >= 4_000) {
-      items.createEl('p', {
-        cls: 'local-dictation-muted',
-        text: 'Large context windows can slow local models and reduce LLM transform quality.',
-      });
-    }
-
+    // The cap only governs per-utterance context (note text + prior utterances);
+    // batch context is bounded by "Note context chars" alone, so hide it there.
     if (settings.llmPostprocessMode !== 'batch') {
+      this.addNumberSetting(
+        items,
+        'Total context cap',
+        'Hard cap on context chars',
+        settings.llmPostprocessTotalContextCap,
+        (value) => this.saveField('llmPostprocessTotalContextCap', value, { rerender: false }),
+        'Hard cap on total context characters across note and prior utterances.',
+      );
+
+      if (Math.ceil(settings.llmPostprocessTotalContextCap / 4) >= 4_000) {
+        items.createEl('p', {
+          cls: 'local-dictation-muted',
+          text: 'Large context windows can slow local models and reduce LLM transform quality.',
+        });
+      }
+
       this.addNumberSetting(
         items,
         'Prior utterances',
@@ -520,6 +522,17 @@ export class LocalDictationView extends ItemView {
         settings.llmPostprocessPriorUtterancesN,
         (value) => this.saveField('llmPostprocessPriorUtterancesN', value, { rerender: false }),
         'Number of recent transcribed utterances included as conversation history.',
+      );
+    }
+
+    if (settings.llmRemoteFeaturesEnabled && settings.llmRouting !== 'local') {
+      this.addNumberSetting(
+        items,
+        'Remote timeout (seconds)',
+        'Give up on OpenRouter after this long',
+        settings.llmRemoteTimeoutSec,
+        (value) => this.saveField('llmRemoteTimeoutSec', value, { rerender: false }),
+        'Abort an OpenRouter transform request after this many seconds. The raw transcript is kept.',
       );
     }
 

--- a/src/ui/local-dictation-view.ts
+++ b/src/ui/local-dictation-view.ts
@@ -450,7 +450,7 @@ export class LocalDictationView extends ItemView {
   }
 
   private renderUseNoteContextToggle(parent: HTMLElement, settings: PluginSettings): void {
-    new Setting(parent)
+    const setting = new Setting(parent)
       .setName('Use note as LLM context')
       .setDesc('Include the open note above the cursor in the LLM prompt.')
       .addToggle((toggle) => {
@@ -459,6 +459,7 @@ export class LocalDictationView extends ItemView {
           await this.saveField('useLlmNoteContext', value);
         });
       });
+    appendInfoTooltip(setting, 'Experimental: results vary with note length and model.');
   }
 
   private renderPromptEditor(parent: HTMLElement, settings: PluginSettings): void {

--- a/styles.css
+++ b/styles.css
@@ -767,6 +767,12 @@
   border-top: 1px solid var(--background-modifier-border);
 }
 
+/* The labeled divider replaces the built-in row separator, so drop the
+   following setting row's own border to avoid a doubled line. */
+.local-dictation-route-leg + .setting-item {
+  border-top: none;
+}
+
 .local-stt-hidden {
   display: none;
 }

--- a/styles.css
+++ b/styles.css
@@ -748,12 +748,23 @@
 }
 
 .local-dictation-route-leg {
-  padding: var(--size-4-3) var(--size-4-3) var(--size-4-1);
+  display: flex;
+  align-items: center;
+  gap: var(--size-4-2);
+  padding: var(--size-4-3) 0 var(--size-4-1);
   font-size: var(--font-ui-smaller);
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--text-faint);
+}
+
+/* Trailing hairline so the leg label reads as a section divider instead of a
+   stray caption between setting rows. */
+.local-dictation-route-leg::after {
+  content: "";
+  flex: 1;
+  border-top: 1px solid var(--background-modifier-border);
 }
 
 .local-stt-hidden {

--- a/test/__mocks__/obsidian.ts
+++ b/test/__mocks__/obsidian.ts
@@ -12,6 +12,10 @@ export abstract class AbstractInputSuggest<T> {
   close(): void {}
 }
 
+// Export-resolution stub so modules importing `Setting` load under vitest's
+// node environment; tests that exercise render paths need a real DOM stub.
+export class Setting {}
+
 export const Platform = {
   isMacOS: false,
   isWin: false,

--- a/test/llm-routing-controls.test.ts
+++ b/test/llm-routing-controls.test.ts
@@ -1,0 +1,107 @@
+import type { App } from 'obsidian';
+import { describe, expect, it, vi } from 'vitest';
+
+const { createProviderMock } = vi.hoisted(() => ({ createProviderMock: vi.fn() }));
+
+vi.mock('../src/llm/provider', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/llm/provider')>();
+  return { ...actual, createProvider: createProviderMock };
+});
+
+import { DEFAULT_PLUGIN_SETTINGS, type PluginSettings } from '../src/settings/plugin-settings';
+import { LlmRoutingControls } from '../src/ui/llm-routing-controls';
+import { createFakeLlmProvider } from './fixtures/llm';
+
+function createControls(overrides: Partial<PluginSettings> = {}) {
+  const requestRerender = vi.fn();
+  const controls = new LlmRoutingControls({
+    app: {} as App,
+    getSettings: () => ({ ...DEFAULT_PLUGIN_SETTINGS, ...overrides }),
+    persist: vi.fn(async () => {}),
+    requestRerender,
+  });
+  return { controls, requestRerender };
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('LlmRoutingControls.refreshActiveProviders', () => {
+  it('retries a provider whose previous load failed', async () => {
+    const listModels = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('connection refused'))
+      .mockResolvedValue([{ displayName: 'llama3', id: 'llama3' }]);
+    createProviderMock.mockReturnValue(createFakeLlmProvider({ listModels }));
+    const { controls } = createControls();
+
+    // Initial load while Ollama is down.
+    controls.refreshActiveProviders();
+    await flushAsyncWork();
+    expect(listModels).toHaveBeenCalledTimes(1);
+
+    // The user starts Ollama, then refocuses the window.
+    controls.refreshActiveProviders();
+    await flushAsyncWork();
+    expect(listModels).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not refetch a provider that already loaded successfully', async () => {
+    const listModels = vi.fn().mockResolvedValue([{ displayName: 'llama3', id: 'llama3' }]);
+    createProviderMock.mockReturnValue(createFakeLlmProvider({ listModels }));
+    const { controls } = createControls();
+
+    controls.refreshActiveProviders();
+    await flushAsyncWork();
+
+    controls.refreshActiveProviders();
+    await flushAsyncWork();
+    expect(listModels).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('LlmRoutingControls.testOpenRouter', () => {
+  const configured = {
+    llmOpenRouterApiKey: 'sk-or-test',
+    llmProviderModels: { ollama: '', openrouter: 'anthropic/claude-sonnet-4.5' },
+  };
+
+  it('returns null when a minimal completion succeeds with the selected model', async () => {
+    const cleanup = vi.fn(async () => 'OK');
+    createProviderMock.mockReturnValue(createFakeLlmProvider({ cleanup }));
+    const { controls } = createControls(configured);
+
+    await expect(controls.testOpenRouter()).resolves.toBeNull();
+    expect(cleanup).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'anthropic/claude-sonnet-4.5' }),
+    );
+  });
+
+  it('returns the specific failure message when the provider rejects the model', async () => {
+    const { ProviderError } = await import('../src/llm/provider');
+    const cleanup = vi.fn(async () => {
+      throw new ProviderError('OpenRouter model was not found.', 'unknown_model');
+    });
+    createProviderMock.mockReturnValue(createFakeLlmProvider({ cleanup }));
+    const { controls } = createControls(configured);
+
+    await expect(controls.testOpenRouter()).resolves.toBe(
+      'OpenRouter model not found. Pick another under Where it runs.',
+    );
+  });
+
+  it('reports an unconfigured model without calling the provider', async () => {
+    const cleanup = vi.fn(async () => 'OK');
+    createProviderMock.mockReturnValue(createFakeLlmProvider({ cleanup }));
+    const { controls } = createControls({
+      ...configured,
+      llmProviderModels: { ollama: '', openrouter: '' },
+    });
+
+    await expect(controls.testOpenRouter()).resolves.toBe(
+      'OpenRouter model is not configured. Pick one under Where it runs.',
+    );
+    expect(cleanup).not.toHaveBeenCalled();
+  });
+});

--- a/test/llm/cleanup-failure-banner.test.ts
+++ b/test/llm/cleanup-failure-banner.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatCleanupFailureBanner } from '../../src/ui/llm-provider-ui';
+
+describe('formatCleanupFailureBanner', () => {
+  it('names the provider whose model is not configured', () => {
+    expect(
+      formatCleanupFailureBanner({
+        code: 'model_not_configured',
+        message: 'Ollama model is not configured.',
+        providerId: 'ollama',
+      }),
+    ).toBe('Ollama model is not configured. Pick one under Where it runs.');
+  });
+
+  it('names the provider that rejected the selected model', () => {
+    expect(
+      formatCleanupFailureBanner({
+        code: 'unknown_model',
+        message: 'OpenRouter model was not found.',
+        providerId: 'openrouter',
+      }),
+    ).toBe('OpenRouter model not found. Pick another under Where it runs.');
+  });
+});

--- a/test/llm/openrouter-provider.test.ts
+++ b/test/llm/openrouter-provider.test.ts
@@ -174,6 +174,29 @@ describe('OpenRouterProvider', () => {
     await assertion;
   });
 
+  it('honors a configured cleanup timeout', async () => {
+    vi.useFakeTimers();
+    mockFetch((_url, init) => rejectWhenAborted(init));
+
+    const promise = new OpenRouterProvider({
+      apiKey: 'sk-or-test',
+      baseUrl: 'https://openrouter.test/api/v1',
+      timeoutMs: 5_000,
+    }).cleanup({
+      model: 'anthropic/claude-sonnet-4.5',
+      prompt: 'Clean it.',
+      temperature: 0.2,
+      userMessage: 'raw',
+    });
+    const assertion = expect(promise).rejects.toMatchObject({
+      code: 'timeout',
+      name: 'ProviderError',
+    } satisfies Partial<ProviderError>);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await assertion;
+  });
+
   it('propagates caller abort signals', async () => {
     mockFetch((_url, init) => rejectWhenAborted(init));
     const controller = new AbortController();

--- a/test/llm/router.test.ts
+++ b/test/llm/router.test.ts
@@ -123,18 +123,18 @@ describe('createLlmRouter', () => {
     expect(result.providerId).toBe(expected);
   });
 
-  it('throws unknown_model when the routed provider has no configured model', async () => {
+  it('throws model_not_configured when the routed provider has no configured model', async () => {
     const { router } = routerWithSpy(
       settings({ llmProviderModels: { ollama: '', openrouter: '' }, llmRouting: 'local' }),
     );
 
     await expect(router.cleanup(cleanupArgs('hi'))).rejects.toMatchObject({
-      code: 'unknown_model',
+      code: 'model_not_configured',
       name: 'ProviderError',
     } satisfies Partial<ProviderError>);
   });
 
-  it('throws unknown_model for the remote provider when auto escalates but no remote model is set', async () => {
+  it('throws model_not_configured for the remote provider when auto escalates but no remote model is set', async () => {
     const { router } = routerWithSpy(
       settings({
         llmProviderModels: { ollama: 'llama3.2:latest', openrouter: '' },
@@ -144,7 +144,7 @@ describe('createLlmRouter', () => {
     );
 
     await expect(router.cleanup(cleanupArgs('x'.repeat(200)))).rejects.toMatchObject({
-      code: 'unknown_model',
+      code: 'model_not_configured',
       message: expect.stringContaining('OpenRouter'),
       name: 'ProviderError',
     } satisfies Partial<ProviderError>);

--- a/test/ollama-client.test.ts
+++ b/test/ollama-client.test.ts
@@ -3,6 +3,8 @@ import http from 'node:http';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { createOllamaClient, type OllamaClientError } from '../src/llm/ollama-client';
+import { OllamaProvider } from '../src/llm/ollama-provider';
+import type { ProviderError } from '../src/llm/provider';
 
 const servers: http.Server[] = [];
 
@@ -136,6 +138,27 @@ describe('Ollama client', () => {
       code: 'invalid_response',
       name: 'OllamaClientError',
     } satisfies Partial<OllamaClientError>);
+  });
+
+  it('maps a missing-model 404 to unknown_model at the provider boundary', async () => {
+    const { port } = await startServer((_request, response) => {
+      response.statusCode = 404;
+      response.end(
+        JSON.stringify({ error: 'model "ghost:latest" not found, try pulling it first' }),
+      );
+    });
+
+    await expect(
+      new OllamaProvider(createOllamaClient({ port })).cleanup({
+        model: 'ghost:latest',
+        prompt: 'Clean this.',
+        temperature: 0.2,
+        userMessage: 'raw',
+      }),
+    ).rejects.toMatchObject({
+      code: 'unknown_model',
+      name: 'ProviderError',
+    } satisfies Partial<ProviderError>);
   });
 
   it('cleanup aborts via the supplied signal', async () => {

--- a/test/plugin-settings.test.ts
+++ b/test/plugin-settings.test.ts
@@ -307,6 +307,13 @@ describe('resolvePluginSettings', () => {
     ).toBe(60_000);
   });
 
+  it('clamps the remote timeout at the settings boundary', () => {
+    expect(resolvePluginSettings({ llmRemoteTimeoutSec: 1 }).llmRemoteTimeoutSec).toBe(5);
+    expect(resolvePluginSettings({ llmRemoteTimeoutSec: 9_999 }).llmRemoteTimeoutSec).toBe(600);
+    expect(resolvePluginSettings({ llmRemoteTimeoutSec: 'soon' }).llmRemoteTimeoutSec).toBe(60);
+    expect(resolvePluginSettings({ llmRemoteTimeoutSec: 120 }).llmRemoteTimeoutSec).toBe(120);
+  });
+
   it('falls back to the default when useLlmNoteContext is not a boolean', () => {
     expect(resolvePluginSettings({ useLlmNoteContext: 'yes' }).useLlmNoteContext).toBe(false);
   });


### PR DESCRIPTION
Follow-up fixes and small features for the 6.7 OpenRouter / auto-routing release.

## Bug fixes

- **Ollama status never recovered without a manual refresh.** A failed catalog load set `modelsLoaded = true`, so the window-focus recheck skipped the provider forever. Open/focus/routing-change now retry any provider whose last load left it unhealthy; render-time warms keep the load-once guard (a failed load triggers a re-render, so retrying there would loop).
- **"Selected model not found." told you nothing.** The router now throws a distinct `model_not_configured` code, and the failure banner names the provider and the actual cause: "Ollama model is not configured. Pick one under Where it runs." vs "OpenRouter model not found. Pick another under Where it runs."
- **Ollama missing-model 404s surfaced as the generic "LLM transform failed."** The client now carries status/body on HTTP errors and the provider maps a missing-model 404 to `unknown_model`, mirroring the OpenRouter mapping.

## Features

- **OpenRouter test button** on the model row (Remote and Auto): sends a minimal "reply OK" completion, proving key validity, credits, and the exact model id end to end. Checkmark flash on success; specific notice on failure.
- **Configurable remote timeout** (`llmRemoteTimeoutSec`, default 60s, clamped 5–600) in Advanced > Limits, shown only for remote/auto routing. Plumbs through to OpenRouter cleanup requests.

## UI cleanups

- Auto-threshold explainer moved from a muted paragraph into the standard info tooltip.
- Total context cap (and its hint) hidden in batch mode — it only governs per-utterance context; batch context is bounded by Note context chars alone.
- Auto-tab leg labels ("Local · Ollama" / "Remote · OpenRouter") restyled as labeled dividers with a trailing hairline; the built-in row border directly beneath each label is suppressed so there is a single divider line.
- "Use note as LLM context" toggle gains an info tooltip marking it experimental.

## Test plan

- [x] All changes TDD'd where logic is testable: focus-retry semantics, banner formatting, router error code, Ollama 404 mapping (real local HTTP server), provider timeout option (fake timers), settings clamping.
- [x] 444 tests pass, typecheck clean, biome + obsidian eslint clean.
- [ ] Manual: dev-vault pass over the sidebar (tooltip, leg labels, test button, timeout row visibility).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
