### PR TITLE
fix(release): install cufft sub-package for Windows CUDA archive

### DIFF
--- a/.github/cuda-windows-subpackages.json
+++ b/.github/cuda-windows-subpackages.json
@@ -1,1 +1,11 @@
-["nvcc", "crt", "nvvm", "cudart", "cublas", "cublas_dev", "thrust", "visual_studio_integration"]
+[
+  "nvcc",
+  "crt",
+  "nvvm",
+  "cudart",
+  "cublas",
+  "cublas_dev",
+  "cufft",
+  "thrust",
+  "visual_studio_integration"
+]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -370,11 +370,16 @@ jobs:
           #   nvvm   -> the cicc device compiler + libdevice (nvvm/bin, nvvm/libdevice)
           #   thrust -> include/cccl (Thrust/CUB) used by ggml-cuda kernels
           # Without them CMake's CUDA compiler probe fails (C1083 on host_config.h,
-          # then "cannot find the path" for nvvm/bin). cuFFT is never linked by
-          # ggml/whisper, so it's trimmed; cublas_dev stays (ships cublas.lib /
-          # cublasLt.lib — the MSVC import libs the final link needs; LNK1181 without
-          # it, since the runtime cublas package ships only the DLLs). The set lives
-          # in .github/cuda-windows-subpackages.json so it also feeds the cache key.
+          # then "cannot find the path" for nvvm/bin). cufft is NOT a build/link
+          # dependency (ggml/whisper never link it) but it ships cufft64_*.dll,
+          # which onnxruntime_providers_cuda.dll loads at runtime; we redistribute
+          # that DLL (native/cuda-artifacts.json), so its runtime package must be
+          # installed here for the packager to copy — dropping it breaks the
+          # release archive (Linux gets cufft free via its full-toolkit install).
+          # cublas_dev stays (ships cublas.lib / cublasLt.lib — the MSVC import
+          # libs the final link needs; LNK1181 without it, since the runtime cublas
+          # package ships only the DLLs). The set lives in
+          # .github/cuda-windows-subpackages.json so it also feeds the cache key.
           # See #139, #143.
           sub-packages: ${{ steps.cuda-subpkgs.outputs.list }}
 

--- a/test/cuda-windows-subpackages.test.ts
+++ b/test/cuda-windows-subpackages.test.ts
@@ -1,0 +1,48 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+
+// The Windows release job installs only the CUDA sub-packages listed in
+// .github/cuda-windows-subpackages.json (full-toolkit installs are slow), so
+// every runtime DLL we redistribute (native/cuda-artifacts.json) must have its
+// providing sub-package in that list — otherwise the installer never drops the
+// DLL and the packager's copyFile fails the release. Guards the regression
+// where `cufft` was trimmed as a non-build dependency while cufft64_*.dll was
+// still bundled for onnxruntime_providers_cuda.dll.
+const SUBPACKAGES_PATH = '.github/cuda-windows-subpackages.json';
+const ARTIFACTS_PATH = 'native/cuda-artifacts.json';
+
+// Maps a Windows CUDA runtime DLL's library stem (the name minus the
+// `64_<soname>.dll` suffix) to the installer sub-package that ships it. Most
+// libraries are self-named; cublasLt is the exception — it rides along in the
+// cublas runtime package rather than one of its own.
+const LIBRARY_TO_SUBPACKAGE: Record<string, string> = {
+  cudart: 'cudart',
+  cublas: 'cublas',
+  cublasLt: 'cublas',
+  cufft: 'cufft',
+};
+
+async function readJson(path: string): Promise<unknown> {
+  return JSON.parse(await readFile(path, 'utf8'));
+}
+
+describe('Windows CUDA sub-packages', () => {
+  it('installs a sub-package for every redistributed runtime DLL', async () => {
+    const subPackages = (await readJson(SUBPACKAGES_PATH)) as string[];
+    const { runtime } = (await readJson(ARTIFACTS_PATH)) as { runtime: { win32: string[] } };
+
+    for (const dll of runtime.win32) {
+      const stem = dll.match(/^(.+?)64_\d+\.dll$/)?.[1];
+      if (stem === undefined) {
+        throw new Error(`unrecognized Windows CUDA DLL name: ${dll}`);
+      }
+      const subPackage = LIBRARY_TO_SUBPACKAGE[stem];
+      if (subPackage === undefined) {
+        throw new Error(`no known sub-package mapping for ${dll}`);
+      }
+      expect(subPackages, `${dll} needs the '${subPackage}' sub-package installed`).toContain(
+        subPackage,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The most recent Windows CUDA release job fails while packaging the archive:

```
Error: ENOENT: no such file or directory, copyfile
  'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2\bin\x64\cufft64_12.dll'
  -> '...\dist\sidecar-windows-x86_64-cuda\cufft64_12.dll'
```

## Root cause

The Windows release job installs only the CUDA sub-packages listed in `.github/cuda-windows-subpackages.json` (full-toolkit installs on Windows are slow). A refactor trimmed `cufft` from that list with the reasoning *"cuFFT is never linked by ggml/whisper."*

That reasoning only accounts for the **build/link** dependency. It misses the **redistribution** dependency: `cufft64_12.dll` is still in `native/cuda-artifacts.json` runtime list because `onnxruntime_providers_cuda.dll` loads cuFFT at runtime (established in the ORT provider import-chain audit, commit `70f8085`). With the sub-package gone, the installer never drops the DLL, so the packager's `copyFile` fails.

**Evidence:**
- Failed run's install command: `... cublas_dev_13.2 thrust_13.2 ...` — **no `cufft_13.2`**. The 3 preceding runtime DLLs (`cudart64_13`, `cublas64_13`, `cublasLt64_13`) copy fine; only `cufft64_12.dll` is missing.
- The last **successful** CUDA release run installed `cufft_13.2` and packaged `cufft64_12.dll` without issue.
- A local CUDA 13.2 install confirms the runtime `cufft` sub-package ships `bin\x64\cufft64_12.dll` (the manifest name is correct).
- The **Linux** CUDA job is unaffected — it installs the full toolkit (no sub-package filter), so `libcufft.so.12` is present for free.

## Fix

- Re-add the `cufft` runtime sub-package to `.github/cuda-windows-subpackages.json`.
- Correct the misleading comment in `release.yml` so the redistribution requirement is documented (prevents the same trim recurring).
- Add `test/cuda-windows-subpackages.test.ts` asserting every redistributed Windows runtime DLL has a providing sub-package, so this kind of drift fails a fast unit test instead of a release build. Verified it fails against the pre-fix list and passes after.

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅ (43 files, 521 tests)
- New test fails on the broken list, passes on the fixed list ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)