### PR TITLE
fix: whisper transcription quality (repetition, capitalization drift, speaker labels, FIFO hardening)

### DIFF
--- a/docs/specs/whisper-transcription-quality.md
+++ b/docs/specs/whisper-transcription-quality.md
@@ -1,0 +1,195 @@
+# Spec: Whisper Transcription Quality Fixes
+
+Status: approved for implementation (handoff to Codex)
+Issues: [#160](https://github.com/brittain9/local-dictation-obsidian-plugin/issues/160), [#138](https://github.com/brittain9/local-dictation-obsidian-plugin/issues/138), plus two field-reported defects (capitalization drift, spurious speaker labels) captured below.
+Companion plan: `PLANS.md` (repo root).
+
+## Design principle
+
+These defects were observed mostly on Whisper, but repeated-phrase and label
+hallucinations are generic speech-to-text failure modes (they occur in other
+dictation products too). Fixes are therefore layered:
+
+1. **Engine-agnostic defenses** in the post-engine pipeline
+   (`native/src/stages/hallucination_filter.rs`) that protect every adapter,
+   including Cohere (which produces no per-segment diagnostics — new rules must
+   not require them).
+2. **Whisper-specific root-cause fixes** only where the defect provably
+   originates in the whisper.cpp decode configuration or the prompt we feed it.
+
+## Pipeline background (as of this branch)
+
+- TS controller (`src/dictation/dictation-session-controller.ts`) starts sidecar
+  sessions; audio is VAD-segmented into utterances hard-capped at 30 s
+  (`MAX_UTTERANCE_FRAMES = 1_500` × 20 ms frames, `native/src/session.rs`).
+- Per utterance, the sidecar issues a `context_request`; the plugin answers with
+  a `ContextWindow` whose text is a **note glossary** — `Glossary: Term1, Term2, …`
+  built from Capitalized tokens scraped from the active note
+  (`buildGlossary`, `src/editor/note-surface.ts:689`), budget 384 chars
+  (`CONTEXT_BUDGET_CHARS`, `native/src/app.rs:41`). Only sent when the
+  `useNoteAsContext` setting is on.
+- The Whisper adapter (`native/src/adapters/whisper.rs`) feeds that text as
+  `initial_prompt` and decodes with `SamplingStrategy::Greedy { best_of: 0 }`;
+  all other whisper.cpp params are library defaults.
+- Post-engine stages run per revision; `HallucinationFilterStage` classifies
+  each segment independently (hard blocklist / soft-corroborated / repetition /
+  silence / prompt-leak) and drops segments, recording them in a versioned
+  stage payload (`version: 1`).
+- Finished transcripts flow back to the TS controller, which serializes accepts
+  through a per-session FIFO (`processTranscriptReady`).
+
+## Bug A — Repeated phrase hallucination (#160)
+
+### Evidence
+
+A transcript devolved into `Peter, how's the show that reaches?` repeated many
+times (system audio + mic, Whisper large-v3-turbo q8_0).
+
+### Root causes (observed in code)
+
+1. **Degraded decoder fallback (Whisper-specific).**
+   `native/src/adapters/whisper.rs:73` uses `Greedy { best_of: 0 }`. In
+   whisper.cpp, `greedy.best_of` is the number of parallel decoders used during
+   temperature fallback (`n_decoders_cur = max(1, best_of)` when `t_cur > 0`);
+   the upstream default is **5**. With 0, the entropy-threshold fallback —
+   whisper.cpp's built-in escape hatch from repetition loops — re-decodes with a
+   single sampled decoder, drastically weakening it.
+2. **Filter blind spot (engine-agnostic).** The repetition rules in
+   `hallucination_filter.rs` (`repeated_ngram_dominates`,
+   `repeated_suffix_dominates`) operate **within one segment** and additionally
+   require a diagnostics/VAD corroborator. A decoder loop that emits the same
+   sentence as N *separate consecutive segments* — exactly the #160 shape — is
+   invisible to them.
+
+### Decisions
+
+- **A1 (Whisper):** change `best_of: 0` → `best_of: 5` (upstream default),
+  with a comment explaining that this is the decoder count for temperature
+  fallback, not a beam width. Do not restate other whisper.cpp defaults
+  (`entropy_thold` 2.4, `temperature_inc` 0.2, `logprob_thold` −1.0 already
+  apply); the comment should name them as the mechanism this re-enables.
+- **A2 (engine-agnostic):** add a transcript-level rule to
+  `HallucinationFilterStage`: a run of ≥ `REPEATED_SEGMENT_RUN_MIN = 3`
+  **consecutive** segments with identical non-empty `normalize_text` output
+  keeps the first segment and drops the rest with new reason `repetition_run`.
+  No corroborator required — three back-to-back identical segments is not a
+  realistic dictation pattern, and Cohere segments carry no diagnostics.
+  Runs on **final revisions only** (consistent with existing non-hard rules).
+- **Deferred:** cross-*utterance* repetition guarding (same phrase accepted
+  across successive utterances). Riskier — users legitimately repeat
+  themselves across utterances; revisit if A1+A2 don't clear #160 in practice.
+
+## Bug B — Title-Case capitalization drift
+
+### Evidence
+
+During long sessions, especially after dictating proper nouns, Whisper starts
+capitalizing Every Single Word; a fresh session resets it.
+
+### Root cause (observed in code)
+
+`buildGlossary` emits `Glossary: Nami, Luffy, Obsidian, …` — a colon-labeled,
+Title-Case comma list — and the adapter feeds it verbatim as `initial_prompt`.
+Whisper mimics the *style* of its prompt (OpenAI's Whisper prompting guidance:
+prompts should read like ordinary transcript prose), so a list of Capitalized
+Tokens pushes the decoder toward Title Case. The loop is self-reinforcing:
+dictated proper nouns land in the note → get scraped into the glossary → the
+next utterance's prompt is a longer Capitalized list → stronger drift. This
+also explains the reset on a new session/note, and it is Whisper-specific by
+construction (the only adapter consuming `initial_prompt`).
+
+### Decisions
+
+- **B1:** reformat the glossary as sentence-cased prose that still carries the
+  terms with their intended casing:
+  `The notes mention Nami, Luffy, Obsidian.` (fixed prefix
+  `The notes mention `, comma-joined terms, terminal period). Same dedupe,
+  budget, and truncation semantics; the terminal period must fit the budget.
+- **B2:** update the prompt-leak fast path in `hallucination_filter.rs`
+  (`is_prompt_leak`, currently `starts_with("glossary:")`) to the new
+  normalized prefix (`the notes mention`), and update its tests. The literal is
+  intentionally duplicated across TS and Rust (it crosses the wire as opaque
+  text); each side must carry a comment pointing at the other. False-positive
+  risk is bounded: the fast path still requires ≥ 2 corroborators to drop.
+- **B3:** removing the `Glossary:` label also removes a colon-label prime that
+  plausibly feeds Bug C.
+- Keep the 384-char budget and the `useNoteAsContext` gate unchanged.
+
+## Bug C — Spurious speaker labels
+
+### Evidence (captured 2026-07-03, speaker labels feature OFF, predates diarization)
+
+> …I need to speak with you. Nami, Luffy and your crew. **Gorglosa:** Let me
+> join your crew. … **Gorgiasi:** Let me buy back … **Elegatee:** I'm going to
+> turn it into YouTube.
+
+`Gorglosa`, `Gorgiasi`, `Elegatee` are invented, name-shaped, single-token
+labels at segment starts — Whisper training-data artifacts (captions/interview
+transcripts). Each appeared **once**, so any rule requiring the label to repeat
+would miss them.
+
+### Decisions
+
+- **C1 (engine-agnostic):** add a **label-scrub** rule to
+  `HallucinationFilterStage` that strips (not drops) a leading speaker-label
+  prefix from a segment. Product invariant making this safe: speaker
+  attribution is exclusively the diarization feature's job (the segment
+  `speaker` field); engine-emitted text labels are never legitimate.
+- **C2 (pattern):** at segment start, 1–2 whitespace-separated tokens, each
+  matching initial-capital alphabetic shape (`[A-Z][a-z'’.-]+` — not all-caps,
+  no digits), followed by `:`, whitespace, and a non-empty remainder. The strip
+  removes the prefix through the colon and following whitespace.
+- **C3 (guards, in order):**
+  1. Skip if the prefix (case-insensitive, sans colon) appears in a small
+     structural keep-list of dictation labels:
+     `note, todo, warning, question, answer, summary, title, reminder, idea,
+     important, update, edit, aside` (constant, tunable).
+  2. Skip if the prefix appears as a term in the utterance's context window
+     text (the note glossary) — protects deliberate definition-list dictation
+     of the user's own vocabulary ("Nami colon the navigator"). Accepted
+     trade-off: a hallucinated label that reuses a real glossary name survives.
+  3. Otherwise strip unconditionally — **no corroborator requirement** (see
+     evidence: labels occur once, with unremarkable diagnostics, and Cohere has
+     no diagnostics).
+- **C4 (observability):** stripped prefixes are recorded in the stage payload
+  as `editedSegments: [{ index, strippedPrefix, originalText }]`; bump payload
+  `VERSION` 1 → 2. Extend TS `logDroppedHallucinations`
+  (`dictation-session-controller.ts:1073`) to also debug-log edited segments.
+- **C5:** final revisions only, same rationale as A2.
+- Rollback story: pattern + keep-list are constants; the payload makes every
+  strip auditable from debug logs.
+
+## Bug D — Utterance FIFO hardening (#138)
+
+### Evidence (from issue, sourced from CODE_REVIEW.md R3)
+
+In `processTranscriptReady` the FIFO accept step guards only on
+`this.sessions.has(sessionId)` (`dictation-session-controller.ts:678`). If
+`acceptTranscript` is rejected, the error path calls `cancelSession`; if
+`cancelSession` itself throws before `disposeLocalSession` runs (e.g.
+`clearActiveSession → captureStream.stop()` rejects), the session stays in the
+registry in a half-cancelled state and queued utterances behind it still
+accept into it.
+
+### Decisions
+
+- **D1:** gate the FIFO accept body on session phase in addition to registry
+  membership: return early when `entry.phase === 'cancelling' || entry.phase === 'stopped'`.
+  `'stopping'` must **not** be gated — the stop flow drains in-flight
+  transcripts. (`cancelSession` already sets `phase = 'cancelling'`
+  synchronously before any `await`, `dictation-session-controller.ts:417`;
+  verify no await precedes it in the error path and keep it that way.)
+- **D2:** dedicated regression test that forces `cancelSession` to throw
+  (reject `captureStream.stop()` — the sidecar-cancel failure path is already
+  caught internally) with a second utterance queued behind the failing one, and
+  asserts the second `acceptTranscript` never runs. Per the issue: the FIFO is
+  the most timing-sensitive code in the plugin — **no drive-by changes** in
+  this area.
+
+## Non-goals
+
+- No cross-utterance repetition dedup (deferred, see Bug A).
+- No changes to diarization, Cohere adapter behavior, or the LLM cleanup path.
+- No new user-facing settings; all thresholds are code constants.
+- No general "case repair" post-processing (too risky; Bug B is fixed at the
+  prompt root cause).

