### PR TITLE
chore: align ESLint with Obsidian community scanner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@typescript-eslint/parser": "^8.62.1",
         "esbuild": "0.28.1",
         "eslint": "^10.6.0",
-        "eslint-plugin-obsidianmd": "^0.3.0",
+        "eslint-plugin-obsidianmd": "^0.4.1",
         "obsidian": "1.11.4",
         "tslib": "2.8.1",
         "typescript": "6.0.3",
@@ -702,6 +702,36 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-plugin-eslint-comments": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-4.7.2.tgz",
+      "integrity": "sha512-LF03qURSwEWm2dz5wtdDCzNk+7Opl0X7q6I3undsaIuNsEiNvRV3BCtqu14Q/6Pzg1tBj44LcxpW2EpSLZStZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "ignore": "^7.0.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-plugin-eslint-comments/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2954,12 +2984,13 @@
       }
     },
     "node_modules/eslint-plugin-obsidianmd": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.3.0.tgz",
-      "integrity": "sha512-QvGDI6B2nxJBrsZKGTg31da2A/fEJNlnwN+fRZkaoPIu1QL3fYXUdpP7ThyMdr/0iTYQxifb9lt2X9cpydQx1w==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.4.1.tgz",
+      "integrity": "sha512-Nv3593kVsFOS8kir/HWaJ5CR3xcyiPWEPyXst5Pib8mxRYYuLYPpJS2ALMoZXHulHyiGwoYW8AaxvLRc4rhrRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/js": "^9.30.1",
         "@eslint/json": "0.14.0",
@@ -2968,7 +2999,7 @@
         "@types/node": "20.12.12",
         "@typescript-eslint/types": "^8.33.1",
         "@typescript-eslint/utils": "^8.33.1",
-        "eslint": ">=9.0.0",
+        "eslint": ">=9.19.0",
         "eslint-plugin-depend": "1.3.1",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-json-schema-validator": "5.1.0",
