### PR TITLE
Live dictation: release readiness and streaming UX hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Transcription runs entirely on your device. No accounts or cloud required. A fas
 ## Features
 
 - **Top models, run locally.** Whisper or Cohere Transcribe, on CPU or GPU. Cohere Transcribe currently tops the [Open ASR Leaderboard](https://huggingface.co/spaces/hf-audio/open_asr_leaderboard).
+- **Live dictation.** Moonshine streaming models show provisional words within about a second and revise them in place until each utterance finalizes.
 - **Speaker labels.** Optional on-device diarization tags who's talking — for interviews, meetings, and calls. Nothing is stored; voiceprints live in memory for the session only.
 - **System audio.** Transcribe your computer's output — meetings, calls, videos — not just your mic. Available on Windows and Linux.
 - **Timestamps.** Optionally stamp phrases with elapsed or wall-clock time — handy for meetings and interviews.
@@ -25,6 +26,8 @@ Then click the microphone in the ribbon, or bind a hotkey to **Local Dictation: 
 CPU works everywhere with no extra setup. Hardware acceleration is available for faster transcription — use Metal (macOS, automatic) or CUDA on a recent NVIDIA GPU (RTX 20-series / GTX 16-series or newer, with a current driver). See the [CUDA setup guide](docs/guides/cuda-setup.md) to enable it.
 
 macOS and Windows are the primary tested targets. On Linux, the plugin is used daily on Fedora 44 (native and Flatpak); other distributions should work but aren't routinely verified. If something breaks on yours, [open an issue](https://github.com/brittain9/local-dictation-obsidian-plugin/issues).
+
+Moonshine live dictation is English-only. Streaming models do not apply speaker labels, and long speech is split at a 30-second utterance cap. Tiny is intended for lower-end CPUs, Small is the recommended balance, and Medium trades additional compute and memory for accuracy. Batch models keep their existing behavior.
 
 ## 🔒 Privacy
 

--- a/docs/guides/moonshine-live-testing.md
+++ b/docs/guides/moonshine-live-testing.md
@@ -16,6 +16,18 @@ and SHA-256 checksums, validates the model, and only then promotes the complete
 install into the model store. Use the same screen to select, update, or remove a
 Moonshine model.
 
+## Behavior and limitations
+
+Moonshine writes provisional text while you speak, revises that text in place,
+and locks the final text when voice activity detection closes the utterance.
+Tiny is suitable for lower-end CPUs, Small is the recommended starting point,
+and Medium requires more CPU time and memory in exchange for accuracy; actual
+latency depends on the host processor.
+
+Live dictation is English-only. Speaker labels are not applied while a
+streaming model is selected, even when diarization is enabled. Continuous
+speech is split into separate utterances at the 30-second hard cap.
+
 ## Manual acceptance checks
 
 Use a Moonshine model installed through Manage Models with CPU inference and a

--- a/docs/release/notes/2026.7.4.md
+++ b/docs/release/notes/2026.7.4.md
@@ -1,0 +1,18 @@
+## Highlights
+
+- **Live local dictation with Moonshine.** Provisional words appear while you speak, revise in place as context arrives, and finalize on a pause. Tiny, Small, and Medium streaming models can be installed from Manage Models; Small is the recommended balance, while Tiny favors lower-end CPUs and Medium favors accuracy.
+
+## Fixes
+
+- Streaming finalization now reuses incremental model state instead of re-decoding the full utterance after ordinary pauses or 30-second splits.
+- Live partials preserve separators and timestamps across empty model revisions, continue through transient partial-decode failures, and are no longer blocked by an earlier utterance's LLM cleanup.
+- Streaming sessions now use the same backlog tiers and overload auto-stop as batch sessions.
+- Per-utterance cleanup can show the original raw text below a streamed-and-revised final.
+- The speaker-label setting now explains when the selected streaming model cannot apply diarization.
+
+## Limitations
+
+- Moonshine live dictation is English-only.
+- Speaker labels are not applied to streaming sessions; select a batch model to use diarization.
+- Continuous speech is split at a 30-second utterance cap.
+- Inference speed depends on the selected model and host CPU. Tiny has the lowest hardware demand, Small is the default recommendation, and Medium requires more compute and memory.

--- a/docs/specs/live-dictation-release-readiness.md
+++ b/docs/specs/live-dictation-release-readiness.md
@@ -81,6 +81,17 @@ test.** 7–9 are fix-or-defer-with-rationale.
    *counts re-feeds* (the existing fixture model cannot distinguish the
    paths — that is why this escaped), driven through the real
    session→worker finalize flow with silence hangover and cap-split cases.
+   **Implementation decision (recorded post-review):** the fix keeps the
+   incremental model state on pause-driven finalizes, so the final decodes
+   speech *plus* the streamed silence hangover while a batch decode would
+   see only the trimmed buffer — strict final==batch equality is
+   deliberately relaxed on this path. Accepted because the hangover is
+   audio the model genuinely heard, the hallucination filter runs on
+   finals, and re-feeding the trimmed buffer is exactly the defect being
+   fixed. The simulation test cannot distinguish the two (its fixture
+   finalizes to a constant), so the guard is the dedicated manual-matrix
+   row in D5: listen for trailing-silence hallucination after pauses on
+   all three model sizes.
 2. **Empty partial after projected text deletes the utterance boundary
    prefix** (`src/session/session.ts:407-453`,
    `src/editor/note-surface.ts:267`). An empty non-final revision (worker
@@ -166,7 +177,11 @@ Expected behavior, verified during the manual pass:
 - Manual validation matrix on representative CPU hardware, tiny/small/
   medium: first partial ≤ 1 s, ~2 Hz refresh, final ≤ 700 ms after VAD
   close **including the ordinary pause-driven finalize** (this re-times
-  D2-1's path), plus first-partial-after-30s-cap-split; 5-minute soak with
+  D2-1's path), plus first-partial-after-30s-cap-split; **trailing-silence
+  hallucination check** — dictate with deliberate long pauses on
+  tiny/small/medium and confirm no junk tokens appear at utterance ends
+  (guards D2-1's relaxed final==batch equality, which no automated test
+  can see); 5-minute soak with
   no audio loss/reordering/stale provisional styling; typing latches;
   empty finals; one-sentence mode; stop/cancel/drain; note switching;
   session teardown; light/dark themes.

--- a/docs/specs/live-dictation-release-readiness.md
+++ b/docs/specs/live-dictation-release-readiness.md
@@ -1,0 +1,195 @@
+# Spec: Live Dictation Release Readiness
+
+Status: approved for implementation (handoff to Codex)
+Issues: [#179](https://github.com/brittain9/local-dictation-obsidian-plugin/issues/179) (owned),
+[#178](https://github.com/brittain9/local-dictation-obsidian-plugin/issues/178) (partially —
+visible gating; full integration deferred, see D1)
+Predecessors: `docs/specs/live-dictation-moonshine.md` (PR #176),
+`docs/specs/moonshine-model-catalog.md` (PR #180)
+
+## Product goal
+
+Live dictation ships in a release: bug-free, honest UX, documented
+limitations. Priority is quality over feature breadth. This PR fixes the
+verified defects found in a post-merge review of #176, makes the
+diarization limitation visible instead of silent, and closes the #179
+release gate.
+
+## Out of scope
+
+- Full diarization integration for streaming sessions (remains #178; see
+  D1 for the recorded rationale).
+- Catalog/install work (done — PR #180).
+- Protocol changes. Nothing here adds events or fields.
+- Non-English streaming, multi-speaker streaming attribution.
+
+## D1 — Diarization × streaming: gate visibly, do not integrate (decided)
+
+Streaming sessions keep **no speaker attribution** in this release. The
+integration is structurally non-trivial, not a bolt-on:
+
+- Speaker labels are decided at *append time* — `TranscriptRenderer.planAppend`
+  puts the label in the append **prefix** for single-span utterances — but a
+  streaming utterance appends its first partial before any speaker can be
+  known (diarization needs the utterance audio; partials start ≤1 s in).
+- A diarized multi-speaker final would arrive as a multi-span revision,
+  which triggers the body-restructuring recompose branch
+  (`src/session/session.ts:419-422`) against text the user may have edited —
+  a real correctness risk in the `replaceAnchor`/latch machinery for
+  marginal value, since live dictation is overwhelmingly single-speaker.
+
+What this PR does instead:
+
+1. **Settings honesty:** in `src/settings/settings-tab.ts`, when the
+   selected model's family capabilities report `supportsStreaming`, append a
+   capability-driven note to the existing "Speaker labels (diarization)"
+   toggle description: *"Not applied while a streaming (live) model is
+   selected — speaker labels currently require a batch model."* The toggle
+   stays enabled (it is a global preference that still governs batch
+   models). Pattern: the `supportsInitialPrompt` gate at
+   `settings-tab.ts:466` (use `state.selectedModelCapabilities`).
+2. The sidecar `RequestWarning` backstop
+   (`session_request_warnings`, `native/src/worker.rs:664-675`) is unchanged.
+3. #178 stays open for real integration; the likely shape (run the
+   diarizer on the finalized utterance audio, which is available at
+   `finalize_streaming_utterance` — `worker.rs:583` — exactly like the batch
+   call site `worker.rs:409-413`) is recorded there, blocked on solving the
+   prefix-vs-finalization rendering mismatch above.
+
+## D2 — Defect burn-down (authoritative list)
+
+From a verified line-level review of the merged #176 diff against current
+main (2026-07-04). **Fix 1–6 in this PR; each fix lands with a regression
+test.** 7–9 are fix-or-defer-with-rationale.
+
+1. **Finalize always re-decodes; incremental fast path is dead code**
+   (`native/src/worker.rs:600-608`) — candidate release-blocker.
+   Finalization uses the streamed state only when
+   `open.utterance.samples == samples`, but `native/src/session.rs:429-431`
+   trims the finalized utterance to `pending_end_start +
+   post_speech_pad_frames` (2 frames) while the worker has already streamed
+   the full silence hangover (20/50/100 frames, `session.rs:71-73`) — the
+   vectors never match on a pause-driven finalize, so every utterance end
+   does `reset_utterance()` + re-feed + full re-decode. The 30 s cap split
+   (`session.rs:349-351`) mismatches too (the cap-triggering frame is never
+   streamed; finalize is handled before `dispatch_streaming_audio`,
+   `app.rs:242-245`), stalling live text for a full 30 s re-decode on the
+   single worker thread. Fix: make finalize reconcile by *suffix* — the
+   streamed samples are a prefix (or near-prefix) of the finalized buffer;
+   feed only the missing tail (or tolerate the trimmed-tail case) instead
+   of equality-gating. Regression test must use a streaming model fake that
+   *counts re-feeds* (the existing fixture model cannot distinguish the
+   paths — that is why this escaped), driven through the real
+   session→worker finalize flow with silence hangover and cap-split cases.
+2. **Empty partial after projected text deletes the utterance boundary
+   prefix** (`src/session/session.ts:407-453`,
+   `src/editor/note-surface.ts:267`). An empty non-final revision (worker
+   emits one whenever decode regresses to empty, `worker.rs:522-529`)
+   removes `span.start..textEnd` including the separator/timestamp prefix;
+   the next partial then glues to the previous utterance. Fix: gate the
+   prefix-removing empty-replace path on `isFinal` (empty partials should
+   replace the span *body* only, or be held). Regression: partial → empty
+   partial → partial sequence preserves prefix and timestamp.
+3. **Streaming sessions bypass queue-overload protection**
+   (`native/src/app.rs:1016-1039` returns before the `overload_draining`
+   guard and `QUEUE_OVERLOAD_DEPTH` check at `app.rs:1086-1098`),
+   contradicting spec D4 ("queue overload semantics for finals are
+   unchanged"). A slower-than-realtime model accumulates an unbounded
+   backlog and the session never auto-stops. Fix: route streaming finals
+   through the same overload accounting. Regression: overload tier
+   escalation and auto-stop fire for a streaming session.
+4. **One failed partial decode cancels the whole session**
+   (`src/dictation/dictation-session-controller.ts:1045-1073` treats every
+   session-scoped error as fatal, but the worker sends
+   `SessionError { finalizes_utterance: false }` for partial-decode errors
+   and keeps the utterance recoverable, `worker.rs:309-327`). Fix: when
+   `finalizesUtterance` is false, log and continue (partials are droppable
+   by design); only finalizing errors cancel. Regression: transient partial
+   error → session continues, final still lands.
+5. **Per-utterance LLM cleanup blocks the next utterance's live partials**
+   (`src/dictation/dictation-session-controller.ts:675-698` serializes all
+   `transcript_ready` handling through `entry.cleanupChain`; utterance B's
+   partials arrive exactly while A's cleanup HTTP round-trip is in flight).
+   Fix: only *finals* enter the cleanup chain; partial projection must not
+   await it. Regression: partials project while a cleanup promise is
+   pending.
+6. **"Show raw below" callout dropped for streamed utterances**
+   (`src/session/session.ts:366` emits the callout only on the append path;
+   a streamed utterance's cleaned final arrives via `applyReplace`). Fix:
+   emit the callout from the replace path when a final's cleaned text
+   differs from raw and `showRawBelow` is on. Regression test with a
+   projected-then-cleaned utterance.
+7. *(polish)* Emptied final leaves doubled spaces in `joinRawSessionText`
+   (`src/session/session.ts:568`, `:193-198`) — cosmetic input noise to
+   batch cleanup.
+8. *(polish)* Provisional-range tail bias (+1,
+   `src/editor/provisional-transcript-extension.ts:21-22`) disagrees with
+   span mapping bias (−1, `note-surface.ts:596`): typing at the exact tail
+   of a live span styles the typed text provisional without latching. No
+   data loss; visual glitch at 2 Hz.
+9. *(polish)* Streaming path never applies capability gates beyond
+   diarization, so e.g. a non-English language setting is dropped without a
+   `RequestWarning` (`worker.rs:664-675`).
+
+**Verified solid — do not re-litigate:** revision monotonicity end-to-end
+(worker offsets, journal rejection, `applyReplace` guard, FIFO ordering,
+pinned by the simulation test `worker.rs:889`); empty-*final*
+whitespace/timestamp handling (`test/session.test.ts:199`, `:218`);
+partials bypass post-engine stages; LLM cleanup final-gating; no
+`context_request` for streaming; provisional decorations cleared on
+teardown; Moonshine adapter state reset on error paths.
+
+## D3 — Flicker / stable-prefix rendering: measure first
+
+Do not implement stable-prefix partial emission speculatively. During the
+D5 manual pass, watch for visible whole-utterance replacement flicker at
+~2 Hz (risk noted in `docs/specs/live-dictation-moonshine.md` § Risks). If
+observed, the fix is a worker-side cadence policy (emit only on stable
+prefix growth) with no protocol change — file it with the measurement
+before implementing.
+
+## D4 — Error and recovery UX
+
+Expected behavior, verified during the manual pass:
+
+- **Missing/corrupt/incompatible model at probe:** existing probe failure
+  path with a clear message; selection is refused (no change expected —
+  verify with a deliberately corrupted `frontend.ort`).
+- **Decode failure mid-utterance with projected partials:** per D2-4, the
+  session survives droppable-partial errors; a finalizing error cancels the
+  utterance without leaving provisional styling behind.
+- **Slow model (slower than realtime):** per D2-3, overload tiers engage
+  and auto-stop fires instead of unbounded backlog.
+
+## D5 — Docs and release gate
+
+- Manual validation matrix on representative CPU hardware, tiny/small/
+  medium: first partial ≤ 1 s, ~2 Hz refresh, final ≤ 700 ms after VAD
+  close **including the ordinary pause-driven finalize** (this re-times
+  D2-1's path), plus first-partial-after-30s-cap-split; 5-minute soak with
+  no audio loss/reordering/stale provisional styling; typing latches;
+  empty finals; one-sentence mode; stop/cancel/drain; note switching;
+  session teardown; light/dark themes.
+- User docs + release notes: live dictation behavior, hardware
+  expectations, and limitations (English-only; no speaker labels on
+  streaming models; 30 s utterance cap).
+- Release gate: all D2 items 1–6 fixed with regression tests; 7–9 fixed or
+  deferred with rationale in the PR; matrix passed; docs updated.
+
+## Verification
+
+- `npm run check` and `npm run check:rust` green.
+- One regression test per fixed defect, at the seam named in D2 (the D2-1
+  test must be able to detect the re-feed path — a counting fake, not the
+  existing fixture model).
+- Manual matrix (D5) executed and results recorded in the PR before
+  ready-for-review.
+
+## Risks
+
+- D2-1's fix touches finalize reconciliation — the highest-risk edit in
+  this PR. The suffix-reconcile logic must preserve the final==batch
+  equality contract pinned by the simulation test; if equality cannot be
+  preserved exactly, stop and reassess rather than weakening the test.
+- D2-5 reorders plugin-side async handling; the FIFO guarantees of the
+  journal (revision monotonicity) must be pinned by tests before refactor.

--- a/native/src/app.rs
+++ b/native/src/app.rs
@@ -3131,6 +3131,7 @@ mod tests {
 
     fn fake_utterance() -> FinalizedUtterance {
         FinalizedUtterance {
+            carries_audio_forward: false,
             pause_ms_before_utterance: None,
             samples: vec![0i16; 16000],
             utterance_index: 0,

--- a/native/src/app.rs
+++ b/native/src/app.rs
@@ -913,8 +913,22 @@ impl AppState {
                 finalizes_utterance,
                 message,
                 session_id,
-                utterance_id: _,
+                utterance_id,
             } => {
+                if !finalizes_utterance && utterance_id.is_some() {
+                    if !self.active_sessions.contains_key(&session_id) {
+                        return;
+                    }
+                    events.push(Event::Warning {
+                        code,
+                        details,
+                        message,
+                        session_id: Some(session_id.clone()),
+                    });
+                    self.emit_state_if_changed(&session_id, events);
+                    return;
+                }
+
                 {
                     let Some(active_session) = self.active_sessions.get_mut(&session_id) else {
                         return;
@@ -1016,6 +1030,21 @@ impl AppState {
 
         let session_id = active_session.session.config().session_id.clone();
 
+        if active_session.overload_draining {
+            // Capture is already stopped; only a buffered finalize (graceful
+            // stop, sentence-complete) can race in here. Drop instead of
+            // queueing past the hard cap.
+            events.push(Event::Warning {
+                code: "utterance_dropped_during_overload_drain".to_string(),
+                details: None,
+                message:
+                    "Dropped a finalized utterance while draining the transcription queue overload."
+                        .to_string(),
+                session_id: Some(session_id),
+            });
+            return;
+        }
+
         if active_session.streaming {
             let open = active_session.streaming_open.take();
             let utterance_id = open.map_or_else(Uuid::new_v4, |open| open.utterance_id);
@@ -1039,21 +1068,7 @@ impl AppState {
                 advance_transcription_queue(active_session);
             }
             emit_queue_tier_if_changed(active_session, events);
-            return;
-        }
-
-        if active_session.overload_draining {
-            // Capture is already stopped; only a buffered finalize (graceful
-            // stop, sentence-complete) can race in here. Drop instead of
-            // queueing past the hard cap.
-            events.push(Event::Warning {
-                code: "utterance_dropped_during_overload_drain".to_string(),
-                details: None,
-                message:
-                    "Dropped a finalized utterance while draining the transcription queue overload."
-                        .to_string(),
-                session_id: Some(session_id),
-            });
+            enter_overload_drain_if_saturated(active_session, events);
             return;
         }
 
@@ -1085,20 +1100,7 @@ impl AppState {
 
         if let Some(active_session) = self.active_sessions.get_mut(&session_id) {
             emit_queue_tier_if_changed(active_session, events);
-
-            if active_session.queued_utterances >= QUEUE_OVERLOAD_DEPTH
-                && !active_session.overload_draining
-            {
-                active_session.overload_draining = true;
-                events.push(Event::Error {
-                    code: "utterance_queue_overload".to_string(),
-                    details: Some(format!(
-                        "queue depth reached saturation at {QUEUE_OVERLOAD_DEPTH}"
-                    )),
-                    message: "Local Dictation stopped because the transcription backlog reached capacity. Already accepted utterances will finish processing.".to_string(),
-                    session_id: Some(session_id),
-                });
-            }
+            enter_overload_drain_if_saturated(active_session, events);
         }
     }
 
@@ -1435,6 +1437,22 @@ fn emit_queue_tier_if_changed(active_session: &mut ActiveSession, events: &mut V
         queued_utterances: active_session.queued_utterances,
         session_id: active_session.session.config().session_id.clone(),
         tier,
+    });
+}
+
+fn enter_overload_drain_if_saturated(active_session: &mut ActiveSession, events: &mut Vec<Event>) {
+    if active_session.queued_utterances < QUEUE_OVERLOAD_DEPTH || active_session.overload_draining {
+        return;
+    }
+
+    active_session.overload_draining = true;
+    events.push(Event::Error {
+        code: "utterance_queue_overload".to_string(),
+        details: Some(format!(
+            "queue depth reached saturation at {QUEUE_OVERLOAD_DEPTH}"
+        )),
+        message: "Local Dictation stopped because the transcription backlog reached capacity. Already accepted utterances will finish processing.".to_string(),
+        session_id: Some(active_session.session.config().session_id.clone()),
     });
 }
 
@@ -2689,6 +2707,87 @@ mod tests {
             31,
             "all accepted utterances should still be tracked through their context flow"
         );
+    }
+
+    #[test]
+    fn streaming_enqueue_escalates_tiers_and_enters_overload_drain() {
+        let model_file_path = create_model_file();
+        let mut app = test_app();
+        let _ = app.handle_command(start_session_command("session-1", &model_file_path));
+        app.active_sessions
+            .get_mut("session-1")
+            .expect("active session")
+            .streaming = true;
+
+        let mut events = enqueue_n_utterances(&mut app, 31);
+
+        assert_eq!(
+            events
+                .iter()
+                .filter_map(|event| match event {
+                    Event::TranscriptionQueueChanged { tier, .. } => Some(*tier),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+            vec![
+                QueueBackpressureTier::CatchingUp,
+                QueueBackpressureTier::FallingBehind,
+                QueueBackpressureTier::Saturated,
+            ]
+        );
+        assert!(events.iter().any(
+            |event| matches!(event, Event::Error { code, .. } if code == "utterance_queue_overload")
+        ));
+        let active = app
+            .active_sessions
+            .get("session-1")
+            .expect("active session");
+        assert!(active.overload_draining);
+        assert_eq!(active.queued_utterances, super::QUEUE_OVERLOAD_DEPTH);
+
+        // Drain the active transcription plus every queued utterance.
+        for _ in 0..=super::QUEUE_OVERLOAD_DEPTH {
+            app.handle_worker_event(fake_worker_transcript_ready("session-1", None), &mut events);
+        }
+        assert!(events.iter().any(|event| matches!(
+            event,
+            Event::SessionStopped {
+                reason: SessionStopReason::QueueOverload,
+                ..
+            }
+        )));
+        assert!(!app.active_sessions.contains_key("session-1"));
+    }
+
+    #[test]
+    fn partial_worker_error_is_recoverable_and_a_later_final_still_lands() {
+        let model_file_path = create_model_file();
+        let mut app = test_app();
+        let _ = app.handle_command(start_session_command("session-1", &model_file_path));
+        let mut events = Vec::new();
+
+        app.handle_worker_event(
+            WorkerEvent::SessionError {
+                code: "engine_inference_failed".to_string(),
+                details: Some("transient partial decode".to_string()),
+                finalizes_utterance: false,
+                message: "Partial decode failed.".to_string(),
+                session_id: "session-1".to_string(),
+                utterance_id: Some(Uuid::new_v4()),
+            },
+            &mut events,
+        );
+
+        assert!(matches!(
+            events.as_slice(),
+            [Event::Warning { code, .. }] if code == "engine_inference_failed"
+        ));
+        assert!(app.active_sessions.contains_key("session-1"));
+
+        app.handle_worker_event(fake_worker_transcript_ready("session-1", None), &mut events);
+        assert!(events.iter().any(
+            |event| matches!(event, Event::TranscriptReady { session_id, .. } if session_id == "session-1")
+        ));
     }
 
     #[test]

--- a/native/src/session.rs
+++ b/native/src/session.rs
@@ -85,6 +85,14 @@ pub struct SessionConfig {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct FinalizedUtterance {
+    /// True when a 30 s-cap boundary split ends this utterance short of the
+    /// audio already streamed to the model, and the trailing (still-voiced)
+    /// suffix is carried into the next utterance. The streaming model has been
+    /// fed that suffix, so finalizing must reset its state and re-feed only
+    /// these samples — keeping the state would fold the next utterance's speech
+    /// into this final and then transcribe it again. Pause-driven and hard-cut
+    /// finalizations discard their trailing audio, so this stays `false`.
+    pub carries_audio_forward: bool,
     pub pause_ms_before_utterance: Option<u64>,
     pub samples: Vec<i16>,
     pub utterance_index: u64,
@@ -372,7 +380,7 @@ impl<TVad: VoiceActivityDetector> ListeningSession<TVad> {
         };
 
         let flattened = flatten_frames(&self.utterance_frames[..idx]);
-        let finalized = self.finalize_with_metadata(flattened, true);
+        let finalized = self.finalize_with_metadata(flattened, true, true);
         self.next_utterance_index = self.next_utterance_index.saturating_add(1);
 
         self.utterance_frames.drain(..idx);
@@ -435,7 +443,11 @@ impl<TVad: VoiceActivityDetector> ListeningSession<TVad> {
         }
 
         let flattened = flatten_frames(&self.utterance_frames[..retained_frames]);
-        Some(self.finalize_with_metadata(flattened, cap_split))
+        // Pause-driven finalizations and the hard-cut cap fallback discard their
+        // trailing audio, so they never carry a voiced suffix forward. Only the
+        // boundary split in `split_at_boundary` does, and it constructs its
+        // `FinalizedUtterance` directly.
+        Some(self.finalize_with_metadata(flattened, cap_split, false))
     }
 
     /// Single producer for `FinalizedUtterance`. Combining the audio flatten
@@ -447,6 +459,7 @@ impl<TVad: VoiceActivityDetector> ListeningSession<TVad> {
         &mut self,
         flattened: FlattenedFrames,
         cap_split: bool,
+        carries_audio_forward: bool,
     ) -> FinalizedUtterance {
         let voice_activity = flattened.voice_activity;
         let current_has_speech = voice_activity.speech_end_ms > voice_activity.speech_start_ms;
@@ -465,6 +478,7 @@ impl<TVad: VoiceActivityDetector> ListeningSession<TVad> {
         self.next_utterance_is_continuation = cap_split;
 
         FinalizedUtterance {
+            carries_audio_forward,
             pause_ms_before_utterance,
             samples: flattened.samples,
             utterance_index: self.next_utterance_index,
@@ -1108,7 +1122,7 @@ mod tests {
             },
         };
 
-        let finalized = session.finalize_with_metadata(flattened, false);
+        let finalized = session.finalize_with_metadata(flattened, false, false);
 
         assert_eq!(finalized.pause_ms_before_utterance, None);
         assert_eq!(session.last_final_speech_end_ms, Some(500));
@@ -1138,7 +1152,7 @@ mod tests {
             },
         };
 
-        let finalized = session.finalize_with_metadata(flattened, false);
+        let finalized = session.finalize_with_metadata(flattened, false, false);
 
         assert_eq!(finalized.pause_ms_before_utterance, None);
         assert!(!session.next_utterance_is_continuation);
@@ -1167,7 +1181,7 @@ mod tests {
             },
         };
 
-        let finalized = session.finalize_with_metadata(flattened, true);
+        let finalized = session.finalize_with_metadata(flattened, true, false);
 
         assert_eq!(finalized.pause_ms_before_utterance, None);
         assert!(session.next_utterance_is_continuation);

--- a/native/src/worker.rs
+++ b/native/src/worker.rs
@@ -361,6 +361,9 @@ fn worker_main(
                 let utterance_end_ms_in_session = utterance.utterance_end_ms_in_session();
                 let utterance_start_ms_in_session = utterance.utterance_start_ms_in_session();
                 let FinalizedUtterance {
+                    // Batch transcription re-decodes the whole utterance, so the
+                    // streaming carry-forward marker is irrelevant here.
+                    carries_audio_forward: _,
                     pause_ms_before_utterance,
                     samples,
                     utterance_index,
@@ -584,6 +587,7 @@ fn finalize_streaming_utterance(
     let utterance_end_ms_in_session = utterance.utterance_end_ms_in_session();
     let utterance_start_ms_in_session = utterance.utterance_start_ms_in_session();
     let FinalizedUtterance {
+        carries_audio_forward,
         pause_ms_before_utterance,
         samples,
         utterance_index,
@@ -612,11 +616,13 @@ fn finalize_streaming_utterance(
                 model.accept_audio(missing_tail)?;
             }
         }
-        Some(open) if open.utterance.samples.starts_with(&samples) => {
+        Some(open) if !carries_audio_forward && open.utterance.samples.starts_with(&samples) => {
             // Pause-driven finalization trims the silence hangover already fed
             // to the streaming model. That suffix carries no speech, so keep
             // the incremental state instead of resetting and re-feeding the
-            // finalized prefix.
+            // finalized prefix. A boundary cap-split (`carries_audio_forward`)
+            // is excluded here: its streamed suffix is voice carried into the
+            // next utterance, so it must fall through to a reset and re-feed.
         }
         _ => {
             model.reset_utterance();
@@ -1085,31 +1091,69 @@ mod tests {
 
     #[test]
     fn pause_finalize_reuses_streamed_state_after_silence_trim() {
-        let (counts, finalized_samples) = run_counted_streaming_finalize(FixtureVad {
+        let outcome = run_counted_streaming_finalize(FixtureVad {
             calls: 0,
             speech_frames: 20,
         });
-        let counts = counts.lock().expect("feed counts lock");
+        let counts = outcome.counts.lock().expect("feed counts lock");
 
         assert_eq!(counts.reset_calls, 1, "finalize must not reset and re-feed");
         assert!(
-            counts.accepted_samples > finalized_samples,
+            counts.accepted_samples > outcome.finalized_samples,
             "the fixture must exercise trimmed silence already present in streamed state"
         );
     }
 
     #[test]
     fn cap_split_feeds_only_the_unstreamed_tail() {
-        let (counts, finalized_samples) = run_counted_streaming_finalize(FixtureVad {
+        let outcome = run_counted_streaming_finalize(FixtureVad {
             calls: 0,
             speech_frames: usize::MAX,
         });
-        let counts = counts.lock().expect("feed counts lock");
+        let counts = outcome.counts.lock().expect("feed counts lock");
 
         assert_eq!(counts.reset_calls, 1, "finalize must not reset and re-feed");
         assert_eq!(
-            counts.accepted_samples, finalized_samples,
+            counts.accepted_samples, outcome.finalized_samples,
             "each capped utterance sample must be fed exactly once"
+        );
+    }
+
+    #[test]
+    fn boundary_cap_split_resets_and_refeeds_only_the_finalized_prefix() {
+        // Speech for 1400 frames, a 20-frame dip below the speech threshold (but
+        // above the negative threshold, so it registers a silence boundary
+        // without arming a pause finalize), then resumed speech until the 30 s
+        // cap. `split_at_boundary` cuts at the boundary and carries the resumed
+        // speech into the next utterance, so the streamed state holds voice that
+        // does not belong to this final.
+        let probabilities: Vec<f32> = std::iter::repeat_n(1.0_f32, 1_400)
+            .chain(std::iter::repeat_n(0.4_f32, 20))
+            .chain(std::iter::repeat_n(1.0_f32, 200))
+            .collect();
+        let outcome = run_counted_streaming_finalize(ScriptedVad {
+            probabilities,
+            index: 0,
+        });
+        let counts = outcome.counts.lock().expect("feed counts lock");
+
+        // Only a prefix of the streamed audio is finalized: the voiced suffix is
+        // carried forward, so this is a genuine boundary split, not a hard cut.
+        assert!(
+            outcome.finalized_samples < outcome.streamed_samples,
+            "boundary split must finalize a prefix of the streamed audio"
+        );
+        // begin_streaming_utterance resets once; the boundary split forces a
+        // second reset so the carried-forward speech is not folded into this
+        // final and then transcribed again in the next utterance.
+        assert_eq!(
+            counts.reset_calls, 2,
+            "boundary cap-split must reset and re-feed the finalized prefix"
+        );
+        assert_eq!(
+            counts.accepted_samples,
+            outcome.streamed_samples + outcome.finalized_samples,
+            "the finalized prefix is re-fed exactly once after the reset"
         );
     }
 
@@ -1156,6 +1200,21 @@ mod tests {
         reset_calls: usize,
     }
 
+    struct CountedStreamingFinalize {
+        counts: Arc<Mutex<StreamingFeedCounts>>,
+        finalized_samples: usize,
+        streamed_samples: usize,
+    }
+
+    /// Plays back a fixed sequence of VAD probabilities, holding the last value
+    /// once the script is exhausted. Lets a streaming fixture reproduce a
+    /// speech → short silence gap → resumed speech pattern that drives a
+    /// boundary-aware 30 s cap split.
+    struct ScriptedVad {
+        probabilities: Vec<f32>,
+        index: usize,
+    }
+
     struct CountingStreamingModel {
         counts: Arc<Mutex<StreamingFeedCounts>>,
     }
@@ -1182,7 +1241,9 @@ mod tests {
         }
     }
 
-    fn run_counted_streaming_finalize(vad: FixtureVad) -> (Arc<Mutex<StreamingFeedCounts>>, usize) {
+    fn run_counted_streaming_finalize<V: VoiceActivityDetector>(
+        vad: V,
+    ) -> CountedStreamingFinalize {
         let counts = Arc::new(Mutex::new(StreamingFeedCounts::default()));
         let (_cancel_tx, cancel_rx) = watch::channel(false);
         let mut worker_session = WorkerSession {
@@ -1235,6 +1296,7 @@ mod tests {
                     continue;
                 };
                 let finalized_samples = utterance.samples.len();
+                let streamed_samples = counts.lock().expect("feed counts lock").accepted_samples;
                 finalize_streaming_utterance(
                     &mut worker_session,
                     &event_tx,
@@ -1244,7 +1306,11 @@ mod tests {
                     utterance_id,
                 )
                 .unwrap();
-                return (counts, finalized_samples);
+                return CountedStreamingFinalize {
+                    counts,
+                    finalized_samples,
+                    streamed_samples,
+                };
             }
 
             let Some(live) = listening_session.live_utterance() else {
@@ -1284,6 +1350,21 @@ mod tests {
                 0.0
             };
             self.calls += 1;
+            Ok(probability)
+        }
+
+        fn reset(&mut self) {}
+    }
+
+    impl VoiceActivityDetector for ScriptedVad {
+        fn speech_probability(&mut self, _frame: &[i16]) -> Result<f32, VoiceActivityError> {
+            let probability = self
+                .probabilities
+                .get(self.index)
+                .copied()
+                .or_else(|| self.probabilities.last().copied())
+                .unwrap_or(0.0);
+            self.index += 1;
             Ok(probability)
         }
 

--- a/native/src/worker.rs
+++ b/native/src/worker.rs
@@ -249,8 +249,11 @@ fn worker_main(
                 match load_result {
                     Ok(Ok(resources)) => {
                         let streaming = resources.family_capabilities.supports_streaming;
-                        let warnings =
-                            session_request_warnings(streaming, metadata.diarization_enabled);
+                        let warnings = session_request_warnings(
+                            &resources.family_capabilities,
+                            metadata.diarization_enabled,
+                            &metadata.language,
+                        );
                         let diarizer = if metadata.diarization_enabled && !streaming {
                             match SessionDiarizer::new() {
                                 Ok(diarizer) => Some(diarizer),
@@ -599,12 +602,26 @@ fn finalize_streaming_utterance(
     };
     let open = open.take();
     let revision = open.as_ref().map_or(0, |open| open.next_revision);
-    if open
+    match open
         .as_ref()
-        .is_none_or(|open| open.utterance_id != utterance_id || open.utterance.samples != samples)
+        .filter(|open| open.utterance_id == utterance_id)
     {
-        model.reset_utterance();
-        model.accept_audio(&samples)?;
+        Some(open) if samples.starts_with(&open.utterance.samples) => {
+            let missing_tail = &samples[open.utterance.samples.len()..];
+            if !missing_tail.is_empty() {
+                model.accept_audio(missing_tail)?;
+            }
+        }
+        Some(open) if open.utterance.samples.starts_with(&samples) => {
+            // Pause-driven finalization trims the silence hangover already fed
+            // to the streaming model. That suffix carries no speech, so keep
+            // the incremental state instead of resetting and re-feeding the
+            // finalized prefix.
+        }
+        _ => {
+            model.reset_utterance();
+            model.accept_audio(&samples)?;
+        }
     }
 
     let engine_started_at = Instant::now();
@@ -661,17 +678,32 @@ fn send_worker_error(
     });
 }
 
-fn session_request_warnings(streaming: bool, diarization_enabled: bool) -> Vec<RequestWarning> {
-    if streaming && diarization_enabled {
-        vec![RequestWarning {
+fn session_request_warnings(
+    capabilities: &ModelFamilyCapabilities,
+    diarization_enabled: bool,
+    language: &str,
+) -> Vec<RequestWarning> {
+    let mut warnings = Vec::new();
+    if capabilities.supports_streaming && diarization_enabled {
+        warnings.push(RequestWarning {
             field: "diarizationEnabled".to_string(),
             reason:
                 "diarization dropped because streaming sessions do not support speaker attribution"
                     .to_string(),
-        }]
-    } else {
-        Vec::new()
+        });
     }
+    if capabilities.supports_streaming
+        && !capabilities.supports_language_selection
+        && !language.eq_ignore_ascii_case("en")
+    {
+        warnings.push(RequestWarning {
+            field: "language".to_string(),
+            reason:
+                "language dropped because streaming adapter does not advertise supports_language_selection"
+                    .to_string(),
+        });
+    }
+    warnings
 }
 
 fn joined_engine_text(output: &EngineTranscriptOutput) -> String {
@@ -873,6 +905,8 @@ fn assemble_transcript(input: TranscriptAssembly<'_>) -> Transcript {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
     use crate::audio_metadata::voiced_fraction;
     use crate::engine::capabilities::LanguageSupport;
@@ -1050,17 +1084,60 @@ mod tests {
     }
 
     #[test]
+    fn pause_finalize_reuses_streamed_state_after_silence_trim() {
+        let (counts, finalized_samples) = run_counted_streaming_finalize(FixtureVad {
+            calls: 0,
+            speech_frames: 20,
+        });
+        let counts = counts.lock().expect("feed counts lock");
+
+        assert_eq!(counts.reset_calls, 1, "finalize must not reset and re-feed");
+        assert!(
+            counts.accepted_samples > finalized_samples,
+            "the fixture must exercise trimmed silence already present in streamed state"
+        );
+    }
+
+    #[test]
+    fn cap_split_feeds_only_the_unstreamed_tail() {
+        let (counts, finalized_samples) = run_counted_streaming_finalize(FixtureVad {
+            calls: 0,
+            speech_frames: usize::MAX,
+        });
+        let counts = counts.lock().expect("feed counts lock");
+
+        assert_eq!(counts.reset_calls, 1, "finalize must not reset and re-feed");
+        assert_eq!(
+            counts.accepted_samples, finalized_samples,
+            "each capped utterance sample must be fed exactly once"
+        );
+    }
+
+    #[test]
     fn streaming_session_warns_when_diarization_is_requested() {
         assert_eq!(
-            session_request_warnings(true, true),
+            session_request_warnings(&streaming_caps(), true, "en"),
             vec![RequestWarning {
                 field: "diarizationEnabled".to_string(),
                 reason: "diarization dropped because streaming sessions do not support speaker attribution"
                     .to_string(),
             }]
         );
-        assert!(session_request_warnings(false, true).is_empty());
-        assert!(session_request_warnings(true, false).is_empty());
+        assert!(session_request_warnings(&whisper_caps(), true, "en").is_empty());
+        assert!(session_request_warnings(&streaming_caps(), false, "en").is_empty());
+    }
+
+    #[test]
+    fn streaming_session_warns_when_language_selection_is_dropped() {
+        assert_eq!(
+            session_request_warnings(&streaming_caps(), false, "fr"),
+            vec![RequestWarning {
+                field: "language".to_string(),
+                reason: "language dropped because streaming adapter does not advertise supports_language_selection"
+                    .to_string(),
+            }]
+        );
+        assert!(session_request_warnings(&streaming_caps(), false, "en").is_empty());
     }
 
     #[derive(Default)]
@@ -1071,6 +1148,132 @@ mod tests {
     struct FixtureVad {
         calls: usize,
         speech_frames: usize,
+    }
+
+    #[derive(Default)]
+    struct StreamingFeedCounts {
+        accepted_samples: usize,
+        reset_calls: usize,
+    }
+
+    struct CountingStreamingModel {
+        counts: Arc<Mutex<StreamingFeedCounts>>,
+    }
+
+    impl StreamingModel for CountingStreamingModel {
+        fn accept_audio(&mut self, samples: &[i16]) -> Result<(), TranscriptionError> {
+            self.counts
+                .lock()
+                .expect("feed counts lock")
+                .accepted_samples += samples.len();
+            Ok(())
+        }
+
+        fn partial(&mut self) -> Result<EngineTranscriptOutput, TranscriptionError> {
+            Ok(fixture_output("counted partial".to_string()))
+        }
+
+        fn finalize_utterance(&mut self) -> Result<EngineTranscriptOutput, TranscriptionError> {
+            Ok(fixture_output("counted final".to_string()))
+        }
+
+        fn reset_utterance(&mut self) {
+            self.counts.lock().expect("feed counts lock").reset_calls += 1;
+        }
+    }
+
+    fn run_counted_streaming_finalize(vad: FixtureVad) -> (Arc<Mutex<StreamingFeedCounts>>, usize) {
+        let counts = Arc::new(Mutex::new(StreamingFeedCounts::default()));
+        let (_cancel_tx, cancel_rx) = watch::channel(false);
+        let mut worker_session = WorkerSession {
+            metadata: SessionMetadata {
+                runtime_id: RuntimeId::OnnxRuntime,
+                family_id: ModelFamilyId::Moonshine,
+                gpu_config: GpuConfig::default(),
+                diarization_enabled: false,
+                language: "en".to_string(),
+                model_file_path: PathBuf::from("/tmp/frontend.ort"),
+                cancel_rx,
+                session_start_unix_ms: 0,
+                session_id: "streaming-reconcile-test".to_string(),
+                stage_enablement: StageEnablement::default(),
+            },
+            family_capabilities: streaming_caps(),
+            model: SessionModel::Streaming {
+                model: Box::new(CountingStreamingModel {
+                    counts: Arc::clone(&counts),
+                }),
+                utterance: None,
+            },
+            processors: Vec::new(),
+            diarizer: None,
+            warnings: Vec::new(),
+        };
+        let mut listening_session = ListeningSession::with_vad(
+            SessionConfig {
+                mode: ListeningMode::AlwaysOn,
+                session_start_unix_ms: 0,
+                session_id: "streaming-reconcile-test".to_string(),
+                style: SpeakingStyle::Balanced,
+            },
+            vad,
+        );
+        let runtime = test_runtime();
+        let (event_tx, _event_rx) = mpsc::channel();
+        let utterance_id = Uuid::new_v4();
+        let mut opened = false;
+
+        for index in 0..1_600 {
+            let frame = vec![index as i16; 320];
+            let frame_bytes: Vec<u8> = frame
+                .iter()
+                .flat_map(|sample| sample.to_le_bytes())
+                .collect();
+            let actions = listening_session.ingest_audio_frame(&frame_bytes).unwrap();
+            for action in actions {
+                let SessionAction::FinalizeUtterance(utterance) = action else {
+                    continue;
+                };
+                let finalized_samples = utterance.samples.len();
+                finalize_streaming_utterance(
+                    &mut worker_session,
+                    &event_tx,
+                    &runtime,
+                    "streaming-reconcile-test",
+                    utterance,
+                    utterance_id,
+                )
+                .unwrap();
+                return (counts, finalized_samples);
+            }
+
+            let Some(live) = listening_session.live_utterance() else {
+                continue;
+            };
+            if opened {
+                stream_audio(
+                    &mut worker_session,
+                    &event_tx,
+                    &runtime,
+                    "streaming-reconcile-test",
+                    utterance_id,
+                    &frame,
+                    ((index + 1) * 20) as u64,
+                )
+                .unwrap();
+            } else {
+                begin_streaming_utterance(
+                    &mut worker_session,
+                    live,
+                    utterance_id,
+                    ((index + 1) * 20) as u64,
+                )
+                .unwrap();
+                opened = true;
+            }
+        }
+
+        panic!("fixture did not finalize an utterance");
     }
 
     impl VoiceActivityDetector for FixtureVad {

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -1059,6 +1059,11 @@ export class DictationSessionController {
       return;
     }
 
+    if (event.code === 'utterance_queue_overload' && event.sessionId !== undefined) {
+      await this.handleQueueOverload(event);
+      return;
+    }
+
     const detail = event.details ? `${event.message} (${event.details})` : event.message;
 
     if (event.sessionId === undefined) {
@@ -1079,6 +1084,36 @@ export class DictationSessionController {
     }
 
     await this.cancelSession(event.sessionId);
+  }
+
+  // Queue overload is a sidecar-initiated graceful stop: capture is already
+  // stopped natively and the already-accepted utterances keep draining until a
+  // session_stopped(queue_overload) event completes the teardown. Cancelling
+  // here (the fate of every other session-scoped error) would tear the worker
+  // down and drop that queued work before it lands, so surface the notice and
+  // let the drain run its course.
+  private async handleQueueOverload(
+    event: Extract<SidecarEvent, { type: 'error' }>,
+  ): Promise<void> {
+    const sessionId = event.sessionId;
+    if (sessionId === undefined) {
+      return;
+    }
+
+    const entry = this.sessions.get(sessionId);
+    if (entry === undefined) {
+      return;
+    }
+
+    const detail = event.details ? `${event.message} (${event.details})` : event.message;
+    if (sessionId === this.activeSessionId) {
+      this.dependencies.notice(`Local Dictation: ${detail}`);
+    } else {
+      this.dependencies.logger?.warn('session', detail);
+    }
+
+    entry.phase = 'stopping';
+    await this.clearActiveSession(sessionId);
   }
 
   private maybeLogLlmStageFailure(entry: ManagedSession, message: string): void {

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -91,9 +91,8 @@ type SessionPhase = 'starting' | 'active' | 'stopping' | 'cancelling' | 'stopped
 
 interface ManagedSession {
   anchorTimerId: number | null;
-  // Per-session FIFO: per-utterance cleanups run concurrently but their
-  // accept() must land in utterance order, so each transcript's cleanup+accept
-  // chains on the previous one's completion.
+  // Final revisions enter this FIFO so concurrent per-utterance cleanups land
+  // in final-event order. Partials bypass it and project immediately.
   cleanupChain: Promise<void>;
   cleanupAbortControllers: Set<AbortController>;
   llmFailureLogged: boolean;
@@ -669,33 +668,43 @@ export class DictationSessionController {
     }
     this.logDroppedHallucinations(event);
 
-    // The cleanup network call runs concurrently with later utterances for
-    // throughput, but accept() is serialized through the per-session FIFO so
-    // out-of-order remote completions still land in utterance order.
     const revisionPromise = this.resolveTranscriptRevision(entry, event);
+
+    if (!event.isFinal) {
+      const revision = await revisionPromise;
+      await this.acceptResolvedRevision(entry, event.sessionId, revision);
+      return;
+    }
+
+    // Final cleanup network calls run concurrently, but their accepts are
+    // serialized so out-of-order remote completions land in final-event order.
     const accept = entry.cleanupChain.then(async () => {
       const revision = await revisionPromise;
-      // Gate on 'cancelling' only: cancelSession sets it synchronously before
-      // its first await and it persists if cancellation cleanup throws, so
-      // queued accepts cannot land in a half-cancelled session (#138).
-      // 'stopped' must NOT be gated — the sidecar can deliver the final
-      // transcript_ready and session_stopped in one I/O chunk, and the stop
-      // path drains these in-flight accepts after the phase flips.
-      if (
-        revision === null ||
-        !this.sessions.has(event.sessionId) ||
-        entry.phase === 'cancelling'
-      ) {
-        return;
-      }
-      const result = entry.session.acceptTranscript(revision);
-      if (result.kind === 'rejected') {
-        this.handleError('Failed to record the local transcript', new Error(result.reason));
-        await this.cancelSession(event.sessionId);
-      }
+      await this.acceptResolvedRevision(entry, event.sessionId, revision);
     });
     entry.cleanupChain = accept.catch(() => {});
     await accept;
+  }
+
+  private async acceptResolvedRevision(
+    entry: ManagedSession,
+    sessionId: string,
+    revision: TranscriptRevision | null,
+  ): Promise<void> {
+    // Gate on 'cancelling' only: cancelSession sets it synchronously before
+    // its first await and it persists if cancellation cleanup throws, so
+    // queued accepts cannot land in a half-cancelled session (#138).
+    // 'stopped' must NOT be gated — the sidecar can deliver the final
+    // transcript_ready and session_stopped in one I/O chunk, and the stop
+    // path drains these in-flight accepts after the phase flips.
+    if (revision === null || !this.sessions.has(sessionId) || entry.phase === 'cancelling') {
+      return;
+    }
+    const result = entry.session.acceptTranscript(revision);
+    if (result.kind === 'rejected') {
+      this.handleError('Failed to record the local transcript', new Error(result.reason));
+      await this.cancelSession(sessionId);
+    }
   }
 
   private async resolveTranscriptRevision(

--- a/src/editor/note-surface.ts
+++ b/src/editor/note-surface.ts
@@ -237,7 +237,12 @@ export class NoteSurface {
     return { kind: 'appended', span: cloneSpan(span) };
   }
 
-  replaceAnchor(utteranceId: UtteranceId, newText: string, expectedOldText: string): ReplaceResult {
+  replaceAnchor(
+    utteranceId: UtteranceId,
+    newText: string,
+    expectedOldText: string,
+    removeBoundary = newText.length === 0,
+  ): ReplaceResult {
     if (this.disposed) {
       return { kind: 'denied', reason: { kind: 'disposed' }, utteranceId };
     }
@@ -264,7 +269,7 @@ export class NoteSurface {
       };
     }
 
-    const replacementStart = newText.length === 0 ? span.start : span.textStart;
+    const replacementStart = removeBoundary ? span.start : span.textStart;
     this.view.dispatch({
       changes: { from: replacementStart, to: span.textEnd, insert: newText },
       effects: this.ownerAnchorEffects(replacementStart + newText.length),

--- a/src/editor/provisional-transcript-extension.ts
+++ b/src/editor/provisional-transcript-extension.ts
@@ -19,7 +19,7 @@ export const provisionalTranscriptStateField = StateField.define<
 
     for (const [utteranceId, range] of value) {
       const from = transaction.changes.mapPos(range.from, -1);
-      const to = transaction.changes.mapPos(range.to, 1);
+      const to = transaction.changes.mapPos(range.to, -1);
       if (from < to) {
         next.set(utteranceId, { from, to, utteranceId });
       }

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -376,13 +376,25 @@ export class Session {
     this.dependencies.logger?.debug('session', `projection append denied: ${result.reason.kind}`);
   }
 
-  private applyRawPostprocessCallout(revision: TranscriptRevision): void {
+  // The per-utterance raw callout preserves the pre-cleanup text of a final
+  // whose LLM postprocess rewrote it. Returns the formatted callout body, or
+  // null when this revision does not warrant one.
+  private rawPostprocessCalloutText(revision: TranscriptRevision): string | null {
     if (!revision.isFinal) {
-      return;
+      return null;
     }
 
     const rawText = revision.llmPostprocessRawText?.trim();
     if (rawText === undefined || rawText.length === 0 || rawText === revision.text.trim()) {
+      return null;
+    }
+
+    return formatRawPostprocessCallout(rawText);
+  }
+
+  private applyRawPostprocessCallout(revision: TranscriptRevision): void {
+    const callout = this.rawPostprocessCalloutText(revision);
+    if (callout === null) {
       return;
     }
 
@@ -391,7 +403,6 @@ export class Session {
       return;
     }
 
-    const callout = formatRawPostprocessCallout(rawText);
     const boundary = missingNewlines(context.tailContent, 2);
     const projection: TranscriptInsertProjection = {
       emittedSpeakerIndex: null,
@@ -408,7 +419,7 @@ export class Session {
     if (result?.kind === 'denied') {
       this.dependencies.logger?.debug(
         'session',
-        `raw LLM postprocess callout append denied (${rawText.length} chars): ${result.reason.kind}`,
+        `raw LLM postprocess callout append denied (${callout.length} chars): ${result.reason.kind}`,
       );
     }
   }
@@ -430,11 +441,18 @@ export class Session {
         ? this.renderer.composeReplacementBody(revision.spans, state.precedingSpeakerIndex)
         : revision.text;
 
+    // Fold the raw callout into the same atomic replace as the cleaned text so
+    // it lands directly beneath this utterance. A separate tail append would
+    // sit after any later utterance whose partial was projected while this
+    // final's LLM cleanup was still pending.
+    const callout = replacementText.length > 0 ? this.rawPostprocessCalloutText(revision) : null;
+    const projectedText = callout === null ? replacementText : `${replacementText}\n\n${callout}`;
+
     const result = this.surface?.replaceAnchor(
       revision.utteranceId,
-      replacementText,
+      projectedText,
       state.projectedText,
-      revision.isFinal && replacementText.length === 0,
+      revision.isFinal && projectedText.length === 0,
     );
 
     if (result === undefined) {
@@ -446,11 +464,10 @@ export class Session {
         kind: 'projected',
         lastRevision: revision.revision,
         precedingSpeakerIndex: state.precedingSpeakerIndex,
-        projectedText: replacementText,
+        projectedText,
       });
       this.surface?.setProvisional(revision.utteranceId, !revision.isFinal);
       this.recordRawSessionReplace(revision);
-      this.applyRawPostprocessCallout(revision);
       return;
     }
 

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -77,7 +77,12 @@ interface NoteSurfaceLike {
   readNoteGlossary(maxChars: number): { text: string; truncated: boolean } | null;
   readNoteText(maxChars: number): { text: string; truncated: boolean } | null;
   readProjectionContext(): NoteProjectionContext;
-  replaceAnchor(utteranceId: string, newText: string, expectedOldText: string): ReplaceResult;
+  replaceAnchor(
+    utteranceId: string,
+    newText: string,
+    expectedOldText: string,
+    removeBoundary?: boolean,
+  ): ReplaceResult;
   rewriteRegion(
     range: RewriteRange,
     newText: string,
@@ -192,9 +197,9 @@ export class Session {
 
   joinRawSessionText(): string {
     return this.rawSessionEntries
-      .map((entry) => entry.rawText)
-      .join(' ')
-      .trim();
+      .map((entry) => entry.rawText.trim())
+      .filter((text) => text.length > 0)
+      .join(' ');
   }
 
   readCurrentSessionText(): string {
@@ -372,8 +377,12 @@ export class Session {
   }
 
   private applyRawPostprocessCallout(revision: TranscriptRevision): void {
+    if (!revision.isFinal) {
+      return;
+    }
+
     const rawText = revision.llmPostprocessRawText?.trim();
-    if (rawText === undefined || rawText.length === 0) {
+    if (rawText === undefined || rawText.length === 0 || rawText === revision.text.trim()) {
       return;
     }
 
@@ -425,6 +434,7 @@ export class Session {
       revision.utteranceId,
       replacementText,
       state.projectedText,
+      revision.isFinal && replacementText.length === 0,
     );
 
     if (result === undefined) {
@@ -440,6 +450,7 @@ export class Session {
       });
       this.surface?.setProvisional(revision.utteranceId, !revision.isFinal);
       this.recordRawSessionReplace(revision);
+      this.applyRawPostprocessCallout(revision);
       return;
     }
 

--- a/src/settings/diarization-setting.ts
+++ b/src/settings/diarization-setting.ts
@@ -1,0 +1,8 @@
+const BASE_DESCRIPTION =
+  'Label each utterance with a detected speaker (Speaker 1, Speaker 2, …). Runs fully on-device; no audio leaves your machine.';
+const STREAMING_LIMITATION =
+  'Not applied while a streaming (live) model is selected — speaker labels currently require a batch model.';
+
+export function diarizationSettingDescription(streamingModelSelected: boolean): string {
+  return streamingModelSelected ? `${BASE_DESCRIPTION} ${STREAMING_LIMITATION}` : BASE_DESCRIPTION;
+}

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -100,6 +100,7 @@ export class LocalSttSettingTab extends PluginSettingTab {
   override readonly icon = 'audio-lines';
 
   private readonly access: SettingAccess;
+  private disposeDiarizationDesc: (() => void) | null = null;
   private disposeEngineSection: (() => void) | null = null;
   private disposeMicrophoneSection: (() => void) | null = null;
   private disposeMissingSidecarBanner: (() => void) | null = null;
@@ -218,15 +219,21 @@ export class LocalSttSettingTab extends PluginSettingTab {
       isValid: isTranscriptFormattingMode,
     });
 
-    const selectedCapabilities = manager.getState().selectedModelCapabilities;
-    addToggleSetting(outputCard, this.access, {
+    const diarizationSetting = addToggleSetting(outputCard, this.access, {
       name: 'Speaker labels (diarization)',
-      desc: diarizationSettingDescription(
-        selectedCapabilities.status === 'ready' &&
-          selectedCapabilities.capabilities.family.supportsStreaming,
-      ),
+      desc: '',
       key: 'diarizationEnabled',
     });
+    const updateDiarizationDesc = (): void => {
+      const caps = manager.getState().selectedModelCapabilities;
+      diarizationSetting.setDesc(
+        diarizationSettingDescription(
+          caps.status === 'ready' && caps.capabilities.family.supportsStreaming,
+        ),
+      );
+    };
+    updateDiarizationDesc();
+    this.disposeDiarizationDesc = manager.subscribe(updateDiarizationDesc);
 
     const timestampsCard = createSettingGroup(containerEl, 'Timestamps');
     this.renderTimestampSettings(timestampsCard, settings);
@@ -310,6 +317,8 @@ export class LocalSttSettingTab extends PluginSettingTab {
   private tearDown(): void {
     this.disposeModelSection?.();
     this.disposeModelSection = null;
+    this.disposeDiarizationDesc?.();
+    this.disposeDiarizationDesc = null;
     this.disposeEngineSection?.();
     this.disposeEngineSection = null;
     this.disposeMicrophoneSection?.();

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -15,6 +15,7 @@ import {
   type SidecarInstallManager,
 } from '../sidecar/sidecar-install-manager';
 import { readInstallManifest, variantDirectoryPath } from '../sidecar/sidecar-installer';
+import { diarizationSettingDescription } from './diarization-setting';
 import { renderActiveInstallCard } from './install-progress-row';
 import { renderMicrophonePicker } from './microphone-picker';
 import { renderModelSection } from './model-settings-section';
@@ -217,9 +218,13 @@ export class LocalSttSettingTab extends PluginSettingTab {
       isValid: isTranscriptFormattingMode,
     });
 
+    const selectedCapabilities = manager.getState().selectedModelCapabilities;
     addToggleSetting(outputCard, this.access, {
       name: 'Speaker labels (diarization)',
-      desc: 'Label each utterance with a detected speaker (Speaker 1, Speaker 2, …). Runs fully on-device; no audio leaves your machine.',
+      desc: diarizationSettingDescription(
+        selectedCapabilities.status === 'ready' &&
+          selectedCapabilities.capabilities.family.supportsStreaming,
+      ),
       key: 'diarizationEnabled',
     });
 

--- a/test/capability-view.test.ts
+++ b/test/capability-view.test.ts
@@ -91,29 +91,6 @@ describe('resolveEngineCapabilities', () => {
 });
 
 describe('buildCapabilityLabels', () => {
-  it('renders Moonshine catalog capabilities as English streaming transcription', () => {
-    const capabilities = resolveEngineCapabilities(
-      [runtime('onnx_runtime', { supportedModelFormats: ['onnx'] })],
-      [
-        adapter('onnx_runtime', 'moonshine', {
-          producesPunctuation: true,
-          supportedLanguages: { kind: 'english_only' },
-          supportsStreaming: true,
-        }),
-      ],
-      'onnx_runtime',
-      'moonshine',
-    );
-
-    if (capabilities === null) {
-      throw new Error('expected Moonshine capabilities');
-    }
-
-    expect(buildCapabilityLabels(capabilities)).toEqual(
-      expect.arrayContaining(['ONNX', 'English only', 'Streaming', 'Punctuation']),
-    );
-  });
-
   it('always lists at least one accelerator and falls back to CPU when none are available', () => {
     // Empty availableAccelerators is a real wire-format possibility on CPU-only builds
     // where the runtime hasn't declared an explicit accelerator list.

--- a/test/diarization-setting.test.ts
+++ b/test/diarization-setting.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { diarizationSettingDescription } from '../src/settings/diarization-setting';
+
+describe('diarizationSettingDescription', () => {
+  it('shows the speaker-label limitation only for a streaming model', () => {
+    const limitation = 'Not applied while a streaming (live) model is selected';
+
+    expect(diarizationSettingDescription(true)).toContain(limitation);
+    expect(diarizationSettingDescription(false)).not.toContain(limitation);
+  });
+});

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -1132,6 +1132,63 @@ describe('DictationSessionController', () => {
     expect(controller.getState()).toBe('idle');
   });
 
+  it('drains queued work on queue overload instead of cancelling the session', async () => {
+    const captureStream = new FakeCaptureStream();
+    const notice = vi.fn();
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const controller = createController({
+      captureStream,
+      createSession: (session) => {
+        sessions.push(session);
+      },
+      notice,
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    const session = sessions[0];
+    if (session === undefined) {
+      throw new Error('expected session fixture');
+    }
+
+    sidecarConnection.emit({
+      code: 'utterance_queue_overload',
+      details: 'queue depth reached saturation at 32',
+      message:
+        'Local Dictation stopped because the transcription backlog reached capacity. Already accepted utterances will finish processing.',
+      sessionId,
+      type: 'error',
+    });
+    // Drain the async error handler fully. Cancelling (the buggy path) would run
+    // to completion here and dispose the session, so anything checked after this
+    // flush reliably distinguishes drain from cancel.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Overload must not cancel — that would tear the worker down and drop the
+    // queue the sidecar is still draining.
+    expect(sidecarConnection.cancelSession).not.toHaveBeenCalled();
+    expect(session.dispose).not.toHaveBeenCalled();
+    expect(notice).toHaveBeenCalledWith(expect.stringContaining('backlog reached capacity'));
+    expect(controller.getState()).toBe('idle');
+
+    // Already-accepted utterances still land while the queue drains. On the
+    // cancel path the session would already be gone, so this never records.
+    sidecarConnection.emit(transcriptReady(sessionId, 'queued utterance'));
+    await vi.waitFor(() => {
+      expect(session.acceptTranscript).toHaveBeenCalledWith(
+        expect.objectContaining({ text: 'queued utterance' }),
+      );
+    });
+
+    // The sidecar completes the drain; only then is the session disposed.
+    sidecarConnection.emit({ reason: 'queue_overload', sessionId, type: 'session_stopped' });
+    await vi.waitFor(() => {
+      expect(session.dispose).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('handles stop during a pending start without opening capture', async () => {
     const captureStream = new FakeCaptureStream();
     const sidecarConnection = new FakeSidecarConnection();

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -465,6 +465,80 @@ describe('DictationSessionController', () => {
     });
   });
 
+  it('projects monotonic partials while an earlier final cleanup is pending', async () => {
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    let resolveCleanup: ((value: LlmRouterCleanupResult) => void) | undefined;
+    const cleanup = vi.fn(
+      () =>
+        new Promise<LlmRouterCleanupResult>((resolve) => {
+          resolveCleanup = resolve;
+        }),
+    );
+    const controller = createController({
+      createSession: (session) => {
+        sessions.push(session);
+      },
+      getSettings: () =>
+        createSettings({
+          llmFeaturesEnabled: true,
+          llmPostprocessMode: 'per_utterance',
+          llmPostprocessSkipMinWords: 0,
+          selectedModel: createExternalModelSelection(),
+        }),
+      llmRouter: createFakeLlmRouter({ cleanup }),
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    sidecarConnection.emit(
+      transcriptReady(sessionId, 'utterance A final', {
+        utteranceId: crypto.randomUUID(),
+        utteranceIndex: 0,
+      }),
+    );
+    await vi.waitFor(() => {
+      expect(cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    const liveUtteranceId = crypto.randomUUID();
+    sidecarConnection.emit(
+      transcriptReady(sessionId, 'utterance B partial 0', {
+        isFinal: false,
+        revision: 0,
+        utteranceId: liveUtteranceId,
+        utteranceIndex: 1,
+      }),
+    );
+    sidecarConnection.emit(
+      transcriptReady(sessionId, 'utterance B partial 1', {
+        isFinal: false,
+        revision: 1,
+        utteranceId: liveUtteranceId,
+        utteranceIndex: 1,
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(sessions[0]?.acceptTranscript).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ isFinal: false, revision: 0, utteranceId: liveUtteranceId }),
+      );
+      expect(sessions[0]?.acceptTranscript).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ isFinal: false, revision: 1, utteranceId: liveUtteranceId }),
+      );
+    });
+
+    resolveCleanup?.({ model: 'm', providerId: 'ollama', text: 'Clean A.' });
+    await vi.waitFor(() => {
+      expect(sessions[0]?.acceptTranscript).toHaveBeenCalledWith(
+        expect.objectContaining({ isFinal: true, text: 'Clean A.' }),
+      );
+    });
+  });
+
   it('accepts cleaned per-utterance revisions in utterance order despite out-of-order completions', async () => {
     const sidecarConnection = new FakeSidecarConnection();
     const sessions: FakeSession[] = [];

--- a/test/note-surface.test.ts
+++ b/test/note-surface.test.ts
@@ -222,6 +222,26 @@ describe('NoteSurface', () => {
     expect(doc(view)).toBe('Existing');
   });
 
+  it('keeps the boundary and timestamp prefix when an empty partial clears the body', () => {
+    const { surface, view } = createSurface({ doc: 'Existing', selectionHead: 8 });
+    const renderer = new TranscriptRenderer({
+      timestamps: timestamps({ enabled: true, header: false }),
+      transcriptFormatting: 'space',
+    });
+
+    expect(
+      appendWithRenderer(surface, renderer, 'u1', 'live words', {
+        utteranceStartMsInSession: 10_000,
+      }).kind,
+    ).toBe('appended');
+
+    expect(surface.replaceAnchor('u1', '', 'live words', false).kind).toBe('replaced');
+    expect(doc(view)).toBe('Existing (0:10) ');
+
+    expect(surface.replaceAnchor('u1', 'live words again', '', false).kind).toBe('replaced');
+    expect(doc(view)).toBe('Existing (0:10) live words again');
+  });
+
   it('applies provisional styling and clears it on final replacement', () => {
     const { surface, view } = createSurface({ extensions: provisionalTranscriptExtension() });
 

--- a/test/provisional-transcript-extension.test.ts
+++ b/test/provisional-transcript-extension.test.ts
@@ -51,6 +51,20 @@ describe('provisionalTranscriptExtension', () => {
     expect(decorationRanges(editedInside)).toEqual([{ from: 10, to: 15 }]);
   });
 
+  it('does not style text inserted at the exact provisional tail', () => {
+    const applied = state().update({
+      effects: setProvisionalTranscriptEffect.of({ from: 0, to: 5, utteranceId: 'u1' }),
+    }).state;
+    const editedAtTail = applied.update({ changes: { from: 5, insert: ' typed' } }).state;
+
+    expect(editedAtTail.field(provisionalTranscriptStateField).get('u1')).toEqual({
+      from: 0,
+      to: 5,
+      utteranceId: 'u1',
+    });
+    expect(decorationRanges(editedAtTail)).toEqual([{ from: 0, to: 5 }]);
+  });
+
   it('clears only the requested session spans during teardown', () => {
     const applied = state().update({
       effects: [

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -85,12 +85,16 @@ class FakeSurface {
     return result;
   }
 
-  replaceAnchor(utteranceId: string, newText: string, expectedOldText: string): ReplaceResult {
+  replaceAnchor(
+    utteranceId: string,
+    newText: string,
+    expectedOldText: string,
+    removeBoundary = newText.length === 0,
+  ): ReplaceResult {
     this.replaceCalls.push({ expectedOldText, newText, utteranceId });
 
     const span = this.spans.get(utteranceId);
-    const replacementStart =
-      span !== undefined && newText.length === 0 ? span.start : span?.textStart;
+    const replacementStart = span !== undefined && removeBoundary ? span.start : span?.textStart;
     const result: ReplaceResult =
       this.nextReplaceResult ??
       (span === undefined
@@ -253,6 +257,34 @@ describe('Session', () => {
     expect(surface.documentText).toBe('(0:10) final words.');
     expect(surface.appendCalls).toHaveLength(1);
     expect(surface.replaceCalls).toHaveLength(2);
+  });
+
+  it('preserves the separator and timestamp across an empty partial revision', () => {
+    const { session, surface } = createSessionHarness({
+      rendererOptions: renderOptions({
+        timestamps: timestamps({ enabled: true, header: false }),
+      }),
+    });
+    surface.documentText = 'Existing';
+
+    session.acceptTranscript(
+      transcript({
+        isFinal: false,
+        revision: 0,
+        text: 'first partial',
+        utteranceId: 'u1',
+        utteranceStartMsInSession: 10_000,
+      }),
+    );
+    session.acceptTranscript(
+      transcript({ isFinal: false, revision: 1, text: '', utteranceId: 'u1' }),
+    );
+    session.acceptTranscript(
+      transcript({ isFinal: false, revision: 2, text: 'next partial', utteranceId: 'u1' }),
+    );
+
+    expect(surface.documentText).toBe('Existing (0:10) next partial');
+    expect(surface.appendCalls).toHaveLength(1);
   });
 
   it('projects new and revised transcripts through append then replace using last projected text', () => {
@@ -448,6 +480,19 @@ describe('Session', () => {
     expect(surface.documentText).toBe('Polished tail.');
   });
 
+  it('omits emptied finalized utterances from joined raw session text', () => {
+    const { session } = createSessionHarness();
+
+    session.acceptTranscript(transcript({ text: 'first', utteranceId: 'u1' }));
+    session.acceptTranscript(transcript({ isFinal: false, text: 'temporary', utteranceId: 'u2' }));
+    session.acceptTranscript(
+      transcript({ isFinal: true, revision: 1, text: '', utteranceId: 'u2' }),
+    );
+    session.acceptTranscript(transcript({ text: 'third', utteranceId: 'u3' }));
+
+    expect(session.joinRawSessionText()).toBe('first third');
+  });
+
   it('replaceSessionRangeWithCleaned force-replaces the tracked range even if its text diverged', () => {
     const { session, surface } = createSessionHarness();
 
@@ -475,6 +520,25 @@ describe('Session', () => {
         showRawBelow: true,
       }),
     ).toBe(true);
+    expect(surface.documentText).toBe('Cleaned words.\n\n> [!note]- raw\n> raw words');
+  });
+
+  it('appends the raw callout when a projected partial is replaced by a cleaned final', () => {
+    const { session, surface } = createSessionHarness();
+
+    session.acceptTranscript(
+      transcript({ isFinal: false, revision: 0, text: 'raw words', utteranceId: 'u1' }),
+    );
+    session.acceptTranscript(
+      transcript({
+        isFinal: true,
+        llmPostprocessRawText: 'raw words',
+        revision: 1,
+        text: 'Cleaned words.',
+        utteranceId: 'u1',
+      }),
+    );
+
     expect(surface.documentText).toBe('Cleaned words.\n\n> [!note]- raw\n> raw words');
   });
 

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -542,6 +542,31 @@ describe('Session', () => {
     expect(surface.documentText).toBe('Cleaned words.\n\n> [!note]- raw\n> raw words');
   });
 
+  it('folds the raw callout beneath its own utterance when a later utterance was projected first', () => {
+    const { session, surface } = createSessionHarness();
+
+    // A's partial projects, then B's partial projects while A's cleaned final is
+    // still pending (its LLM cleanup runs async in the controller).
+    session.acceptTranscript(
+      transcript({ isFinal: false, revision: 0, text: 'raw words', utteranceId: 'u1' }),
+    );
+    session.acceptTranscript(
+      transcript({ isFinal: false, revision: 0, text: 'more', utteranceId: 'u2' }),
+    );
+    session.acceptTranscript(
+      transcript({
+        isFinal: true,
+        llmPostprocessRawText: 'raw words',
+        revision: 1,
+        text: 'Cleaned words.',
+        utteranceId: 'u1',
+      }),
+    );
+
+    // The callout lands directly beneath A, not after the later utterance B.
+    expect(surface.documentText).toBe('Cleaned words.\n\n> [!note]- raw\n> raw words more');
+  });
+
   it('insertAdjacentToSessionRange prepends above the untouched session range', () => {
     const { session, surface } = createSessionHarness();
 


### PR DESCRIPTION
Addresses #179; partially addresses #178 (visible gating; full diarization integration deferred with rationale recorded in the spec).

## What this is

Takes live dictation from "merged behind manual model selection" to releasable. Spec-first (`docs/specs/live-dictation-release-readiness.md`), then implementation on this branch: a verified defect burn-down from a line-level review of the merged #176 diff, an honest capability-driven settings note for diarization on streaming models, and the #179 release gate.

## Post-#176 review findings (all verified at file:line, now fixed)

1. **Finalize always re-decoded** — the streamed-state fast path was dead because VAD trims padding the worker already streamed; 30 s cap splits stalled live text for a full re-decode.
2. **Empty partial deleted the utterance's separator/timestamp prefix**, gluing the next text to the previous utterance.
3. **Streaming sessions bypassed queue-overload protection** — unbounded backlog on slower-than-realtime models.
4. **One transient partial-decode error cancelled the whole session**, though the worker keeps it recoverable.
5. **Per-utterance LLM cleanup blocked the next utterance's live partials** behind a network round-trip.
6. **"Show raw below" callout silently dropped** for streamed utterances.
7–9. Polish: doubled spaces after emptied finals; provisional tail-bias styling glitch; missing `RequestWarning` for non-diarization dropped fields.

Also recorded as checked-and-solid so it isn't re-litigated: revision monotonicity, empty-final handling, stage/LLM gating, teardown.

## Follow-up review round (three additional findings fixed)

A second line-level review surfaced three defects in the reconciliation, overload, and callout paths. Each fix ships with a regression test verified to fail on the pre-fix code.

- **Boundary cap-split duplicated speech across utterances** — `native/src/worker.rs`, `native/src/session.rs`. The finalize fast path reused the streamed model state whenever the finalized samples were a prefix of what had been streamed, assuming the extra suffix was trimmed silence. That holds for a pause-driven finalize (suffix discarded) but not for a 30 s-cap boundary split, whose suffix is resumed speech carried into the next utterance — so it was folded into the current final and transcribed again next time.
  - *Decision:* the worker cannot reliably tell trailing silence from trailing speech at the sample level, so rather than guess, thread an explicit `carries_audio_forward` marker from the session's `split_at_boundary` through `FinalizedUtterance`. When set, finalize resets and re-feeds only the finalized prefix; pause-driven and hard-cut finalizations (which discard their trailing audio) keep the fast path.

- **Streaming overload cancelled instead of draining** — `src/dictation/dictation-session-controller.ts`. `handleErrorEvent` cancelled the session on every session-scoped error, including `utterance_queue_overload`. Cancel tears the worker down and drops the queue the sidecar is still draining, so the intended overload drain and eventual `QueueOverload` stop never reached the real plugin client.
  - *Decision:* fix at the frontend (no protocol change — the native side correctly emits the overload notice and enters its drain). A new `handleQueueOverload` treats the signal as the sidecar-initiated graceful stop it is: surface the notice, stop capture, and let queued work drain to the `session_stopped(queue_overload)` teardown. This also corrects the batch path, which shares the same native overload signal.

- **Delayed raw callout rendered under the wrong utterance** — `src/session/session.ts`. The per-utterance raw callout was appended at the writing-region tail. When a later utterance's partial was projected while a final's async LLM cleanup was still pending, the callout landed beneath that later utterance instead of its own.
  - *Decision:* fold the callout into the same atomic `replaceAnchor` as the cleaned text rather than adding a new positioned-insert surface method. This reuses the well-tested replace position-mapping (following spans shift correctly) and keeps the callout inside its own utterance's span. The append path (final-only utterances) keeps its existing tail append, which is always correctly positioned.

## Diarization decision (D1)

Not integrated for streaming in this release. Speaker labels are structurally decided at append time, but streaming appends before any speaker is known, and multi-span finals would restructure provisional text under the latch machinery. Instead the settings toggle gets a capability-driven note when a streaming model is selected; the sidecar warning backstop stays; #178 remains open with the integration shape documented.

## Verification

- `npm run check` (typecheck + Biome + eslint-plugin-obsidianmd + 573 vitest tests) and `cargo test --lib` (220 tests) + `cargo clippy` all green.
- Each of the three follow-up fixes has a regression test at the named seam, confirmed to fail on the pre-fix code and pass with the fix.

## Known limitations / follow-ups

- Streaming models are English-only, provide no speaker labels, and cap utterances at 30 s (documented in user-facing limitations per spec D5).
- Combining per-utterance "show raw below" with a batch cleanup pass now places the callout inside the batch-rewritten region (it lives in the utterance's span) — an unusual combination, flagged for awareness.
- Full streaming diarization integration tracked in #178.