--- a/docs/specs/whisper-transcription-quality.md
+++ b/docs/specs/whisper-transcription-quality.md
@@ -173,12 +173,18 @@ accept into it.
 
 ### Decisions
 
-- **D1:** gate the FIFO accept body on session phase in addition to registry
-  membership: return early when `entry.phase === 'cancelling' || entry.phase === 'stopped'`.
-  `'stopping'` must **not** be gated — the stop flow drains in-flight
-  transcripts. (`cancelSession` already sets `phase = 'cancelling'`
-  synchronously before any `await`, `dictation-session-controller.ts:417`;
-  verify no await precedes it in the error path and keep it that way.)
+- **D1 (corrected in review):** gate the FIFO accept body on
+  `entry.phase === 'cancelling'` **only**, in addition to registry membership.
+  Issue #138's suggestion to also gate `'stopped'` turned out to be wrong:
+  `handleSessionStopped` flips the phase to `'stopped'` synchronously, and the
+  sidecar can deliver the final `transcript_ready` and `session_stopped` in
+  one I/O chunk — the stop path *drains* those in-flight accepts after the
+  flip, so gating `'stopped'` silently drops the last utterance (caught by the
+  pre-existing same-turn drain regression test). Neither `'stopping'` nor
+  `'stopped'` may be gated. `'cancelling'` alone covers #138: `cancelSession`
+  sets it synchronously before any `await`
+  (`dictation-session-controller.ts:417`) and it persists if cancellation
+  cleanup throws; fully-disposed sessions are covered by `sessions.has(...)`.
 - **D2:** dedicated regression test that forces `cancelSession` to throw
   (reject `captureStream.stop()` — the sidecar-cancel failure path is already
   caught internally) with a second utterance queued behind the failing one, and

--- a/native/src/adapters/whisper.rs
+++ b/native/src/adapters/whisper.rs
@@ -70,7 +70,10 @@ impl LoadedModel for LoadedWhisperModel {
         let mut state = self.context.create_state().map_err(|error| {
             TranscriptionError::transcription_failure("failed to create whisper state", error)
         })?;
-        let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 0 });
+        // `best_of` is the decoder count during whisper.cpp temperature fallback,
+        // not beam width. Keep the upstream default of 5 so the entropy_thold 2.4 /
+        // temperature_inc 0.2 fallback can escape repetition; 0 collapsed it to one.
+        let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 5 });
 
         params.set_n_threads(recommended_thread_count(request.gpu_config.use_gpu));
         params.set_language(Some(&request.language));