@@ -2989,7 +3020,7 @@
       "peerDependencies": {
         "@eslint/js": "^9.30.1",
         "@eslint/json": "0.14.0",
-        "eslint": ">=9.0.0",
+        "eslint": ">=9.19.0",
         "obsidian": "1.8.7",
         "typescript-eslint": "^8.35.1"
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@typescript-eslint/parser": "^8.62.1",
     "esbuild": "0.28.1",
     "eslint": "^10.6.0",
-    "eslint-plugin-obsidianmd": "^0.3.0",
+    "eslint-plugin-obsidianmd": "^0.4.1",
     "obsidian": "1.11.4",
     "tslib": "2.8.1",
     "typescript": "6.0.3",

--- a/src/editor/dictation-anchor-extension.ts
+++ b/src/editor/dictation-anchor-extension.ts
@@ -57,7 +57,7 @@ class DictationAnchorWidget extends WidgetType {
   }
 
   toDOM(): HTMLElement {
-    const span = activeDocument.createElement('span');
+    const span = createSpan();
     span.className = 'local-stt-dictation-anchor local-stt-dictation-anchor--visible';
     span.setAttribute('aria-hidden', 'true');
     return span;

--- a/src/models/manage-models-modal.ts
+++ b/src/models/manage-models-modal.ts
@@ -247,7 +247,7 @@ export class ManageModelsModal extends Modal {
       if (progressState !== null) {
         const progressEl = createInstallProgressElement(progressState);
         this.progressElements.set(getRowKey(row), progressEl);
-        const fragment = activeDocument.createDocumentFragment();
+        const fragment = createFragment();
         fragment.append(progressEl);
         setting.setDesc(fragment);
       }
@@ -469,11 +469,11 @@ export class ManageModelsModal extends Modal {
   }
 
   private buildTagsFragment(model: CatalogModelRecord): DocumentFragment {
-    const frag = activeDocument.createDocumentFragment();
-    const tagsContainer = frag.createEl('span', { cls: 'local-stt-tags' });
+    const frag = createFragment();
+    const tagsContainer = frag.createSpan({ cls: 'local-stt-tags' });
 
     for (const tag of model.uxTags) {
-      tagsContainer.createEl('span', {
+      tagsContainer.createSpan({
         cls: 'local-stt-tag',
         text: tag,
       });
@@ -481,7 +481,7 @@ export class ManageModelsModal extends Modal {
 
     const totalSize = getTotalModelSize(model);
     if (totalSize > 0) {
-      tagsContainer.createEl('span', {
+      tagsContainer.createSpan({
         cls: 'local-stt-tag local-stt-tag--size',
         text: formatBytes(totalSize),
       });

--- a/src/models/model-install-progress.ts
+++ b/src/models/model-install-progress.ts
@@ -48,9 +48,9 @@ export function buildInstallProgressViewModel(
 
 export function createInstallProgressElement(state: InstallProgressState): HTMLDivElement {
   const viewModel = buildInstallProgressViewModel(state);
-  const root = activeDocument.createElement('div');
-  const header = activeDocument.createElement('div');
-  const statusLine = activeDocument.createElement('span');
+  const root = createDiv();
+  const header = createDiv();
+  const statusLine = createSpan();
 
   root.className = 'local-stt-install-progress';
   if (viewModel.isCancelling) {
@@ -63,7 +63,7 @@ export function createInstallProgressElement(state: InstallProgressState): HTMLD
   header.append(statusLine);
 
   if (viewModel.bytesLabel !== null) {
-    const bytesLabel = activeDocument.createElement('span');
+    const bytesLabel = createSpan();
     bytesLabel.className = 'local-stt-install-progress__bytes';
     bytesLabel.textContent = viewModel.bytesLabel;
     header.append(bytesLabel);
@@ -71,8 +71,8 @@ export function createInstallProgressElement(state: InstallProgressState): HTMLD
 
   root.append(header);
 
-  const progressTrack = activeDocument.createElement('div');
-  const progressFill = activeDocument.createElement('div');
+  const progressTrack = createDiv();
+  const progressFill = createDiv();
 
   progressTrack.className = 'local-stt-install-progress__track';
   progressTrack.setAttribute('role', 'progressbar');
@@ -86,7 +86,7 @@ export function createInstallProgressElement(state: InstallProgressState): HTMLD
   root.append(progressTrack);
 
   if (viewModel.secondaryLine !== null) {
-    const secondaryLine = activeDocument.createElement('div');
+    const secondaryLine = createDiv();
     secondaryLine.className = 'local-stt-install-progress__details';
     secondaryLine.textContent = viewModel.secondaryLine;
     root.append(secondaryLine);

--- a/src/settings/install-progress-row.ts
+++ b/src/settings/install-progress-row.ts
@@ -17,7 +17,7 @@ export function renderActiveInstallCard(
   opts: ActiveInstallCardOptions,
 ): { progressEl: HTMLDivElement } {
   const progressEl = createInstallProgressElement(opts.progressState);
-  const fragment = activeDocument.createDocumentFragment();
+  const fragment = createFragment();
   fragment.append(progressEl);
 
   const setting = new Setting(container).setName(opts.name).setDesc(fragment);

--- a/src/settings/model-settings-section.ts
+++ b/src/settings/model-settings-section.ts
@@ -54,7 +54,7 @@ export function renderModelSection(
     const currentModel = deriveCurrentModelDisplay(state);
 
     // --- Current model row ---
-    const descFragment = activeDocument.createDocumentFragment();
+    const descFragment = createFragment();
     if (currentModel.engineLabel.length > 0) {
       descFragment.createSpan({ text: `${currentModel.engineLabel} \u00b7 ` });
     }

--- a/src/setup/sidecar-install-modal.ts
+++ b/src/setup/sidecar-install-modal.ts
@@ -156,7 +156,7 @@ export class SidecarInstallModal extends Modal {
 
   private renderProgress(active: ActiveSidecarInstall): void {
     const progressState = buildSidecarProgressState(active);
-    const fragment = activeDocument.createDocumentFragment();
+    const fragment = createFragment();
     this.installProgressEl = createInstallProgressElement(progressState);
     fragment.append(this.installProgressEl);
     this.contentEl.append(fragment);

--- a/src/ui/preset-manager-modal.ts
+++ b/src/ui/preset-manager-modal.ts
@@ -172,12 +172,12 @@ export class PresetManagerModal extends Modal {
     for (const hit of hits) {
       const { entry } = hit;
       const { preset } = entry;
-      const name = activeDocument.createDocumentFragment();
+      const name = createFragment();
       renderMatches(name, preset.label, hit.labelMatches);
       if (entry.ref === activeRef) {
         name.append(' ✓');
       }
-      const description = activeDocument.createDocumentFragment();
+      const description = createFragment();
       renderMatches(description, hit.description, hit.descriptionMatches);
       const setting = new Setting(listEl).setName(name).setDesc(description);
       setting.settingEl.addClass('local-stt-preset-row');


### PR DESCRIPTION
## Summary

- Upgrade `eslint-plugin-obsidianmd` from 0.3.0 to 0.4.1, whose recommended config matches the community scanner's effective rule severities.
- Replace native DOM element and fragment construction reported by the updated ruleset with Obsidian's typed DOM helpers.
- Reduce local scanner-aligned lint output from 19 warnings to 1 advisory warning and 0 errors.

## Key changes

- Frontend: use `createDiv`, `createSpan`, `createFragment`, and element shorthand helpers in the affected UI paths.
- Tooling: include the scanner-aligned rules and its new ESLint comments dependency through the updated lockfile.

## Notes

The remaining warning is `obsidianmd/settings-tab/prefer-setting-definitions`. It recommends the Obsidian 1.13 declarative settings API, while this plugin currently targets Obsidian 1.11.5 and uses the compatible `display()` path. Migrating that settings architecture is intentionally outside this lint-alignment change.

The community portal will only reflect source changes after a release is published and rescanned.

## Test plan

- [x] `npm run check:frontend` (TypeScript, Biome, scanner-aligned ESLint, 565 Vitest tests, production frontend build)
- [x] `git diff --check`
