### PR TITLE
fix(ui): repair preset manager duplicate/delete and save contract

### DIFF
--- a/src/llm/presets.ts
+++ b/src/llm/presets.ts
@@ -42,7 +42,6 @@ export type LlmBuiltinPresetId =
   | 'professional-writing'
   | 'tldr'
   | 'markdown-formatting'
-  | 'brain-dump'
   | 'action-items';
 
 export interface LlmPresetEntry {
@@ -62,9 +61,6 @@ const TLDR_PROMPT =
 
 const MARKDOWN_FORMATTING_PROMPT =
   "Reformat dictated speech as well-structured Markdown. Add headings, bullet or numbered lists, bold, emphasis, and fenced code blocks where the content calls for it. Lightly clean filler, false starts, punctuation, and capitalization; preserve the speaker's wording, every fact, name, and term. Return only the Markdown — no preamble, no commentary.";
-
-const BRAIN_DUMP_PROMPT =
-  "Organize a free-form brain dump into clear structure. Cluster the speaker's points into themes with short headings, and surface action items, open questions, and decisions as separate sections where present. Drop pure filler. Preserve every fact, name, and term. Use the reference context only for spelling. Return only the organized Markdown — no preamble, no commentary.";
 
 const ACTION_ITEMS_PROMPT =
   "Extract action items from the dictated transcript. Output an 'Action items' heading followed by a Markdown checklist of concrete tasks, naming an owner when the speaker mentions one. If the transcript contains no action items, return nothing. Return only the heading and checklist — do not repeat the transcript, no preamble, no commentary.";
@@ -101,15 +97,6 @@ export const LLM_BUILTIN_PRESETS = [
       'Reformat the session transcript as structured Markdown with headings, lists, and emphasis.',
     output: 'replace',
     prompt: MARKDOWN_FORMATTING_PROMPT,
-    timing: 'batch',
-  },
-  {
-    id: 'brain-dump',
-    label: 'Brain dump organizer',
-    description:
-      'Cluster a rambling brain dump into themes, action items, questions, and decisions.',
-    output: 'replace',
-    prompt: BRAIN_DUMP_PROMPT,
     timing: 'batch',
   },
   {

--- a/src/settings/plugin-settings.ts
+++ b/src/settings/plugin-settings.ts
@@ -80,7 +80,7 @@ export const MAX_LLM_REMOTE_THRESHOLD_CHARS = 60_000;
 
 export const LLM_USER_PRESET_MAX_LABEL_CHARS = 60;
 export const LLM_USER_PRESET_MAX_DESCRIPTION_CHARS = 240;
-export const LLM_USER_PRESET_MAX_COUNT = 25;
+export const LLM_USER_PRESET_MAX_COUNT = 50;
 
 // Shared bounds for the min-words skip gate and sampling temperature, used by
 // the settings reader, the preset editor, and the preset draft validator.

--- a/src/ui/preset-draft.ts
+++ b/src/ui/preset-draft.ts
@@ -1,12 +1,17 @@
-import type {
-  LlmPreset,
-  LlmPresetOutput,
-  LlmPresetOverrides,
-  LlmPresetTiming,
+import { randomUUID } from 'node:crypto';
+
+import {
+  LLM_BUILTIN_PRESETS,
+  type LlmPreset,
+  type LlmPresetOutput,
+  type LlmPresetOverrides,
+  type LlmPresetTiming,
 } from '../llm/presets';
+import type { LlmPresetState } from '../settings/llm-preset-state';
 import {
   LLM_MIN_WORDS_MAX,
   LLM_TEMPERATURE_MAX,
+  LLM_USER_PRESET_MAX_COUNT,
   LLM_USER_PRESET_MAX_DESCRIPTION_CHARS,
   LLM_USER_PRESET_MAX_LABEL_CHARS,
 } from '../settings/plugin-settings';
@@ -41,11 +46,20 @@ export function emptyPresetDraft(): LlmPresetDraft {
   };
 }
 
-// Truncate the base label first so the suffix survives the length cap;
-// slicing afterwards would silently reproduce the original name.
-export function duplicateLabel(label: string): string {
-  const suffix = ' (copy)';
-  return `${label.slice(0, LLM_USER_PRESET_MAX_LABEL_CHARS - suffix.length)}${suffix}`;
+// Pick the first free "Base (copy)" / "Base (copy N)" name. Duplicating a
+// copy numbers up from its base instead of stacking suffixes. The base label
+// is truncated first so the suffix survives the length cap; slicing
+// afterwards would silently reproduce an existing name.
+export function duplicateLabel(label: string, existingLabels: readonly string[]): string {
+  const taken = new Set(existingLabels.map((existing) => existing.trim().toLowerCase()));
+  const base = label.replace(/ \(copy(?: \d+)?\)$/, '');
+  for (let attempt = 1; ; attempt += 1) {
+    const suffix = attempt === 1 ? ' (copy)' : ` (copy ${attempt})`;
+    const candidate = `${base.slice(0, LLM_USER_PRESET_MAX_LABEL_CHARS - suffix.length)}${suffix}`;
+    if (!taken.has(candidate.toLowerCase())) {
+      return candidate;
+    }
+  }
 }
 
 export function draftFromPreset(preset: LlmPreset): LlmPresetDraft {
@@ -118,6 +132,62 @@ export function validatePresetDraft(
       ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
       prompt: draft.prompt,
       ...(timing !== undefined ? { timing } : {}),
+    },
+  };
+}
+
+export const MAX_PRESETS_MESSAGE = `You can save up to ${LLM_USER_PRESET_MAX_COUNT} presets. Delete one first.`;
+
+export interface PresetSaveOutcome {
+  error: string | null;
+  state: LlmPresetState;
+}
+
+// The save contract for the preset editor: editing updates the preset in
+// place; if the edited preset no longer exists (deleted in another window),
+// the edits are saved back under the same id rather than dropped; name
+// collisions with built-ins or other user presets are rejected.
+export function applyPresetDraftSave(
+  state: Readonly<LlmPresetState>,
+  draft: LlmPresetDraft,
+  editedId: string | null,
+): PresetSaveOutcome {
+  const label = draft.label.trim().toLowerCase();
+  if (LLM_BUILTIN_PRESETS.some((preset) => preset.label.toLowerCase() === label)) {
+    return {
+      error: 'That name is used by a built-in preset — choose a different name.',
+      state,
+    };
+  }
+
+  const existingLabels = state.userPresets
+    .filter((preset) => preset.id !== editedId)
+    .map((preset) => preset.label);
+  const result = validatePresetDraft(draft, existingLabels);
+  if (result.kind === 'error') {
+    return { error: result.message, state };
+  }
+
+  if (editedId !== null && state.userPresets.some((preset) => preset.id === editedId)) {
+    return {
+      error: null,
+      state: {
+        ...state,
+        userPresets: state.userPresets.map((preset) =>
+          preset.id === editedId ? { ...result.preset, id: editedId } : preset,
+        ),
+      },
+    };
+  }
+
+  if (state.userPresets.length >= LLM_USER_PRESET_MAX_COUNT) {
+    return { error: MAX_PRESETS_MESSAGE, state };
+  }
+  return {
+    error: null,
+    state: {
+      ...state,
+      userPresets: [...state.userPresets, { ...result.preset, id: editedId ?? randomUUID() }],
     },
   };
 }

--- a/src/ui/preset-manager-modal.ts
+++ b/src/ui/preset-manager-modal.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import type { App, DropdownComponent } from 'obsidian';
 import {
   Modal,
@@ -29,11 +27,12 @@ import {
 } from '../settings/plugin-settings';
 import { ConfirmModal } from './confirm-modal';
 import {
+  applyPresetDraftSave,
   draftFromPreset,
   duplicateLabel,
   emptyPresetDraft,
   type LlmPresetDraft,
-  validatePresetDraft,
+  MAX_PRESETS_MESSAGE,
 } from './preset-draft';
 import { type PresetSearchHit, searchPresetEntries } from './preset-search';
 
@@ -46,8 +45,6 @@ type EditorState =
   | { kind: 'create'; draft: LlmPresetDraft }
   | { kind: 'edit'; draft: LlmPresetDraft; presetId: string }
   | { kind: 'view'; preset: LlmPreset };
-
-const MAX_PRESETS_MESSAGE = `You can save up to ${LLM_USER_PRESET_MAX_COUNT} presets. Delete one first.`;
 
 export class PresetManagerModal extends Modal {
   private editor: EditorState | null = null;
@@ -215,7 +212,13 @@ export class PresetManagerModal extends Modal {
       }
 
       setting.settingEl.addEventListener('click', (event) => {
-        if (event.target instanceof HTMLElement && event.target.closest('button') !== null) {
+        // Ignore clicks on the action icons (Obsidian extra buttons are
+        // divs, not <button>s) so edit/duplicate/delete don't also open
+        // the row.
+        if (
+          event.target instanceof HTMLElement &&
+          event.target.closest('.setting-item-control') !== null
+        ) {
           return;
         }
         this.openEntry(entry);
@@ -232,7 +235,10 @@ export class PresetManagerModal extends Modal {
 
   private openDuplicate(preset: LlmPreset): void {
     const draft = draftFromPreset(preset);
-    draft.label = duplicateLabel(preset.label);
+    draft.label = duplicateLabel(preset.label, [
+      ...LLM_BUILTIN_PRESETS.map((entry) => entry.label),
+      ...this.deps.getSettings().llmPostprocessUserPresets.map((entry) => entry.label),
+    ]);
     this.editor = { kind: 'create', draft };
     this.render();
   }
@@ -415,37 +421,9 @@ export class PresetManagerModal extends Modal {
     const editedId = editor.kind === 'edit' ? editor.presetId : null;
     let validationError: string | null = null;
     await this.deps.mutatePresetState((state) => {
-      const label = editor.draft.label.trim().toLowerCase();
-      if (LLM_BUILTIN_PRESETS.some((preset) => preset.label.toLowerCase() === label)) {
-        validationError = 'That name is used by a built-in preset — choose a different name.';
-        return state;
-      }
-
-      const existingLabels = state.userPresets
-        .filter((preset) => preset.id !== editedId)
-        .map((preset) => preset.label);
-      const result = validatePresetDraft(editor.draft, existingLabels);
-      if (result.kind === 'error') {
-        validationError = result.message;
-        return state;
-      }
-
-      if (editedId !== null) {
-        return {
-          ...state,
-          userPresets: state.userPresets.map((preset) =>
-            preset.id === editedId ? { ...result.preset, id: editedId } : preset,
-          ),
-        };
-      }
-      if (state.userPresets.length >= LLM_USER_PRESET_MAX_COUNT) {
-        validationError = MAX_PRESETS_MESSAGE;
-        return state;
-      }
-      return {
-        ...state,
-        userPresets: [...state.userPresets, { ...result.preset, id: randomUUID() }],
-      };
+      const outcome = applyPresetDraftSave(state, editor.draft, editedId);
+      validationError = outcome.error;
+      return outcome.state;
     });
     if (validationError !== null) {
       errorEl.setText(validationError);

--- a/src/ui/preset-manager-modal.ts
+++ b/src/ui/preset-manager-modal.ts
@@ -283,14 +283,24 @@ export class PresetManagerModal extends Modal {
       .setName('Prompt')
       .setDesc('Sent to the model as the system prompt.');
     promptSetting.settingEl.addClass('local-stt-preset-editor__prompt');
+    const updatePromptSize = (value: string) => {
+      promptSizeEl.setText(
+        `~${Math.ceil(value.length / 4)} tokens (${value.length} chars) — sent with every request`,
+      );
+    };
     promptSetting.addTextArea((text) => {
       text.setValue(draft.prompt);
       text.setDisabled(isBuiltinView);
       text.inputEl.rows = 8;
       text.onChange((value) => {
         draft.prompt = value;
+        updatePromptSize(value);
       });
     });
+    const promptSizeEl = this.contentEl.createEl('p', {
+      cls: 'local-stt-preset-editor__prompt-size',
+    });
+    updatePromptSize(draft.prompt);
 
     let timingDropdown: DropdownComponent | null = null;
     new Setting(this.contentEl)

--- a/styles.css
+++ b/styles.css
@@ -524,6 +524,13 @@
   width: 100%;
 }
 
+.local-stt-preset-editor__prompt-size {
+  margin: var(--size-2-2) 0 var(--size-4-2);
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+  text-align: right;
+}
+
 .local-stt-preset-editor__error {
   color: var(--text-error);
   margin: var(--size-2-2) 0;

--- a/test/preset-draft.test.ts
+++ b/test/preset-draft.test.ts
@@ -1,15 +1,25 @@
 import { describe, expect, it } from 'vitest';
 
 import { getLlmBuiltinPreset } from '../src/llm/presets';
-import { LLM_USER_PRESET_MAX_LABEL_CHARS } from '../src/settings/plugin-settings';
+import type { LlmPresetState } from '../src/settings/llm-preset-state';
 import {
+  LLM_USER_PRESET_MAX_COUNT,
+  LLM_USER_PRESET_MAX_LABEL_CHARS,
+} from '../src/settings/plugin-settings';
+import {
+  applyPresetDraftSave,
   draftFromPreset,
   duplicateLabel,
   emptyPresetDraft,
   validatePresetDraft,
 } from '../src/ui/preset-draft';
+import { createUserPreset } from './fixtures/llm';
 
 const NO_LABELS: string[] = [];
+
+function stateWith(presets: LlmPresetState['userPresets']): LlmPresetState {
+  return { activePresetRef: 'builtin:clean-up', userPresets: presets };
+}
 
 describe('preset draft validation', () => {
   it('accepts a minimal valid draft and omits inherited overrides', () => {
@@ -52,10 +62,19 @@ describe('preset draft validation', () => {
     expect(result).toMatchObject({ kind: 'ok', preset: { output: 'add_below', timing: 'batch' } });
   });
 
-  it('duplicateLabel keeps the (copy) suffix within the label limit', () => {
-    expect(duplicateLabel('Mine')).toBe('Mine (copy)');
+  it('duplicateLabel picks the first free (copy N) name, case-insensitively', () => {
+    expect(duplicateLabel('Mine', [])).toBe('Mine (copy)');
+    expect(duplicateLabel('Mine', ['mine (COPY)'])).toBe('Mine (copy 2)');
+    expect(duplicateLabel('Mine', ['Mine (copy)', 'Mine (copy 2)'])).toBe('Mine (copy 3)');
+  });
 
-    const atLimit = duplicateLabel('L'.repeat(LLM_USER_PRESET_MAX_LABEL_CHARS));
+  it('duplicateLabel numbers up from an existing copy instead of stacking suffixes', () => {
+    expect(duplicateLabel('Mine (copy)', ['Mine', 'Mine (copy)'])).toBe('Mine (copy 2)');
+    expect(duplicateLabel('Mine (copy 2)', ['Mine (copy)', 'Mine (copy 2)'])).toBe('Mine (copy 3)');
+  });
+
+  it('duplicateLabel keeps the (copy) suffix within the label limit', () => {
+    const atLimit = duplicateLabel('L'.repeat(LLM_USER_PRESET_MAX_LABEL_CHARS), []);
     expect(atLimit.endsWith(' (copy)')).toBe(true);
     expect(atLimit.length).toBeLessThanOrEqual(LLM_USER_PRESET_MAX_LABEL_CHARS);
   });
@@ -67,5 +86,61 @@ describe('preset draft validation', () => {
       prompt: getLlmBuiltinPreset('tldr').prompt,
       timing: 'batch',
     });
+  });
+});
+
+describe('applyPresetDraftSave', () => {
+  const draft = { ...emptyPresetDraft(), label: 'Mine', prompt: 'Do the thing.' };
+
+  it('creates a new preset with a fresh id', () => {
+    const result = applyPresetDraftSave(stateWith([]), draft, null);
+    expect(result.error).toBeNull();
+    expect(result.state.userPresets).toHaveLength(1);
+    expect(result.state.userPresets[0]).toMatchObject({ label: 'Mine', prompt: 'Do the thing.' });
+    expect(result.state.userPresets[0]?.id).toBeTruthy();
+  });
+
+  it('updates the edited preset in place, keeping its id', () => {
+    const existing = createUserPreset({ id: 'p1', label: 'Old name' });
+    const result = applyPresetDraftSave(stateWith([existing]), draft, 'p1');
+    expect(result.error).toBeNull();
+    expect(result.state.userPresets).toEqual([
+      { id: 'p1', label: 'Mine', output: 'replace', prompt: 'Do the thing.' },
+    ]);
+  });
+
+  it('re-adds an edited preset whose id vanished instead of dropping the edits', () => {
+    const result = applyPresetDraftSave(stateWith([]), draft, 'deleted-elsewhere');
+    expect(result.error).toBeNull();
+    expect(result.state.userPresets).toEqual([
+      { id: 'deleted-elsewhere', label: 'Mine', output: 'replace', prompt: 'Do the thing.' },
+    ]);
+  });
+
+  it('rejects names colliding with built-ins or other user presets', () => {
+    const builtinClash = applyPresetDraftSave(stateWith([]), { ...draft, label: 'clean up' }, null);
+    expect(builtinClash.error).toMatch(/built-in/);
+    expect(builtinClash.state.userPresets).toEqual([]);
+
+    const existing = createUserPreset({ id: 'p1', label: 'Mine' });
+    const userClash = applyPresetDraftSave(
+      stateWith([existing]),
+      { ...draft, label: 'MINE' },
+      null,
+    );
+    expect(userClash.error).toMatch(/already exists/);
+
+    // Keeping your own name while editing is not a collision.
+    const selfEdit = applyPresetDraftSave(stateWith([existing]), draft, 'p1');
+    expect(selfEdit.error).toBeNull();
+  });
+
+  it('enforces the preset cap for new presets', () => {
+    const full = Array.from({ length: LLM_USER_PRESET_MAX_COUNT }, (_, index) =>
+      createUserPreset({ id: `p${index}`, label: `Preset ${index}` }),
+    );
+    const result = applyPresetDraftSave(stateWith(full), draft, null);
+    expect(result.error).toMatch(/up to/);
+    expect(result.state.userPresets).toHaveLength(LLM_USER_PRESET_MAX_COUNT);
   });
 });

--- a/test/presets.test.ts
+++ b/test/presets.test.ts
@@ -20,7 +20,6 @@ describe('LLM presets', () => {
       'professional-writing',
       'tldr',
       'markdown-formatting',
-      'brain-dump',
       'action-items',
     ]);
   });
@@ -50,8 +49,9 @@ describe('LLM presets', () => {
     expect(entries.at(-1)).toMatchObject({ isBuiltin: false, ref: 'user:abc' });
   });
 
-  it('resolvePresetEntry returns null for unknown refs (including removed voice-commands)', () => {
+  it('resolvePresetEntry returns null for unknown refs (including removed built-ins)', () => {
     expect(resolvePresetEntry('builtin:voice-commands', [])).toBeNull();
+    expect(resolvePresetEntry('builtin:brain-dump', [])).toBeNull();
     expect(resolvePresetEntry('user:missing', [])).toBeNull();
     expect(resolvePresetEntry(null, [])).toBeNull();
   });


### PR DESCRIPTION
## Summary

- Fix the root cause of duplicate/delete misbehavior: the row click-to-open handler only ignored `<button>` clicks, but Obsidian extra buttons (pencil/copy/trash) are `<div class="clickable-icon">`, so icon clicks also opened the editor. Clicks inside the control cluster are now ignored.
- Duplicate now picks the first free "(copy)" / "(copy N)" name (case-insensitive, across built-ins and user presets), numbering up from an existing copy instead of stacking suffixes — duplicate-then-save works immediately.
- Extract the save mutation into pure, tested `applyPresetDraftSave` with an explicit contract: edits update in place; edits to a preset deleted elsewhere are re-added under the same id instead of silently dropped; name collisions with built-ins or user presets error; the preset cap is enforced.
- Remove the Brain dump organizer built-in preset; active refs fall back to Clean up via the existing unknown-ref path.
- Raise the user preset cap from 25 to 50.
- Add a muted prompt-size estimate (~tokens / chars) under the prompt textarea, since the prompt is sent with every request.

## Test plan

- [x] New unit tests for `duplicateLabel` collision handling and the `applyPresetDraftSave` contract (create, in-place edit, vanished-id re-add, collisions, cap)
- [x] Updated built-in lineup tests for the Brain dump removal
- [x] `npm run typecheck`, `npm run lint`, `npm run lint:obsidian`, `npm run test` (499 passing), `npm run build:frontend`
- [x] Manually verified in the dev vault: duplicate→save, delete flow, rename collisions, prompt size line

🤖 Generated with [Claude Code](https://claude.com/claude-code)