### PR TITLE
feat(ui): add search to the preset manager

### DIFF
--- a/src/ui/preset-manager-modal.ts
+++ b/src/ui/preset-manager-modal.ts
@@ -1,10 +1,16 @@
 import { randomUUID } from 'node:crypto';
 
 import type { App, DropdownComponent } from 'obsidian';
-import { Modal, Notice, Setting } from 'obsidian';
+import {
+  Modal,
+  Notice,
+  prepareSimpleSearch,
+  renderMatches,
+  SearchComponent,
+  Setting,
+} from 'obsidian';
 
 import {
-  describePresetBehavior,
   formatStyleRef,
   LLM_BUILTIN_PRESETS,
   type LlmPreset,
@@ -29,6 +35,7 @@ import {
   type LlmPresetDraft,
   validatePresetDraft,
 } from './preset-draft';
+import { type PresetSearchHit, searchPresetEntries } from './preset-search';
 
 interface PresetManagerModalDependencies {
   getSettings: () => PluginSettings;
@@ -45,6 +52,7 @@ const MAX_PRESETS_MESSAGE = `You can save up to ${LLM_USER_PRESET_MAX_COUNT} pre
 export class PresetManagerModal extends Modal {
   private editor: EditorState | null = null;
   private isOpen = false;
+  private searchQuery = '';
 
   constructor(
     app: App,
@@ -94,11 +102,6 @@ export class PresetManagerModal extends Modal {
   // ------------------------------------------------------------------ list
 
   private renderList(): void {
-    const settings = this.deps.getSettings();
-    const activeRef = resolveActivePresetEntry(
-      settings.llmPostprocessActivePresetRef,
-      settings.llmPostprocessUserPresets,
-    ).ref;
     const reachedMaxCount = this.reachedMaxCount();
 
     new Setting(this.contentEl)
@@ -119,26 +122,67 @@ export class PresetManagerModal extends Modal {
         });
       });
 
-    const entries = listPresetEntries(settings.llmPostprocessUserPresets);
-    this.renderListSection(
-      'Built-in',
-      entries.filter((entry) => entry.isBuiltin),
-      activeRef,
+    const searchEl = this.contentEl.createDiv('search-input-container local-stt-preset-search');
+    const listEl = this.contentEl.createDiv();
+    new SearchComponent(searchEl)
+      .setPlaceholder('Search presets...')
+      .setValue(this.searchQuery)
+      .onChange((value) => {
+        // Re-render only the list so the search input keeps focus.
+        this.searchQuery = value;
+        this.renderListEntries(listEl);
+      });
+    this.renderListEntries(listEl);
+  }
+
+  private renderListEntries(listEl: HTMLElement): void {
+    listEl.empty();
+    const settings = this.deps.getSettings();
+    const activeRef = resolveActivePresetEntry(
+      settings.llmPostprocessActivePresetRef,
+      settings.llmPostprocessUserPresets,
+    ).ref;
+    const query = this.searchQuery.trim();
+    const hits = searchPresetEntries(
+      listPresetEntries(settings.llmPostprocessUserPresets),
+      query === '' ? null : prepareSimpleSearch(query),
     );
-    const userEntries = entries.filter((entry) => !entry.isBuiltin);
-    if (userEntries.length > 0) {
-      this.renderListSection('Your presets', userEntries, activeRef);
+    if (hits.length === 0) {
+      listEl.createEl('p', {
+        cls: 'local-stt-preset-empty',
+        text: 'No presets match your search.',
+      });
+      return;
+    }
+    const builtinHits = hits.filter((hit) => hit.entry.isBuiltin);
+    if (builtinHits.length > 0) {
+      this.renderListSection(listEl, 'Built-in', builtinHits, activeRef);
+    }
+    const userHits = hits.filter((hit) => !hit.entry.isBuiltin);
+    if (userHits.length > 0) {
+      this.renderListSection(listEl, 'Your presets', userHits, activeRef);
     }
   }
 
-  private renderListSection(heading: string, entries: LlmPresetEntry[], activeRef: string): void {
+  private renderListSection(
+    listEl: HTMLElement,
+    heading: string,
+    hits: PresetSearchHit[],
+    activeRef: string,
+  ): void {
     const reachedMaxCount = this.reachedMaxCount();
-    new Setting(this.contentEl).setName(heading).setHeading();
-    for (const entry of entries) {
+    new Setting(listEl).setName(heading).setHeading();
+    for (const hit of hits) {
+      const { entry } = hit;
       const { preset } = entry;
-      const setting = new Setting(this.contentEl)
-        .setName(entry.ref === activeRef ? `${preset.label} ✓` : preset.label)
-        .setDesc(preset.description ?? describePresetBehavior(preset));
+      const name = activeDocument.createDocumentFragment();
+      renderMatches(name, preset.label, hit.labelMatches);
+      if (entry.ref === activeRef) {
+        name.append(' ✓');
+      }
+      const description = activeDocument.createDocumentFragment();
+      renderMatches(description, hit.description, hit.descriptionMatches);
+      const setting = new Setting(listEl).setName(name).setDesc(description);
       setting.settingEl.addClass('local-stt-preset-row');
 
       setting.addExtraButton((button) => {

--- a/src/ui/preset-search.ts
+++ b/src/ui/preset-search.ts
@@ -1,0 +1,37 @@
+import type { SearchMatches, SearchResult } from 'obsidian';
+
+import { describePresetBehavior, type LlmPresetEntry } from '../llm/presets';
+
+export interface PresetSearchHit {
+  entry: LlmPresetEntry;
+  // The text shown (and searched) as the row description.
+  description: string;
+  labelMatches: SearchMatches | null;
+  descriptionMatches: SearchMatches | null;
+}
+
+export function searchPresetEntries(
+  entries: readonly LlmPresetEntry[],
+  search: ((text: string) => SearchResult | null) | null,
+): PresetSearchHit[] {
+  const hits: PresetSearchHit[] = [];
+  for (const entry of entries) {
+    const description = entry.preset.description ?? describePresetBehavior(entry.preset);
+    if (search === null) {
+      hits.push({ entry, description, labelMatches: null, descriptionMatches: null });
+      continue;
+    }
+    const labelResult = search(entry.preset.label);
+    const descriptionResult = search(description);
+    if (labelResult === null && descriptionResult === null) {
+      continue;
+    }
+    hits.push({
+      entry,
+      description,
+      labelMatches: labelResult?.matches ?? null,
+      descriptionMatches: descriptionResult?.matches ?? null,
+    });
+  }
+  return hits;
+}

--- a/styles.css
+++ b/styles.css
@@ -502,6 +502,24 @@
   margin-bottom: var(--size-4-2);
 }
 
+.local-stt-preset-manager .local-stt-preset-search {
+  width: 100%;
+  margin-bottom: var(--size-4-2);
+}
+
+.local-stt-preset-manager .local-stt-preset-empty {
+  color: var(--text-muted);
+  margin: var(--size-4-2) 0;
+}
+
+/* Highlight search matches like the core search pane instead of the theme's
+   bold/accent suggestion styling. */
+.local-stt-preset-manager .suggestion-highlight {
+  background-color: var(--text-highlight-bg);
+  color: inherit;
+  font-weight: inherit;
+}
+
 .local-stt-preset-editor__prompt textarea {
   width: 100%;
 }

--- a/test/preset-search.test.ts
+++ b/test/preset-search.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { describePresetBehavior, listPresetEntries } from '../src/llm/presets';
+import { searchPresetEntries } from '../src/ui/preset-search';
+import { createUserPreset } from './fixtures/llm';
+
+// Stand-in for obsidian's prepareSimpleSearch: case-insensitive substring match.
+function substringSearch(
+  query: string,
+): (text: string) => { score: number; matches: [number, number][] } | null {
+  return (text) => {
+    const index = text.toLowerCase().indexOf(query.toLowerCase());
+    return index === -1 ? null : { score: 0, matches: [[index, index + query.length]] };
+  };
+}
+
+describe('searchPresetEntries', () => {
+  it('returns every entry without highlights when search is null', () => {
+    const entries = listPresetEntries([createUserPreset()]);
+    const hits = searchPresetEntries(entries, null);
+    expect(hits.map((hit) => hit.entry)).toEqual(entries);
+    expect(hits.every((hit) => hit.labelMatches === null && hit.descriptionMatches === null)).toBe(
+      true,
+    );
+  });
+
+  it('matches on label and reports label match offsets', () => {
+    const entries = listPresetEntries([createUserPreset({ label: 'My transform' })]);
+    const hits = searchPresetEntries(entries, substringSearch('transform'));
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.entry.preset.label).toBe('My transform');
+    expect(hits[0]?.labelMatches).toEqual([[3, 12]]);
+    expect(hits[0]?.descriptionMatches).toBeNull();
+  });
+
+  it('matches on description when the label does not match', () => {
+    const hits = searchPresetEntries(listPresetEntries([]), substringSearch('checklist'));
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.entry.preset.id).toBe('action-items');
+    expect(hits[0]?.labelMatches).toBeNull();
+    expect(hits[0]?.descriptionMatches).not.toBeNull();
+  });
+
+  it('searches the behavior summary when a preset has no description', () => {
+    const preset = createUserPreset();
+    const entries = listPresetEntries([preset]).filter((entry) => !entry.isBuiltin);
+    const hits = searchPresetEntries(entries, substringSearch('rewrites the dictated text'));
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.description).toBe(describePresetBehavior(preset));
+    expect(hits[0]?.descriptionMatches).not.toBeNull();
+  });
+
+  it('excludes entries that match neither label nor description', () => {
+    const hits = searchPresetEntries(listPresetEntries([]), substringSearch('zzz-no-such-preset'));
+    expect(hits).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a search bar to the preset manager modal, styled and behaving like the community plugin browser search
- Match against preset title and visible description (including the generated behavior summary for presets without one) using Obsidian's `prepareSimpleSearch`
- Highlight matched text via `renderMatches`, restyled to the core search highlight background (`--text-highlight-bg`) instead of the theme's bold suggestion styling
- Filter out non-matching presets, collapse empty sections, and show a muted empty state when nothing matches
- Re-render only the list on input so the search box keeps focus; the query survives opening/closing a preset

## Test plan

- [x] New unit tests for the pure filter logic (`test/preset-search.test.ts`): label match, description match, behavior-summary fallback, empty query, no matches
- [x] `npm run typecheck`, `npm run lint`, `npm run lint:obsidian`, `npm run test` (492 passing), `npm run build:frontend`
- [x] Manually verified in the dev vault: filtering, themed highlight, clear button, focus retention

🤖 Generated with [Claude Code](https://claude.com/claude-code)