### PR TITLE
fix(sidecar): update all installed sidecar variants

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -27,7 +27,7 @@ const mainBuildOptions = {
   treeShaking: true,
   outfile: 'main.js',
   external: externalModules,
-  plugins: [pcmRecorderWorkletSourcePlugin()],
+  plugins: [buildModePlugin(), pcmRecorderWorkletSourcePlugin()],
 };
 
 async function buildAll() {
@@ -50,6 +50,31 @@ main().catch((error) => {
   console.error(error);
   process.exitCode = 1;
 });
+
+function buildModePlugin() {
+  const buildModeId = 'virtual:build-mode';
+
+  return {
+    name: 'build-mode',
+    setup(buildContext) {
+      buildContext.onResolve({ filter: /^virtual:build-mode$/ }, () => ({
+        namespace: 'build-mode',
+        path: buildModeId,
+      }));
+
+      buildContext.onLoad(
+        {
+          filter: /^virtual:build-mode$/,
+          namespace: 'build-mode',
+        },
+        () => ({
+          contents: `export const IS_PRODUCTION_BUILD = ${JSON.stringify(isProduction)};`,
+          loader: 'js',
+        }),
+      );
+    },
+  };
+}
 
 function pcmRecorderWorkletSourcePlugin() {
   const workletSourceId = 'virtual:pcm-recorder-worklet-source';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { dirname, join } from 'node:path';
-
+import { IS_PRODUCTION_BUILD } from 'virtual:build-mode';
 import { FileSystemAdapter, Notice, Platform, Plugin } from 'obsidian';
 
 import { AudioCaptureStream } from './audio/audio-capture-stream';
@@ -25,7 +25,7 @@ import {
 } from './settings/plugin-settings';
 import { LocalSttSettingTab } from './settings/settings-tab';
 import {
-  openSidecarInstallModal,
+  openSidecarUpdateModal,
   type SidecarInstallActionDeps,
 } from './settings/sidecar-settings-section';
 import { SetupWizardModal } from './setup/setup-wizard-modal';
@@ -36,7 +36,6 @@ import { SidecarConnection } from './sidecar/sidecar-connection';
 import { formatSidecarExecutableName } from './sidecar/sidecar-executable';
 import { SidecarInstallManager } from './sidecar/sidecar-install-manager';
 import {
-  type ResolvedSidecarExecutable,
   type ResolveSidecarExecutablePathOptions,
   resolveSidecarExecutablePath,
   SidecarNotInstalledError,
@@ -579,71 +578,85 @@ export default class LocalSttPlugin extends Plugin {
   }
 
   /**
-   * On startup, compare the installed sidecar's recorded version against the
-   * current plugin version and prompt for a one-click reinstall when they
-   * differ. Obsidian updates the plugin files but never the separately-
-   * installed sidecar, so the two silently fall out of sync after an update.
-   * Self-contained: every failure path (including no sidecar installed) is
-   * swallowed so this can never disrupt startup.
+   * On startup, compare every release-installed sidecar against the current
+   * plugin version and prompt for a one-click update when any differ. Obsidian
+   * updates the plugin files but never the separately-installed sidecars, so
+   * they silently fall out of sync after an update. Self-contained: every
+   * failure path is swallowed so this can never disrupt startup.
    */
   private async checkSidecarVersionDrift(): Promise<void> {
-    let pluginDirectory: string;
-    let resolved: ResolvedSidecarExecutable;
-
-    try {
-      pluginDirectory = await this.resolvePluginDirectoryPath();
-      resolved = await resolveSidecarExecutablePath(
-        this.buildSidecarResolutionOptions(pluginDirectory),
-      );
-    } catch (error) {
-      // No installed sidecar (or an unreadable plugin dir): the setup and
-      // health paths own that case — there is no installed version to compare.
-      if (!(error instanceof SidecarNotInstalledError)) {
-        this.logger.error('sidecar', 'version drift check could not resolve sidecar', error);
-      }
+    if (!IS_PRODUCTION_BUILD) {
+      this.logger.debug('sidecar', 'version drift check skipped for development plugin build');
       return;
     }
 
-    // Only a release-installed sidecar carries an install.json version. Dev
-    // builds and explicit path overrides are intentionally exempt.
-    if (resolved.source !== 'installed' || resolved.variant === null) return;
+    // A custom executable is managed outside the plugin's installer. Installed
+    // bin/* variants may still exist, but prompting to update them would be
+    // unrelated to the executable the user chose.
+    if (this.settings.sidecarPathOverride.trim().length > 0) {
+      this.logger.debug('sidecar', 'version drift check skipped for sidecar path override');
+      return;
+    }
 
-    let drift: SidecarVersionDrift | null;
+    let pluginDirectory: string;
+    try {
+      pluginDirectory = await this.resolvePluginDirectoryPath();
+    } catch (error) {
+      this.logger.error('sidecar', 'version drift check could not resolve plugin directory', error);
+      return;
+    }
+
+    let drift: SidecarVersionDrift[];
     try {
       drift = await detectSidecarVersionDrift({
         pluginDirectory,
         pluginVersion: this.manifest.version,
-        variant: resolved.variant,
+        preferredVariant: this.settings.accelerationPreference === 'cpu_only' ? 'cpu' : 'cuda',
+        supportsCuda: !Platform.isMacOS,
       });
     } catch (error) {
       this.logger.error('sidecar', 'version drift check failed', error);
       return;
     }
 
-    if (drift === null) return;
+    if (drift.length === 0) return;
 
     this.logger.debug(
       'sidecar',
-      `sidecar version drift: installed ${drift.installedVersion}, plugin ${drift.pluginVersion}`,
+      `sidecar version drift: ${drift
+        .map((entry) => `${entry.variant} ${entry.installedVersion}`)
+        .join(', ')}, plugin ${this.manifest.version}`,
     );
     this.notifySidecarVersionDrift(drift, pluginDirectory);
   }
 
-  private notifySidecarVersionDrift(drift: SidecarVersionDrift, pluginDirectory: string): void {
+  private notifySidecarVersionDrift(
+    drift: readonly SidecarVersionDrift[],
+    pluginDirectory: string,
+  ): void {
+    const variants = drift.map((entry) => entry.variant);
+    const engineLabel =
+      variants.length === 2
+        ? 'CPU and CUDA speech engines are'
+        : variants[0] === 'cuda'
+          ? 'CUDA speech engine is'
+          : 'speech engine is';
     const notice = new Notice(
       createFragment((fragment) => {
         fragment.createDiv({
-          text: `Local Dictation updated to ${drift.pluginVersion}, but its speech engine is still ${drift.installedVersion}. Reinstall to keep them in sync.`,
+          text: `Local Dictation updated to ${this.manifest.version}, but the installed ${engineLabel} out of date. Update now to keep them in sync.`,
         });
         fragment
-          .createEl('a', { href: '#', text: 'Reinstall speech engine' })
+          .createEl('a', {
+            href: '#',
+            text: variants.length === 2 ? 'Update speech engines' : 'Update speech engine',
+          })
           .addEventListener('click', (event) => {
             event.preventDefault();
             notice.hide();
-            openSidecarInstallModal(this.buildSidecarInstallActionDeps(), {
-              intent: 'reinstall',
+            openSidecarUpdateModal(this.buildSidecarInstallActionDeps(), {
               pluginDirectory,
-              variant: drift.variant,
+              variants,
             });
           });
       }),

--- a/src/settings/sidecar-settings-section.ts
+++ b/src/settings/sidecar-settings-section.ts
@@ -3,7 +3,11 @@ import { Notice, Platform, Setting } from 'obsidian';
 
 import type { ModelInstallManager } from '../models/model-install-manager';
 import { updateInstallProgressElement } from '../models/model-install-progress';
-import { getInstallCopy, type InstallIntent } from '../setup/sidecar-install-copy';
+import {
+  getInstallCopy,
+  getSidecarUpdateCopy,
+  type InstallIntent,
+} from '../setup/sidecar-install-copy';
 import { SidecarInstallModal } from '../setup/sidecar-install-modal';
 import { formatErrorMessage } from '../shared/format-utils';
 import type { PluginLogger } from '../shared/plugin-logger';
@@ -308,7 +312,41 @@ export function openSidecarInstallModal(
       deps.refreshSettingsTab();
     },
     pluginDirectory: opts.pluginDirectory,
-    variant: opts.variant,
+    variants: [opts.variant],
+    version: deps.pluginVersion,
+  }).open();
+}
+
+export function openSidecarUpdateModal(
+  deps: SidecarInstallActionDeps,
+  opts: {
+    pluginDirectory: string;
+    variants: readonly SidecarInstallVariant[];
+  },
+): void {
+  if (deps.isDictationBusy()) {
+    new Notice(
+      'Stop dictation before updating sidecars — the update restarts the engine. If a transcript is still processing, run "Cancel dictation" to stop it now.',
+    );
+    return;
+  }
+
+  new SidecarInstallModal(deps.app, {
+    beforeReplace: async () => {
+      await shutdownSidecarBeforeFileMutation(deps, 'sidecar update');
+    },
+    copy: getSidecarUpdateCopy(opts.variants),
+    manager: deps.sidecarInstallManager,
+    onInstalled: async () => {
+      await deps.restartSidecar();
+      await deps.modelInstallManager.init();
+      deps.refreshSettingsTab();
+    },
+    onVariantInstalled: async () => {
+      await deps.restartSidecar();
+    },
+    pluginDirectory: opts.pluginDirectory,
+    variants: opts.variants,
     version: deps.pluginVersion,
   }).open();
 }
@@ -328,9 +366,8 @@ async function uninstallSidecarVariantWithUx(
     return;
   }
 
-  await shutdownSidecarBeforeFileMutation(deps, `${variantLabel} uninstall`);
-
   try {
+    await shutdownSidecarBeforeFileMutation(deps, `${variantLabel} uninstall`);
     await uninstallSidecarVariant(pluginDirectory, variant);
   } catch (error) {
     deps.logger?.error('installer', `failed to uninstall ${variantLabel} sidecar`, error);
@@ -360,6 +397,12 @@ async function shutdownSidecarBeforeFileMutation(
   deps: SidecarInstallActionDeps,
   reason: string,
 ): Promise<void> {
+  if (deps.isDictationBusy()) {
+    throw new Error(
+      'Dictation became active before the sidecar files could be changed. Stop or cancel dictation, then retry.',
+    );
+  }
+
   // Windows holds DLL handles on the live sidecar process, so install and
   // uninstall paths must stop it before removing or replacing bin/*.
   try {

--- a/src/setup/setup-wizard-modal.ts
+++ b/src/setup/setup-wizard-modal.ts
@@ -179,7 +179,7 @@ export class SetupWizardModal extends Modal {
         this.goNext();
       },
       pluginDirectory: this.deps.pluginDirectory,
-      variant: 'cpu',
+      variants: ['cpu'],
       version: this.deps.pluginVersion,
     });
     modal.open();

--- a/src/setup/sidecar-install-copy.ts
+++ b/src/setup/sidecar-install-copy.ts
@@ -82,3 +82,24 @@ export function getInstallCopy(variant: SidecarInstallVariant, intent: InstallIn
   if (intent === 'reinstall') return CPU_REINSTALL;
   return CPU_INSTALL;
 }
+
+export function getSidecarUpdateCopy(variants: readonly SidecarInstallVariant[]): InstallCopy {
+  const hasCpu = variants.includes('cpu');
+  const hasCuda = variants.includes('cuda');
+  const engineLabel =
+    hasCpu && hasCuda
+      ? 'CPU and CUDA speech engines'
+      : hasCuda
+        ? 'CUDA speech engine'
+        : 'speech engine';
+  const plural = hasCpu && hasCuda;
+
+  return {
+    bodyText: `Download the current ${engineLabel} to match this version of Local Dictation. Existing installs are replaced in place.`,
+    primaryButtonText: plural ? 'Update speech engines' : 'Update speech engine',
+    successNotice: plural
+      ? 'Local Dictation speech engines updated and restarted.'
+      : 'Local Dictation speech engine updated and restarted.',
+    title: plural ? 'Update speech engines' : 'Update speech engine',
+  };
+}

--- a/src/setup/sidecar-install-modal.ts
+++ b/src/setup/sidecar-install-modal.ts
@@ -23,8 +23,9 @@ export interface SidecarInstallModalOptions {
   copy: InstallCopy;
   manager: SidecarInstallManager;
   onInstalled: () => Promise<void>;
+  onVariantInstalled?: ((variant: SidecarInstallVariant) => Promise<void>) | undefined;
   pluginDirectory: string;
-  variant: SidecarInstallVariant;
+  variants: readonly SidecarInstallVariant[];
   version: string;
 }
 
@@ -103,9 +104,12 @@ export class SidecarInstallModal extends Modal {
   }
 
   private renderPreInstall(): void {
-    let asset: string;
+    let downloads: Array<{ asset: string; variant: SidecarInstallVariant }>;
     try {
-      asset = detectPlatformAssetForCurrentEnv(this.options.variant);
+      downloads = this.options.variants.map((variant) => ({
+        asset: detectPlatformAssetForCurrentEnv(variant),
+        variant,
+      }));
     } catch (error) {
       // Currently the only path here is Intel Mac (CUDA-on-macOS is unreachable
       // because callers gate the variant on platform). The unsupported view
@@ -123,13 +127,17 @@ export class SidecarInstallModal extends Modal {
       details.createEl('dd', { text: value });
     };
     const releaseTagUrl = `${DEFAULT_RELEASE_BASE_URL.replace(/\/download$/, '/tag')}/${this.options.version}`;
-    details.createEl('dt', { text: 'Download' });
-    const downloadDd = details.createEl('dd');
-    downloadDd.createEl('a', {
-      text: asset,
-      href: releaseTagUrl,
-      attr: { rel: 'noopener noreferrer', target: '_blank' },
-    });
+    for (const download of downloads) {
+      details.createEl('dt', {
+        text: downloads.length === 1 ? 'Download' : `${download.variant.toUpperCase()} download`,
+      });
+      const downloadDd = details.createEl('dd');
+      downloadDd.createEl('a', {
+        text: download.asset,
+        href: releaseTagUrl,
+        attr: { rel: 'noopener noreferrer', target: '_blank' },
+      });
+    }
     appendRow('Version', this.options.version);
 
     const buttons = this.contentEl.createDiv({ cls: 'local-stt-sidecar-install__buttons' });
@@ -197,12 +205,13 @@ export class SidecarInstallModal extends Modal {
 
   private startInstall(): void {
     try {
-      this.options.manager.install({
+      this.options.manager.installBatch({
         beforeReplace: this.options.beforeReplace,
         onInstalled: this.options.onInstalled,
+        onVariantInstalled: this.options.onVariantInstalled,
         pluginDirectory: this.options.pluginDirectory,
         successNotice: this.options.copy.successNotice,
-        variant: this.options.variant,
+        variants: this.options.variants,
         version: this.options.version,
       });
     } catch (error) {

--- a/src/sidecar/sidecar-install-manager.ts
+++ b/src/sidecar/sidecar-install-manager.ts
@@ -10,8 +10,10 @@ import {
 export type SidecarInstallPhase = 'canceling' | 'installing';
 
 export interface ActiveSidecarInstall {
+  currentVariantNumber: number;
   phase: SidecarInstallPhase;
   progress: InstallProgress;
+  totalVariants: number;
   variant: SidecarInstallVariant;
 }
 
@@ -27,6 +29,11 @@ export interface SidecarInstallOptions {
   successNotice: string;
   variant: SidecarInstallVariant;
   version: string;
+}
+
+export interface SidecarInstallBatchOptions extends Omit<SidecarInstallOptions, 'variant'> {
+  onVariantInstalled?: ((variant: SidecarInstallVariant) => Promise<void>) | undefined;
+  variants: readonly SidecarInstallVariant[];
 }
 
 interface SidecarInstallManagerDependencies {
@@ -63,21 +70,29 @@ export class SidecarInstallManager {
   }
 
   install(options: SidecarInstallOptions): void {
+    const { variant, ...batchOptions } = options;
+    this.installBatch({ ...batchOptions, variants: [variant] });
+  }
+
+  installBatch(options: SidecarInstallBatchOptions): void {
     if (this.activeInstall !== null) {
       throw new Error('Another sidecar is already being installed.');
     }
 
+    const variants = normalizeVariants(options.variants);
     const controller = new AbortController();
     this.abortController = controller;
     this.lastError = null;
     this.activeInstall = {
+      currentVariantNumber: 1,
       phase: 'installing',
       progress: INITIAL_PROGRESS,
-      variant: options.variant,
+      totalVariants: variants.length,
+      variant: variants[0],
     };
     this.notify();
 
-    void this.runInstall(options, controller.signal);
+    void this.runInstallBatch({ ...options, variants }, controller.signal);
   }
 
   cancel(): void {
@@ -99,19 +114,48 @@ export class SidecarInstallManager {
     this.listeners.clear();
   }
 
-  private async runInstall(options: SidecarInstallOptions, signal: AbortSignal): Promise<void> {
+  private async runInstallBatch(
+    options: SidecarInstallBatchOptions,
+    signal: AbortSignal,
+  ): Promise<void> {
     try {
-      await installSidecar({
-        beforeReplace: options.beforeReplace,
-        logger: this.deps.logger,
-        onProgress: (progress) => {
-          this.updateProgress(progress);
-        },
-        pluginDirectory: options.pluginDirectory,
-        signal,
-        variant: options.variant,
-        version: options.version,
-      });
+      for (const [index, variant] of options.variants.entries()) {
+        this.activeInstall = {
+          currentVariantNumber: index + 1,
+          phase: 'installing',
+          progress: INITIAL_PROGRESS,
+          totalVariants: options.variants.length,
+          variant,
+        };
+        this.notify();
+
+        await installSidecar({
+          beforeReplace: options.beforeReplace,
+          logger: this.deps.logger,
+          onProgress: (progress) => {
+            this.updateProgress(progress);
+          },
+          pluginDirectory: options.pluginDirectory,
+          signal,
+          variant,
+          version: options.version,
+        });
+
+        const hasMoreVariants = index + 1 < options.variants.length;
+        if (hasMoreVariants && options.onVariantInstalled !== undefined) {
+          try {
+            // Best effort only: an automatic resolver may still select another
+            // stale variant until the whole batch has been replaced.
+            await options.onVariantInstalled(variant);
+          } catch (error) {
+            this.deps.logger?.warn(
+              'installer',
+              `intermediate restart after ${variant} sidecar update failed; continuing batch`,
+              error,
+            );
+          }
+        }
+      }
 
       await options.onInstalled();
       this.deps.notice(options.successNotice);
@@ -153,11 +197,16 @@ export class SidecarInstallManager {
 }
 
 export function buildSidecarProgressState(active: ActiveSidecarInstall): InstallProgressState {
+  const variantProgress =
+    active.totalVariants > 1
+      ? ` ${active.variant.toUpperCase()} sidecar (${String(active.currentVariantNumber)} of ${String(active.totalVariants)})`
+      : '';
+
   return {
     details: null,
     downloadedBytes: active.progress.bytesDownloaded,
     isCancelling: active.phase === 'canceling',
-    message: formatProgressMessage(active.progress.phase),
+    message: `${formatProgressMessage(active.progress.phase)}${variantProgress}`,
     state: 'downloading',
     totalBytes: active.progress.totalBytes,
   };
@@ -176,4 +225,16 @@ function formatProgressMessage(phase: InstallProgress['phase']): string {
 
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === 'AbortError';
+}
+
+function normalizeVariants(
+  variants: readonly SidecarInstallVariant[],
+): [SidecarInstallVariant, ...SidecarInstallVariant[]] {
+  const uniqueVariants = [...new Set(variants)];
+
+  if (uniqueVariants.length === 0) {
+    throw new Error('At least one sidecar variant is required.');
+  }
+
+  return uniqueVariants as [SidecarInstallVariant, ...SidecarInstallVariant[]];
 }

--- a/src/sidecar/sidecar-version-drift.ts
+++ b/src/sidecar/sidecar-version-drift.ts
@@ -10,6 +10,8 @@ export interface SidecarVersionDrift {
   variant: SidecarInstallVariant;
 }
 
+const SIDECAR_VARIANTS: readonly SidecarInstallVariant[] = ['cpu', 'cuda'];
+
 /**
  * True when the on-disk sidecar was installed by a different plugin version.
  *
@@ -24,27 +26,49 @@ export function isSidecarVersionDrifted(installedVersion: string, pluginVersion:
   return installedVersion.trim() !== pluginVersion.trim();
 }
 
+export function isDevelopmentSidecarVersion(version: string): boolean {
+  return version.trim().startsWith('dev-');
+}
+
 /**
- * Reads the install manifest for `variant` and reports version drift against
- * `pluginVersion`. Returns `null` when there is nothing to prompt about: no
- * manifest on disk (sidecar not installed for this variant), or the installed
- * version already matches the plugin.
+ * Reads every supported install manifest and reports release-installed
+ * variants that do not match `pluginVersion`. Development sidecars are copied
+ * into the same directories with `dev-*` manifest versions, so they are
+ * intentionally excluded from release update prompts. The preferred runtime
+ * variant is returned first so it can be updated and restarted before fallback
+ * variants are replaced.
  */
 export async function detectSidecarVersionDrift(params: {
   pluginDirectory: string;
   pluginVersion: string;
-  variant: SidecarInstallVariant;
-}): Promise<SidecarVersionDrift | null> {
-  const manifest = await readInstallManifest(
-    variantDirectoryPath(params.pluginDirectory, params.variant),
+  preferredVariant: SidecarInstallVariant;
+  supportsCuda: boolean;
+}): Promise<SidecarVersionDrift[]> {
+  const variants = params.supportsCuda
+    ? [...SIDECAR_VARIANTS].sort((left, right) => {
+        if (left === params.preferredVariant) return -1;
+        if (right === params.preferredVariant) return 1;
+        return 0;
+      })
+    : SIDECAR_VARIANTS.slice(0, 1);
+  const manifests = await Promise.all(
+    variants.map(async (variant) => ({
+      manifest: await readInstallManifest(variantDirectoryPath(params.pluginDirectory, variant)),
+      variant,
+    })),
   );
 
-  if (manifest === null) return null;
-  if (!isSidecarVersionDrifted(manifest.version, params.pluginVersion)) return null;
+  return manifests.flatMap(({ manifest, variant }) => {
+    if (manifest === null) return [];
+    if (isDevelopmentSidecarVersion(manifest.version)) return [];
+    if (!isSidecarVersionDrifted(manifest.version, params.pluginVersion)) return [];
 
-  return {
-    installedVersion: manifest.version,
-    pluginVersion: params.pluginVersion,
-    variant: params.variant,
-  };
+    return [
+      {
+        installedVersion: manifest.version,
+        pluginVersion: params.pluginVersion,
+        variant,
+      },
+    ];
+  });
 }

--- a/src/virtual-modules.d.ts
+++ b/src/virtual-modules.d.ts
@@ -4,3 +4,7 @@
 declare module 'virtual:pcm-recorder-worklet-source' {
   export const PCM_RECORDER_WORKLET_SOURCE: string;
 }
+
+declare module 'virtual:build-mode' {
+  export const IS_PRODUCTION_BUILD: boolean;
+}

--- a/test/sidecar-install-manager.test.ts
+++ b/test/sidecar-install-manager.test.ts
@@ -15,7 +15,10 @@ vi.mock('../src/sidecar/sidecar-installer', async () => {
   };
 });
 
-import { SidecarInstallManager } from '../src/sidecar/sidecar-install-manager';
+import {
+  buildSidecarProgressState,
+  SidecarInstallManager,
+} from '../src/sidecar/sidecar-install-manager';
 import type { InstallSidecarOptions } from '../src/sidecar/sidecar-installer';
 
 beforeEach(() => {
@@ -113,6 +116,132 @@ describe('SidecarInstallManager', () => {
     expect(notice).toHaveBeenNthCalledWith(1, 'CPU installed.');
     expect(notice).toHaveBeenNthCalledWith(2, 'CUDA installed.');
     expect(manager.getState().lastError).toBeNull();
+  });
+
+  it('installs a variant batch in order with intermediate and final hooks', async () => {
+    installSidecarMock
+      .mockResolvedValueOnce(successfulInstallResult('cpu'))
+      .mockResolvedValueOnce(successfulInstallResult('cuda'));
+    const notice = vi.fn();
+    const onInstalled = vi.fn(async () => {});
+    const onVariantInstalled = vi.fn(async () => {});
+    const manager = new SidecarInstallManager({ notice });
+
+    manager.installBatch({
+      ...defaultInstallOptions(),
+      onInstalled,
+      onVariantInstalled,
+      successNotice: 'Sidecars updated.',
+      variants: ['cpu', 'cuda'],
+    });
+    await vi.waitFor(() => expect(manager.getState().activeInstall).toBeNull());
+
+    expect(installSidecarMock.mock.calls.map(([options]) => options.variant)).toEqual([
+      'cpu',
+      'cuda',
+    ]);
+    expect(onVariantInstalled).toHaveBeenCalledOnce();
+    expect(onVariantInstalled).toHaveBeenCalledWith('cpu');
+    expect(onInstalled).toHaveBeenCalledOnce();
+    expect(notice).toHaveBeenCalledOnce();
+    expect(notice).toHaveBeenCalledWith('Sidecars updated.');
+  });
+
+  it('continues the batch when an intermediate restart fails', async () => {
+    installSidecarMock
+      .mockResolvedValueOnce(successfulInstallResult('cpu'))
+      .mockResolvedValueOnce(successfulInstallResult('cuda'));
+    const logger = { debug: vi.fn(), error: vi.fn(), warn: vi.fn() };
+    const onInstalled = vi.fn(async () => {});
+    const manager = new SidecarInstallManager({ logger, notice: vi.fn() });
+
+    manager.installBatch({
+      ...defaultInstallOptions(),
+      onInstalled,
+      onVariantInstalled: vi.fn(async () => {
+        throw new Error('stale CUDA could not restart');
+      }),
+      variants: ['cpu', 'cuda'],
+    });
+    await vi.waitFor(() => expect(manager.getState().activeInstall).toBeNull());
+
+    expect(installSidecarMock).toHaveBeenCalledTimes(2);
+    expect(onInstalled).toHaveBeenCalledOnce();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'installer',
+      'intermediate restart after cpu sidecar update failed; continuing batch',
+      expect.any(Error),
+    );
+  });
+
+  it('exposes the current variant and batch position while installing', async () => {
+    let resolveCpu: ((value: ReturnType<typeof successfulInstallResult>) => void) | undefined;
+    installSidecarMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveCpu = resolve;
+        }),
+    );
+    const manager = new SidecarInstallManager({ notice: vi.fn() });
+
+    manager.installBatch({
+      ...defaultInstallOptions(),
+      variants: ['cpu', 'cuda'],
+    });
+
+    const active = manager.getState().activeInstall;
+    expect(active).toMatchObject({
+      currentVariantNumber: 1,
+      totalVariants: 2,
+      variant: 'cpu',
+    });
+    expect(active === null ? null : buildSidecarProgressState(active).message).toBe(
+      'Downloading CPU sidecar (1 of 2)',
+    );
+
+    resolveCpu?.(successfulInstallResult('cpu'));
+    await vi.waitFor(() => expect(installSidecarMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('stops a batch after the failing variant without running final initialization', async () => {
+    installSidecarMock
+      .mockResolvedValueOnce(successfulInstallResult('cpu'))
+      .mockRejectedValueOnce(new Error('CUDA download failed'));
+    const notice = vi.fn();
+    const onInstalled = vi.fn(async () => {});
+    const manager = new SidecarInstallManager({ notice });
+
+    manager.installBatch({
+      ...defaultInstallOptions(),
+      onInstalled,
+      variants: ['cpu', 'cuda'],
+    });
+    await vi.waitFor(() => expect(manager.getState().activeInstall).toBeNull());
+
+    expect(installSidecarMock).toHaveBeenCalledTimes(2);
+    expect(onInstalled).not.toHaveBeenCalled();
+    expect(manager.getState().lastError).toBe('CUDA download failed');
+    expect(notice).toHaveBeenCalledWith('Sidecar install failed: CUDA download failed');
+  });
+
+  it('deduplicates variants and rejects an empty batch', async () => {
+    installSidecarMock.mockResolvedValueOnce(successfulInstallResult('cpu'));
+    const manager = new SidecarInstallManager({ notice: vi.fn() });
+
+    expect(() =>
+      manager.installBatch({
+        ...defaultInstallOptions(),
+        variants: [],
+      }),
+    ).toThrow('At least one sidecar variant is required.');
+
+    manager.installBatch({
+      ...defaultInstallOptions(),
+      variants: ['cpu', 'cpu'],
+    });
+    await vi.waitFor(() => expect(manager.getState().activeInstall).toBeNull());
+
+    expect(installSidecarMock).toHaveBeenCalledOnce();
   });
 
   it('records install failures and clears active state', async () => {

--- a/test/sidecar-version-drift.test.ts
+++ b/test/sidecar-version-drift.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { type SidecarInstallVariant, variantDirectoryPath } from '../src/sidecar/sidecar-installer';
 import {
   detectSidecarVersionDrift,
+  isDevelopmentSidecarVersion,
   isSidecarVersionDrifted,
 } from '../src/sidecar/sidecar-version-drift';
 
@@ -32,35 +33,133 @@ describe('isSidecarVersionDrifted', () => {
   });
 });
 
+describe('isDevelopmentSidecarVersion', () => {
+  it('identifies dev install manifests', () => {
+    expect(isDevelopmentSidecarVersion('dev-debug')).toBe(true);
+    expect(isDevelopmentSidecarVersion(' dev-release ')).toBe(true);
+    expect(isDevelopmentSidecarVersion('2026.5.23')).toBe(false);
+  });
+});
+
 describe('detectSidecarVersionDrift', () => {
-  it('returns null when the variant has no install manifest', async () => {
+  it('returns an empty list when no sidecar has an install manifest', async () => {
     const pluginDirectory = await createTempDirectory();
 
     await expect(
-      detectSidecarVersionDrift({ pluginDirectory, pluginVersion: '2026.5.23', variant: 'cpu' }),
-    ).resolves.toBeNull();
+      detectSidecarVersionDrift({
+        pluginDirectory,
+        pluginVersion: '2026.5.23',
+        preferredVariant: 'cuda',
+        supportsCuda: true,
+      }),
+    ).resolves.toEqual([]);
   });
 
-  it('returns null when the installed version matches the plugin version', async () => {
+  it('returns an empty list when installed versions match the plugin version', async () => {
     const pluginDirectory = await createTempDirectory();
     await writeInstallManifest(pluginDirectory, 'cpu', '2026.5.23');
+    await writeInstallManifest(pluginDirectory, 'cuda', '2026.5.23');
 
     await expect(
-      detectSidecarVersionDrift({ pluginDirectory, pluginVersion: '2026.5.23', variant: 'cpu' }),
-    ).resolves.toBeNull();
+      detectSidecarVersionDrift({
+        pluginDirectory,
+        pluginVersion: '2026.5.23',
+        preferredVariant: 'cuda',
+        supportsCuda: true,
+      }),
+    ).resolves.toEqual([]);
   });
 
-  it('reports drift when the installed version differs from the plugin version', async () => {
+  it('reports every stale installed variant with the preferred variant first', async () => {
     const pluginDirectory = await createTempDirectory();
+    await writeInstallManifest(pluginDirectory, 'cpu', '2026.5.18');
     await writeInstallManifest(pluginDirectory, 'cuda', '2026.5.19');
 
     await expect(
-      detectSidecarVersionDrift({ pluginDirectory, pluginVersion: '2026.5.23', variant: 'cuda' }),
-    ).resolves.toEqual({
-      installedVersion: '2026.5.19',
+      detectSidecarVersionDrift({
+        pluginDirectory,
+        pluginVersion: '2026.5.23',
+        preferredVariant: 'cuda',
+        supportsCuda: true,
+      }),
+    ).resolves.toEqual([
+      {
+        installedVersion: '2026.5.19',
+        pluginVersion: '2026.5.23',
+        variant: 'cuda',
+      },
+      {
+        installedVersion: '2026.5.18',
+        pluginVersion: '2026.5.23',
+        variant: 'cpu',
+      },
+    ]);
+  });
+
+  it('prioritizes CPU when the user selected CPU-only acceleration', async () => {
+    const pluginDirectory = await createTempDirectory();
+    await writeInstallManifest(pluginDirectory, 'cpu', '2026.5.18');
+    await writeInstallManifest(pluginDirectory, 'cuda', '2026.5.19');
+
+    const drift = await detectSidecarVersionDrift({
+      pluginDirectory,
       pluginVersion: '2026.5.23',
-      variant: 'cuda',
+      preferredVariant: 'cpu',
+      supportsCuda: true,
     });
+
+    expect(drift.map((entry) => entry.variant)).toEqual(['cpu', 'cuda']);
+  });
+
+  it('reports only stale variants when installed versions are mixed', async () => {
+    const pluginDirectory = await createTempDirectory();
+    await writeInstallManifest(pluginDirectory, 'cpu', '2026.5.23');
+    await writeInstallManifest(pluginDirectory, 'cuda', '2026.5.19');
+
+    await expect(
+      detectSidecarVersionDrift({
+        pluginDirectory,
+        pluginVersion: '2026.5.23',
+        preferredVariant: 'cuda',
+        supportsCuda: true,
+      }),
+    ).resolves.toEqual([
+      {
+        installedVersion: '2026.5.19',
+        pluginVersion: '2026.5.23',
+        variant: 'cuda',
+      },
+    ]);
+  });
+
+  it('ignores dev sidecars even when their versions differ from the plugin', async () => {
+    const pluginDirectory = await createTempDirectory();
+    await writeInstallManifest(pluginDirectory, 'cpu', 'dev-debug');
+    await writeInstallManifest(pluginDirectory, 'cuda', 'dev-release');
+
+    await expect(
+      detectSidecarVersionDrift({
+        pluginDirectory,
+        pluginVersion: '2026.5.23',
+        preferredVariant: 'cuda',
+        supportsCuda: true,
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it('does not inspect CUDA installs on platforms without CUDA sidecars', async () => {
+    const pluginDirectory = await createTempDirectory();
+    await writeInstallManifest(pluginDirectory, 'cpu', '2026.5.23');
+    await writeInstallManifest(pluginDirectory, 'cuda', '2026.5.19');
+
+    await expect(
+      detectSidecarVersionDrift({
+        pluginDirectory,
+        pluginVersion: '2026.5.23',
+        preferredVariant: 'cuda',
+        supportsCuda: false,
+      }),
+    ).resolves.toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Update every stale sidecar variant the user previously installed instead of only the currently selected CPU or CUDA executable.
- Keep plugin and sidecar versions synchronized through one update prompt and one multi-variant modal flow.

## Key changes

- Plugin: scan CPU and supported CUDA install manifests, filter out current and `dev-*` installs, and update only stale release variants.
- Plugin: update the preferred runtime first, then installed fallbacks, with per-variant progress such as `CUDA sidecar (1 of 2)`.
- Plugin: suppress the startup prompt for development bundles and explicit sidecar path overrides.
- Plugin: re-check dictation idleness before replacing files and continue remaining downloads when a best-effort intermediate restart fails.
- Tests: cover CPU-only, CUDA-only, both-installed, mixed-version, development-sidecar, unsupported-CUDA, ordering, progress, failure, and duplicate-input cases.

## Update behavior

The flow derives its variant list from valid `bin/<variant>/install.json` manifests. It does not install a sidecar the user did not already have. On multi-variant updates, the configured runtime is replaced first so a partial failure leaves the preferred engine current. Custom path overrides remain user-managed.

## Test plan

- [x] `npm run check` (TS typecheck + lint + vitest + esbuild)
- [x] `cargo test` (+ `cargo clippy` if Rust changed)
- [ ] Manual: install stale CPU and CUDA release sidecars in Obsidian, load the updated production plugin, and complete the multi-variant update modal.