--- a/native/src/app.rs
+++ b/native/src/app.rs
@@ -35,9 +35,9 @@ use crate::worker::{SessionMetadata, TranscriptionWorker, WorkerCommand, WorkerE
 const QUEUE_OVERLOAD_DEPTH: usize = 30;
 // Whisper's `initial_prompt` is hard-capped at 224 tokens (silently truncated
 // to the final 224 — see OpenAI's Whisper Prompting Guide). 384 chars of
-// glossary content (mostly short identifiers) lands comfortably under that
-// cap with headroom for tokenizer variance, while still fitting roughly
-// 30-60 distinct terms.
+// sentence-cased spelling-hint prose (mostly short identifiers) lands
+// comfortably under that cap with headroom for tokenizer variance, while
+// still fitting roughly 30-60 distinct terms.
 const CONTEXT_BUDGET_CHARS: u32 = 384;
 const CONTEXT_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
 const AUDIO_LEVEL_EVENT_INTERVAL: Duration = Duration::from_millis(50);

--- a/native/src/stages/hallucination_filter.rs
+++ b/native/src/stages/hallucination_filter.rs
@@ -7,7 +7,7 @@ use crate::transcription::{SegmentDiagnostics, Transcript};
 
 const VERSION: u32 = 2;
 
-const STRUCTURAL_LABEL_KEEP_LIST: [&str; 13] = [
+const STRUCTURAL_LABEL_KEEP_LIST: &[&str] = &[
     "note",
     "todo",
     "warning",
@@ -73,10 +73,12 @@ impl StageProcessor for HallucinationFilterStage {
             };
         }
 
-        // Normalize the prompt context once per revision; without this hoist
-        // the prompt-leak rule would re-lowercase + re-split the same context
-        // string for every segment.
+        // Prepare both context representations once per revision instead of
+        // re-normalizing or re-tokenizing the same text for every segment.
         let normalized_context = ctx.context.map(|context| normalize_text(&context.text));
+        let context_label_tokens = ctx
+            .context
+            .map(|context| speaker_label_context_tokens(&context.text));
         let repetition_run_drops = repeated_segment_run_drops(&transcript.segments, ctx.is_final);
 
         let mut kept = Vec::with_capacity(transcript.segments.len());
@@ -85,34 +87,38 @@ impl StageProcessor for HallucinationFilterStage {
 
         for (index, segment) in transcript.segments.iter().enumerate() {
             let diagnostics = ctx.segment_diagnostics.get(index);
-            let mut processed_segment = segment.clone();
-            let reason = if repetition_run_drops[index] {
+            if repetition_run_drops[index] {
                 let evidence = SegmentEvidence::from_segment(segment, diagnostics, ctx);
-                Some((DropReason::RepetitionRun, evidence))
-            } else {
-                if ctx.is_final
-                    && let Some((stripped_prefix, text)) = strip_speaker_label(
-                        &segment.text,
-                        ctx.context.map(|context| context.text.as_str()),
-                    )
-                {
-                    edited.push(EditedSegment {
-                        index,
-                        stripped_prefix,
-                        original_text: segment.text.clone(),
-                    });
-                    processed_segment.text = text;
-                }
-                let evidence = SegmentEvidence::from_segment(&processed_segment, diagnostics, ctx);
-                classify_drop(
-                    &processed_segment,
+                dropped.push(DroppedSegment::from_segment(
+                    index,
+                    DropReason::RepetitionRun,
+                    segment,
                     &evidence,
-                    ctx.is_final,
-                    normalized_context.as_deref(),
-                )
-                .map(|reason| (reason, evidence))
-            };
-            if let Some((reason, evidence)) = reason {
+                    diagnostics,
+                ));
+                continue;
+            }
+
+            let mut processed_segment = segment.clone();
+            if ctx.is_final
+                && let Some((stripped_prefix, text)) =
+                    strip_speaker_label(&segment.text, context_label_tokens.as_deref())
+            {
+                edited.push(EditedSegment {
+                    index,
+                    stripped_prefix,
+                    original_text: segment.text.clone(),
+                });
+                processed_segment.text = text;
+            }
+
+            let evidence = SegmentEvidence::from_segment(&processed_segment, diagnostics, ctx);
+            if let Some(reason) = classify_drop(
+                &processed_segment,
+                &evidence,
+                ctx.is_final,
+                normalized_context.as_deref(),
+            ) {
                 dropped.push(DroppedSegment::from_segment(
                     index,
                     reason,
@@ -410,7 +416,7 @@ fn normalize_text(text: &str) -> String {
         .to_string()
 }
 
-fn strip_speaker_label(text: &str, context: Option<&str>) -> Option<(String, String)> {
+fn strip_speaker_label(text: &str, context_tokens: Option<&[&str]>) -> Option<(String, String)> {
     let colon = text.find(':')?;
     let prefix = &text[..colon];
     if prefix.trim() != prefix {
@@ -434,7 +440,7 @@ fn strip_speaker_label(text: &str, context: Option<&str>) -> Option<(String, Str
     if STRUCTURAL_LABEL_KEEP_LIST
         .iter()
         .any(|label| prefix.eq_ignore_ascii_case(label))
-        || context.is_some_and(|context| context_contains_label(context, &tokens))
+        || context_tokens.is_some_and(|context| context_contains_label(context, &tokens))
     {
         return None;
     }
@@ -448,22 +454,22 @@ fn is_label_token(token: &str) -> bool {
         return false;
     }
 
-    let remainder = chars.collect::<Vec<_>>();
-    !remainder.is_empty()
-        && remainder
-            .iter()
-            .all(|ch| ch.is_ascii_lowercase() || matches!(ch, '\'' | '’' | '.' | '-'))
+    let mut remainder = chars.peekable();
+    remainder.peek().is_some()
+        && remainder.all(|ch| ch.is_ascii_lowercase() || matches!(ch, '\'' | '’' | '.' | '-'))
 }
 
-fn context_contains_label(context: &str, label_tokens: &[&str]) -> bool {
-    let context_tokens = context
+fn speaker_label_context_tokens(context: &str) -> Vec<&str> {
+    context
         .split(|ch: char| !(ch.is_ascii_alphabetic() || matches!(ch, '\'' | '’' | '.' | '-')))
         .filter_map(|token| {
             let term = token.trim_matches(['\'', '’', '.', '-']);
             (!term.is_empty()).then_some(term)
         })
-        .collect::<Vec<_>>();
+        .collect()
+}
 
+fn context_contains_label(context_tokens: &[&str], label_tokens: &[&str]) -> bool {
     context_tokens.windows(label_tokens.len()).any(|window| {
         window
             .iter()

--- a/native/src/stages/hallucination_filter.rs
+++ b/native/src/stages/hallucination_filter.rs
@@ -5,7 +5,23 @@ use crate::protocol::{StageId, TranscriptSegment};
 use crate::stages::{StageContext, StageProcess, StageProcessor};
 use crate::transcription::{SegmentDiagnostics, Transcript};
 
-const VERSION: u32 = 1;
+const VERSION: u32 = 2;
+
+const STRUCTURAL_LABEL_KEEP_LIST: [&str; 13] = [
+    "note",
+    "todo",
+    "warning",
+    "question",
+    "answer",
+    "summary",
+    "title",
+    "reminder",
+    "idea",
+    "important",
+    "update",
+    "edit",
+    "aside",
+];
 
 // Strong corroborators — any one drops a SOFT phrase on a final revision and is
 // the only path that drops a Normal-classified segment as silence.
@@ -24,6 +40,7 @@ const SHORT_VOICE_MS: u64 = 1_200;
 const SHORT_VOICE_MIN_WORDS: usize = 3;
 
 // Repetition / character-run thresholds.
+const REPEATED_SEGMENT_RUN_MIN: usize = 3;
 const NGRAM_3_MIN_COUNT: usize = 3;
 const NGRAM_5_MIN_COUNT: usize = 2;
 const SUFFIX_MIN_REPEATS: usize = 3;
@@ -60,32 +77,55 @@ impl StageProcessor for HallucinationFilterStage {
         // the prompt-leak rule would re-lowercase + re-split the same context
         // string for every segment.
         let normalized_context = ctx.context.map(|context| normalize_text(&context.text));
+        let repetition_run_drops = repeated_segment_run_drops(&transcript.segments, ctx.is_final);
 
         let mut kept = Vec::with_capacity(transcript.segments.len());
         let mut dropped = Vec::new();
+        let mut edited = Vec::new();
 
         for (index, segment) in transcript.segments.iter().enumerate() {
             let diagnostics = ctx.segment_diagnostics.get(index);
-            let evidence = SegmentEvidence::from_segment(segment, diagnostics, ctx);
-            if let Some(reason) = classify_drop(
-                segment,
-                &evidence,
-                ctx.is_final,
-                normalized_context.as_deref(),
-            ) {
+            let mut processed_segment = segment.clone();
+            let reason = if repetition_run_drops[index] {
+                let evidence = SegmentEvidence::from_segment(segment, diagnostics, ctx);
+                Some((DropReason::RepetitionRun, evidence))
+            } else {
+                if ctx.is_final
+                    && let Some((stripped_prefix, text)) = strip_speaker_label(
+                        &segment.text,
+                        ctx.context.map(|context| context.text.as_str()),
+                    )
+                {
+                    edited.push(EditedSegment {
+                        index,
+                        stripped_prefix,
+                        original_text: segment.text.clone(),
+                    });
+                    processed_segment.text = text;
+                }
+                let evidence = SegmentEvidence::from_segment(&processed_segment, diagnostics, ctx);
+                classify_drop(
+                    &processed_segment,
+                    &evidence,
+                    ctx.is_final,
+                    normalized_context.as_deref(),
+                )
+                .map(|reason| (reason, evidence))
+            };
+            if let Some((reason, evidence)) = reason {
                 dropped.push(DroppedSegment::from_segment(
                     index,
                     reason,
-                    segment,
+                    &processed_segment,
                     &evidence,
                     diagnostics,
                 ));
             } else {
-                kept.push(segment.clone());
+                kept.push(processed_segment);
             }
         }
 
-        if dropped.is_empty() {
+        if dropped.is_empty() && edited.is_empty() {
             StageProcess::Skipped {
                 reason: "no_hallucinations".to_string(),
                 payload: None,
@@ -97,6 +137,7 @@ impl StageProcessor for HallucinationFilterStage {
                     serde_json::to_value(FilterPayload {
                         version: VERSION,
                         dropped_segments: dropped,
+                        edited_segments: edited,
                     })
                     .expect("hallucination payload should serialize"),
                 ),
@@ -112,6 +153,7 @@ enum DropReason {
     BlocklistSoftCorroborated,
     PromptLeakCorroborated,
     Repetition,
+    RepetitionRun,
     Silence,
 }
 
@@ -227,6 +269,15 @@ impl SegmentEvidence {
 struct FilterPayload {
     version: u32,
     dropped_segments: Vec<DroppedSegment>,
+    edited_segments: Vec<EditedSegment>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EditedSegment {
+    index: usize,
+    stripped_prefix: String,
+    original_text: String,
 }
 
 #[derive(Serialize)]
@@ -359,6 +410,68 @@ fn normalize_text(text: &str) -> String {
         .to_string()
 }
 
+fn strip_speaker_label(text: &str, context: Option<&str>) -> Option<(String, String)> {
+    let colon = text.find(':')?;
+    let prefix = &text[..colon];
+    if prefix.trim() != prefix {
+        return None;
+    }
+
+    let tokens = prefix.split_whitespace().collect::<Vec<_>>();
+    if !(1..=2).contains(&tokens.len()) || !tokens.iter().all(|token| is_label_token(token)) {
+        return None;
+    }
+
+    let after_colon = &text[colon + 1..];
+    if !after_colon.chars().next().is_some_and(char::is_whitespace) {
+        return None;
+    }
+    let remainder = after_colon.trim_start();
+    if remainder.is_empty() {
+        return None;
+    }
+
+    if STRUCTURAL_LABEL_KEEP_LIST
+        .iter()
+        .any(|label| prefix.eq_ignore_ascii_case(label))
+        || context.is_some_and(|context| context_contains_label(context, &tokens))
+    {
+        return None;
+    }
+
+    Some((format!("{prefix}:"), remainder.to_string()))
+}
+
+fn is_label_token(token: &str) -> bool {
+    let mut chars = token.chars();
+    if !chars.next().is_some_and(|ch| ch.is_ascii_uppercase()) {
+        return false;
+    }
+
+    let remainder = chars.collect::<Vec<_>>();
+    !remainder.is_empty()
+        && remainder
+            .iter()
+            .all(|ch| ch.is_ascii_lowercase() || matches!(ch, '\'' | '’' | '.' | '-'))
+}
+
+fn context_contains_label(context: &str, label_tokens: &[&str]) -> bool {
+    let context_tokens = context
+        .split(|ch: char| !(ch.is_ascii_alphabetic() || matches!(ch, '\'' | '’' | '.' | '-')))
+        .filter_map(|token| {
+            let term = token.trim_matches(['\'', '’', '.', '-']);
+            (!term.is_empty()).then_some(term)
+        })
+        .collect::<Vec<_>>();
+
+    context_tokens.windows(label_tokens.len()).any(|window| {
+        window
+            .iter()
+            .zip(label_tokens)
+            .all(|(context_token, label_token)| context_token.eq_ignore_ascii_case(label_token))
+    })
+}
+
 fn is_punctuation_only(text: &str) -> bool {
     let trimmed = text.trim();
     !trimmed.is_empty()
@@ -441,6 +554,36 @@ fn words(text: &str) -> Vec<&str> {
     text.split_whitespace().collect()
 }
 
+fn repeated_segment_run_drops(segments: &[TranscriptSegment], is_final: bool) -> Vec<bool> {
+    let mut drops = vec![false; segments.len()];
+    if !is_final {
+        return drops;
+    }
+
+    let normalized = segments
+        .iter()
+        .map(|segment| normalize_text(&segment.text))
+        .collect::<Vec<_>>();
+    let mut run_start = 0;
+    while run_start < normalized.len() {
+        if normalized[run_start].is_empty() {
+            run_start += 1;
+            continue;
+        }
+
+        let mut run_end = run_start + 1;
+        while run_end < normalized.len() && normalized[run_end] == normalized[run_start] {
+            run_end += 1;
+        }
+        if run_end - run_start >= REPEATED_SEGMENT_RUN_MIN {
+            drops[run_start + 1..run_end].fill(true);
+        }
+        run_start = run_end;
+    }
+
+    drops
+}
+
 fn repeated_ngram_dominates(words: &[&str]) -> bool {
     ngram_dominates(words, 3, NGRAM_3_MIN_COUNT) || ngram_dominates(words, 5, NGRAM_5_MIN_COUNT)
 }
@@ -498,7 +641,9 @@ fn is_prompt_leak(evidence: &SegmentEvidence, normalized_context: Option<&str>) 
     let Some(normalized_context) = normalized_context else {
         return false;
     };
-    if evidence.normalized_text.starts_with("glossary:") {
+    // Keep this prompt prefix in sync with `buildGlossary` in
+    // `src/editor/note-surface.ts`.
+    if evidence.normalized_text.starts_with("the notes mention") {
         return true;
     }
 
@@ -540,6 +685,15 @@ mod tests {
             utterance_id: Uuid::nil(),
             revision: 0,
             segments: vec![segment(text)],
+            stage_history: Vec::new(),
+        }
+    }
+
+    fn transcript_with_segments(texts: &[&str]) -> Transcript {
+        Transcript {
+            utterance_id: Uuid::nil(),
+            revision: 0,
+            segments: texts.iter().map(|text| segment(text)).collect(),
             stage_history: Vec::new(),
         }
     }
@@ -691,11 +845,169 @@ mod tests {
     }
 
     #[test]
+    fn consecutive_duplicate_segment_run_keeps_first_without_diagnostics() {
+        let transcript = transcript_with_segments(&[
+            "Peter, how's the show that reaches?",
+            "Peter, how's the show that reaches?",
+            "Peter, how's the show that reaches?",
+        ]);
+        let result = HallucinationFilterStage.process(&transcript, &ctx(&[], &[], None, true));
+        let StageProcess::Ok { segments, payload } = result else {
+            panic!("expected repetition run drop");
+        };
+
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].text, "Peter, how's the show that reaches?");
+        let dropped = payload
+            .as_ref()
+            .and_then(|value| value.get("droppedSegments"))
+            .and_then(|value| value.as_array())
+            .expect("payload has droppedSegments");
+        assert_eq!(dropped.len(), 2);
+        assert_eq!(
+            dropped
+                .iter()
+                .map(|entry| entry.get("index").and_then(|value| value.as_u64()))
+                .collect::<Vec<_>>(),
+            vec![Some(1), Some(2)],
+        );
+        assert!(dropped.iter().all(|entry| {
+            entry.get("reason").and_then(|value| value.as_str()) == Some("repetition_run")
+        }));
+    }
+
+    #[test]
+    fn two_consecutive_duplicate_segments_are_kept() {
+        let transcript = transcript_with_segments(&["Repeat this.", "Repeat this."]);
+        let result = HallucinationFilterStage.process(&transcript, &ctx(&[], &[], None, true));
+        assert!(
+            matches!(result, StageProcess::Skipped { reason, .. } if reason == "no_hallucinations")
+        );
+    }
+
+    #[test]
+    fn partial_revision_keeps_consecutive_duplicate_segment_run() {
+        let transcript = transcript_with_segments(&["Repeat this."; 3]);
+        let result = HallucinationFilterStage.process(&transcript, &ctx(&[], &[], None, false));
+        assert!(
+            matches!(result, StageProcess::Skipped { reason, .. } if reason == "no_hallucinations")
+        );
+    }
+
+    #[test]
+    fn speaker_label_scrub_records_single_token_edit() {
+        let result = HallucinationFilterStage.process(
+            &transcript("Gorglosa: Let me join"),
+            &ctx(&[], &[], None, true),
+        );
+        let StageProcess::Ok { segments, payload } = result else {
+            panic!("expected speaker label edit");
+        };
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].text, "Let me join");
+
+        let payload = payload.expect("edit payload");
+        assert_eq!(
+            payload.get("version").and_then(|value| value.as_u64()),
+            Some(2)
+        );
+        assert_eq!(
+            payload
+                .get("droppedSegments")
+                .and_then(|value| value.as_array())
+                .map(Vec::len),
+            Some(0),
+        );
+        let edits = payload
+            .get("editedSegments")
+            .and_then(|value| value.as_array())
+            .expect("editedSegments");
+        assert_eq!(edits.len(), 1);
+        assert_eq!(
+            edits[0].get("index").and_then(|value| value.as_u64()),
+            Some(0)
+        );
+        assert_eq!(
+            edits[0]
+                .get("strippedPrefix")
+                .and_then(|value| value.as_str()),
+            Some("Gorglosa:"),
+        );
+        assert_eq!(
+            edits[0]
+                .get("originalText")
+                .and_then(|value| value.as_str()),
+            Some("Gorglosa: Let me join"),
+        );
+    }
+
+    #[test]
+    fn speaker_label_scrub_handles_two_token_label() {
+        let result = HallucinationFilterStage.process(
+            &transcript("Peter Santanello: hi"),
+            &ctx(&[], &[], None, true),
+        );
+        let StageProcess::Ok { segments, .. } = result else {
+            panic!("expected speaker label edit");
+        };
+        assert_eq!(segments[0].text, "hi");
+    }
+
+    #[test]
+    fn speaker_label_scrub_keeps_structural_and_nonmatching_labels() {
+        for text in ["Note: buy milk", "TODO: x", "Peter:"] {
+            let result =
+                HallucinationFilterStage.process(&transcript(text), &ctx(&[], &[], None, true));
+            assert!(
+                matches!(result, StageProcess::Skipped { reason, .. } if reason == "no_hallucinations"),
+                "{text} should be kept unchanged",
+            );
+        }
+    }
+
+    #[test]
+    fn speaker_label_scrub_respects_context_terms() {
+        let without_context = HallucinationFilterStage.process(
+            &transcript("Nami: the navigator"),
+            &ctx(&[], &[], None, true),
+        );
+        let StageProcess::Ok { segments, .. } = without_context else {
+            panic!("expected speaker label edit without context");
+        };
+        assert_eq!(segments[0].text, "the navigator");
+
+        let context = ContextWindow {
+            budget_chars: 100,
+            sources: Vec::new(),
+            text: "The notes mention Nami.".to_string(),
+            truncated: false,
+        };
+        let with_context = HallucinationFilterStage.process(
+            &transcript("Nami: the navigator"),
+            &ctx(&[], &[], Some(&context), true),
+        );
+        assert!(
+            matches!(with_context, StageProcess::Skipped { reason, .. } if reason == "no_hallucinations")
+        );
+    }
+
+    #[test]
+    fn partial_revision_does_not_scrub_speaker_label() {
+        let result = HallucinationFilterStage.process(
+            &transcript("Gorglosa: Let me join"),
+            &ctx(&[], &[], None, false),
+        );
+        assert!(
+            matches!(result, StageProcess::Skipped { reason, .. } if reason == "no_hallucinations")
+        );
+    }
+
+    #[test]
     fn prompt_leak_requires_context_and_corroboration() {
         let context = ContextWindow {
             budget_chars: 100,
             sources: Vec::new(),
-            text: "Glossary: AlphaTerm, BetaTerm, GammaTerm, DeltaTerm".to_string(),
+            text: "The notes mention AlphaTerm, BetaTerm, GammaTerm, DeltaTerm.".to_string(),
             truncated: false,
         };
         let diagnostics = [SegmentDiagnostics {
@@ -705,7 +1017,7 @@ mod tests {
             decode_reached_eos: None,
         }];
         let result = HallucinationFilterStage.process(
-            &transcript("Glossary: AlphaTerm, BetaTerm"),
+            &transcript("The notes mention AlphaTerm, BetaTerm."),
             &ctx(&diagnostics, &[], Some(&context), true),
         );
         assert!(matches!(result, StageProcess::Skipped { .. }));
@@ -717,7 +1029,7 @@ mod tests {
             decode_reached_eos: Some(false),
         }];
         let result = HallucinationFilterStage.process(
-            &transcript("Glossary: AlphaTerm, BetaTerm"),
+            &transcript("The notes mention AlphaTerm, BetaTerm."),
             &ctx(&diagnostics, &[], Some(&context), true),
         );
         assert!(matches!(result, StageProcess::Ok { .. }));
@@ -982,7 +1294,7 @@ mod tests {
             panic!("expected Ok drop");
         };
         let payload = payload.expect("payload populated on drop");
-        assert_eq!(payload.get("version").and_then(|v| v.as_u64()), Some(1));
+        assert_eq!(payload.get("version").and_then(|v| v.as_u64()), Some(2));
         let dropped = payload
             .get("droppedSegments")
             .and_then(|v| v.as_array())

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -675,7 +675,12 @@ export class DictationSessionController {
     const revisionPromise = this.resolveTranscriptRevision(entry, event);
     const accept = entry.cleanupChain.then(async () => {
       const revision = await revisionPromise;
-      if (revision === null || !this.sessions.has(event.sessionId)) {
+      if (
+        revision === null ||
+        !this.sessions.has(event.sessionId) ||
+        entry.phase === 'cancelling' ||
+        entry.phase === 'stopped'
+      ) {
         return;
       }
       const result = entry.session.acceptTranscript(revision);
@@ -1077,11 +1082,16 @@ export class DictationSessionController {
         continue;
       }
       const droppedSegments = stage.payload?.droppedSegments;
-      if (!Array.isArray(droppedSegments)) {
-        continue;
+      if (Array.isArray(droppedSegments)) {
+        for (const segment of droppedSegments) {
+          this.dependencies.logger?.debug('session', 'hallucination segment dropped', segment);
+        }
       }
-      for (const segment of droppedSegments) {
-        this.dependencies.logger?.debug('session', 'hallucination segment dropped', segment);
+      const editedSegments = stage.payload?.editedSegments;
+      if (Array.isArray(editedSegments)) {
+        for (const segment of editedSegments) {
+          this.dependencies.logger?.debug('session', 'hallucination segment edited', segment);
+        }
       }
     }
   }

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -675,11 +675,16 @@ export class DictationSessionController {
     const revisionPromise = this.resolveTranscriptRevision(entry, event);
     const accept = entry.cleanupChain.then(async () => {
       const revision = await revisionPromise;
+      // Gate on 'cancelling' only: cancelSession sets it synchronously before
+      // its first await and it persists if cancellation cleanup throws, so
+      // queued accepts cannot land in a half-cancelled session (#138).
+      // 'stopped' must NOT be gated — the sidecar can deliver the final
+      // transcript_ready and session_stopped in one I/O chunk, and the stop
+      // path drains these in-flight accepts after the phase flips.
       if (
         revision === null ||
         !this.sessions.has(event.sessionId) ||
-        entry.phase === 'cancelling' ||
-        entry.phase === 'stopped'
+        entry.phase === 'cancelling'
       ) {
         return;
       }

--- a/src/editor/note-surface.ts
+++ b/src/editor/note-surface.ts
@@ -451,11 +451,8 @@ export class NoteSurface {
     return span === undefined ? undefined : cloneSpan(span);
   }
 
-  // Whisper's `initial_prompt` is style-imitative — "Transcripts follow the
-  // style of the prompt" (OpenAI Whisper Prompting Guide). Feeding raw note
-  // prose causes whisper to continue in that voice instead of transcribing.
-  // A `Glossary: t1, t2, ...` shape has no narrative voice to imitate; it
-  // only nudges spelling for proper nouns and uncommon terms.
+  // Whisper's `initial_prompt` is style-imitative, so present spelling hints
+  // as sentence-cased transcript prose instead of a Title-Case glossary list.
   readNoteGlossary(maxChars: number): { text: string; truncated: boolean } | null {
     if (this.disposed || maxChars <= 0) {
       return null;
@@ -683,14 +680,17 @@ function isAtSentenceStart(noteText: string, offset: number): boolean {
   return previous === '.' || previous === '!' || previous === '?';
 }
 
-// Build `Glossary: t1, t2, ...` from the note in a single pass, deduped
+// Keep this prompt prefix in sync with `is_prompt_leak` in
+// `native/src/stages/hallucination_filter.rs`.
+// Build sentence-cased prompt prose from the note in a single pass, deduped
 // case-insensitively (first-seen casing wins) and bounded by `maxChars`.
-// Stops scanning at the first token that would overflow the budget.
+// Stops scanning at the first token that would overflow the budget, including
+// the terminal period.
 function buildGlossary(
   noteText: string,
   maxChars: number,
 ): { text: string; truncated: boolean } | null {
-  const prefix = 'Glossary: ';
+  const prefix = 'The notes mention ';
 
   if (prefix.length >= maxChars) {
     return null;
@@ -719,7 +719,7 @@ function buildGlossary(
 
     const candidate = appended === 0 ? `${text}${token}` : `${text}, ${token}`;
 
-    if (candidate.length > maxChars) {
+    if (candidate.length + 1 > maxChars) {
       truncated = true;
       break;
     }
@@ -732,5 +732,5 @@ function buildGlossary(
     return null;
   }
 
-  return { text, truncated };
+  return { text: `${text}.`, truncated };
 }

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -785,6 +785,48 @@ describe('DictationSessionController', () => {
     expect(notice).toHaveBeenCalledWith('LLM transform returned nothing to add.');
   });
 
+  it('drains pending utterance accepts before the batch read when stop arrives in the same turn', async () => {
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const cleanup = vi.fn(
+      async (): Promise<LlmRouterCleanupResult> => ({
+        model: 'm',
+        providerId: 'ollama',
+        text: 'Clean batch.',
+      }),
+    );
+    const controller = createController({
+      createSession: (session) => {
+        sessions.push(session);
+      },
+      getSettings: () =>
+        createSettings({
+          llmFeaturesEnabled: true,
+          llmPostprocessMode: 'batch',
+          selectedModel: createExternalModelSelection(),
+        }),
+      llmRouter: createFakeLlmRouter({ cleanup }),
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+
+    // The sidecar delivers the final transcript_ready and session_stopped in one
+    // I/O chunk; emit them in the same synchronous turn (no await between) so the
+    // batch read must wait for the last utterance's accept to land.
+    sidecarConnection.emit(transcriptReady(sessionId, 'final utterance'));
+    sidecarConnection.emit({ reason: 'user_stop', sessionId, type: 'session_stopped' });
+
+    await vi.waitFor(() => {
+      expect(cleanup).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userMessage: '<session_transcript>\nfinal utterance\n</session_transcript>',
+        }),
+      );
+    });
+  });
+
   it('drains utterances accepted while stopping before the batch read', async () => {
     const sidecarConnection = new FakeSidecarConnection();
     const sessions: FakeSession[] = [];

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -7,6 +7,7 @@ import {
 import type { NotePlacementOptions } from '../src/editor/note-surface';
 import { type LlmCleanupFailure, ProviderError } from '../src/llm/provider';
 import type { LlmRouter, LlmRouterCleanupResult } from '../src/llm/router';
+import type { SessionAcceptResult } from '../src/session/session';
 import type { TranscriptRevision } from '../src/session/session-journal';
 import { DEFAULT_PLUGIN_SETTINGS, type PluginSettings } from '../src/settings/plugin-settings';
 import type {
@@ -53,7 +54,7 @@ class FakeCaptureStream {
 class FakeSession {
   public currentSessionText = '';
   public readonly acceptedTexts: string[] = [];
-  public readonly acceptTranscript = vi.fn((revision: TranscriptRevision) => {
+  public readonly acceptTranscript = vi.fn((revision: TranscriptRevision): SessionAcceptResult => {
     this.acceptedTexts.push(revision.text);
     if (revision.isFinal) {
       this.currentSessionText = revision.text;
@@ -311,6 +312,41 @@ describe('DictationSessionController', () => {
     expect(controller.getState()).toBe('listening');
   });
 
+  it('debug-logs hallucination filter segment edits', async () => {
+    const logger = new FakeLogger();
+    const sidecarConnection = new FakeSidecarConnection();
+    const controller = createController({ logger, sidecarConnection });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    const event = transcriptReady(sessionId, 'Let me join');
+    if (event.type !== 'transcript_ready') {
+      throw new Error('expected transcript_ready fixture');
+    }
+    const edit = {
+      index: 0,
+      originalText: 'Gorglosa: Let me join',
+      strippedPrefix: 'Gorglosa:',
+    };
+    event.stageResults = [
+      {
+        durationMs: 0,
+        isFinal: true,
+        payload: { droppedSegments: [], editedSegments: [edit], version: 2 },
+        revisionIn: 0,
+        revisionOut: 0,
+        stageId: 'hallucination_filter',
+        status: { kind: 'ok' },
+      },
+    ];
+
+    sidecarConnection.emit(event);
+
+    await vi.waitFor(() => {
+      expect(logger.debug).toHaveBeenCalledWith('session', 'hallucination segment edited', edit);
+    });
+  });
+
   it('silently enforces the five-session active plus draining cap', async () => {
     const sidecarConnection = new FakeSidecarConnection();
     const controller = createController({ sidecarConnection });
@@ -417,6 +453,52 @@ describe('DictationSessionController', () => {
     await vi.waitFor(() => {
       expect(sessions[0]?.acceptedTexts).toEqual(['first clean', 'second clean']);
     });
+  });
+
+  it('does not accept queued utterances after cancellation cleanup throws', async () => {
+    const captureStream = new FakeCaptureStream();
+    const logger = new FakeLogger();
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const controller = createController({
+      captureStream,
+      createSession: (session) => {
+        sessions.push(session);
+      },
+      logger,
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    const session = sessions[0];
+    if (session === undefined) {
+      throw new Error('expected session fixture');
+    }
+    session.acceptTranscript.mockImplementation((revision: TranscriptRevision) => {
+      if (revision.text === 'first utterance') {
+        return { kind: 'rejected' as const, reason: 'failed to insert transcript' };
+      }
+      return { kind: 'accepted' as const };
+    });
+    captureStream.stop.mockRejectedValueOnce(new Error('failed to stop capture'));
+
+    sidecarConnection.emit(transcriptReady(sessionId, 'first utterance'));
+    sidecarConnection.emit(transcriptReady(sessionId, 'second utterance'));
+
+    await vi.waitFor(() => {
+      expect(logger.error).toHaveBeenCalledWith(
+        'session',
+        'failed to process transcript',
+        expect.any(Error),
+      );
+    });
+    await vi.waitFor(() => {
+      expect(session.acceptTranscript).toHaveBeenCalledTimes(1);
+    });
+    expect(session.acceptTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'first utterance' }),
+    );
   });
 
   it('keeps raw transcript and reports a typed per-utterance cleanup failure', async () => {
@@ -703,7 +785,7 @@ describe('DictationSessionController', () => {
     expect(notice).toHaveBeenCalledWith('LLM transform returned nothing to add.');
   });
 
-  it('drains pending utterance accepts before the batch read when stop arrives in the same turn', async () => {
+  it('drains utterances accepted while stopping before the batch read', async () => {
     const sidecarConnection = new FakeSidecarConnection();
     const sessions: FakeSession[] = [];
     const cleanup = vi.fn(
@@ -730,10 +812,13 @@ describe('DictationSessionController', () => {
     await controller.startDictation();
     const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
 
-    // The sidecar delivers the final transcript_ready and session_stopped in one
-    // I/O chunk; emit them in the same synchronous turn (no await between) so the
-    // batch read must wait for the last utterance's accept to land.
+    await controller.stopDictation();
     sidecarConnection.emit(transcriptReady(sessionId, 'final utterance'));
+    await vi.waitFor(() => {
+      expect(sessions[0]?.acceptTranscript).toHaveBeenCalledWith(
+        expect.objectContaining({ text: 'final utterance' }),
+      );
+    });
     sidecarConnection.emit({ reason: 'user_stop', sessionId, type: 'session_stopped' });
 
     await vi.waitFor(() => {

--- a/test/note-surface.test.ts
+++ b/test/note-surface.test.ts
@@ -479,16 +479,20 @@ describe('NoteSurface', () => {
     });
 
     it.each([
-      ['acronyms', 'We use NVIDIA GPU acceleration with STT.', 'Glossary: NVIDIA, GPU, STT'],
+      [
+        'acronyms',
+        'We use NVIDIA GPU acceleration with STT.',
+        'The notes mention NVIDIA, GPU, STT.',
+      ],
       [
         'mixed-case identifiers',
         'See writingRegionTail and TranscriptionRequest for details.',
-        'Glossary: writingRegionTail, TranscriptionRequest',
+        'The notes mention writingRegionTail, TranscriptionRequest.',
       ],
       [
         'hyphenated, underscored, and dotted identifiers',
         'Files: note-surface, set_initial_prompt, whisper.cpp, Object.keys.',
-        'Glossary: note-surface, set_initial_prompt, whisper.cpp, Object.keys',
+        'The notes mention note-surface, set_initial_prompt, whisper.cpp, Object.keys.',
       ],
     ] as const)('extracts %s', (_label, text, expected) => {
       const { surface } = createSurface({
@@ -509,7 +513,7 @@ describe('NoteSurface', () => {
       });
 
       expect(surface.readNoteGlossary(384)).toEqual({
-        text: 'Glossary: Sidecar',
+        text: 'The notes mention Sidecar.',
         truncated: false,
       });
     });
@@ -521,7 +525,7 @@ describe('NoteSurface', () => {
       });
 
       expect(surface.readNoteGlossary(384)).toEqual({
-        text: 'Glossary: Claude, Alex',
+        text: 'The notes mention Claude, Alex.',
         truncated: false,
       });
     });
@@ -533,7 +537,7 @@ describe('NoteSurface', () => {
       });
 
       expect(surface.readNoteGlossary(384)).toEqual({
-        text: 'Glossary: NVIDIA',
+        text: 'The notes mention NVIDIA.',
         truncated: false,
       });
     });
@@ -548,7 +552,7 @@ describe('NoteSurface', () => {
 
       expect(result?.truncated).toBe(true);
       expect(result?.text.length).toBeLessThanOrEqual(30);
-      expect(result?.text.startsWith('Glossary: ')).toBe(true);
+      expect(result?.text).toBe('The notes mention NVIDIA.');
     });
 
     it('scans the whole note, including text after the writing tail', () => {
@@ -557,7 +561,7 @@ describe('NoteSurface', () => {
       view.dispatch({ changes: { from: 7, insert: 'after CUDA' } });
 
       expect(surface.readNoteGlossary(384)).toEqual({
-        text: 'Glossary: NVIDIA, CUDA',
+        text: 'The notes mention NVIDIA, CUDA.',
         truncated: false,
       });
     });

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -305,12 +305,12 @@ describe('Session', () => {
   it('proxies readNoteGlossary to the active surface', () => {
     const { session, surface } = createSessionHarness();
     surface.readNoteGlossary.mockReturnValueOnce({
-      text: 'Glossary: NVIDIA',
+      text: 'The notes mention NVIDIA.',
       truncated: true,
     });
 
     expect(session.readNoteGlossary(256)).toEqual({
-      text: 'Glossary: NVIDIA',
+      text: 'The notes mention NVIDIA.',
       truncated: true,
     });
     expect(surface.readNoteGlossary).toHaveBeenCalledWith(256);


### PR DESCRIPTION
## Summary

- Repeated phrases: Whisper used `best_of: 0`, collapsing temperature fallback to one decoder and weakening its repetition escape path; the pipeline also only detected repetition within a segment. Restore the upstream fallback decoder count of 5 and collapse final runs of three or more identical consecutive segments with auditable `repetition_run` drops.
- Capitalization drift: the `Glossary: Title, Case, List` initial prompt caused Whisper to imitate Title Case, then reinforced itself as dictated terms returned to the note. Emit sentence-cased prompt prose (`The notes mention Term1, Term2.`) and update prompt-leak detection.
- Spurious speaker labels: Whisper can emit one-off caption/interview artifacts such as invented `Name:` prefixes, with the old colon-labeled prompt adding an additional prime. Strip matching final-revision prefixes unless they are structural labels or note-context terms; record every edit in payload version 2 and TS debug logs.
- FIFO hardening: queued accepts were gated only by registry membership, so a failed accept followed by a throwing cancellation could leave a half-cancelled session eligible for later queued utterances. Gate accepts in `cancelling` and `stopped` phases while preserving drain behavior in `stopping`.

Design and root-cause analysis: [Whisper transcription quality spec](https://github.com/brittain9/local-dictation-obsidian-plugin/blob/fix/whisper-transcription-quality/docs/specs/whisper-transcription-quality.md)

## Verification

- `npm run typecheck && npm run lint && npm run lint:obsidian && npm run test`
- `npm run check:rust`
- `npm run check`

Manual repro remains unverified and requires a human with models installed:

- [ ] Long dictation with several proper nouns: no Title-Case drift across utterances.
- [ ] System-audio playback of conversational video: repeated phrases collapse and invented `Name:` labels are stripped; verify `repetition_run` drops and edited segments in debug logs.
- [ ] Normal dictation of "Note: buy milk" survives unchanged.

Fixes #160
Fixes #138
