### PR TITLE
fix: relax engines so the community scanner can install deps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ See [docs/system-architecture.md](docs/system-architecture.md) for the pipeline 
 - CUDA Toolkit `13.2` with `nvcc` for Linux/Windows CUDA sidecar builds only
 - cuDNN `9.x` runtime libraries for local Cohere CUDA verification only
 
-Versions are pinned in `package.json` (`engines`, `packageManager`) and `rust-toolchain.toml`. If you use [mise](https://mise.jdx.dev), `mise install` sets up the Node and Rust toolchains automatically.
+The recommended Node version is pinned in `package.json` `engines` (a compatibility floor, not an exact pin) and the Rust toolchain in `rust-toolchain.toml`. If you use [mise](https://mise.jdx.dev), `mise install` sets up the Node and Rust toolchains automatically.
 
 The CUDA Toolkit is a build-from-source dependency. Published Linux/Windows CUDA sidecar archives bundle the CUDA runtime libraries needed by Whisper CUDA; release users need only a Turing-or-newer NVIDIA GPU and a driver compatible with CUDA 13.x (R580 or newer). Cohere CUDA additionally needs cuDNN `9.x` runtime libraries built for CUDA 13 (9.20 or newer) installed until cuDNN redistribution is reviewed.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,7 @@
         "vitest": "4.1.9"
       },
       "engines": {
-        "node": "24.14.x",
-        "npm": "11.12.x"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@biomejs/biome": {

--- a/package.json
+++ b/package.json
@@ -6,10 +6,8 @@
   "license": "MIT",
   "main": "main.js",
   "type": "module",
-  "packageManager": "npm@11.12.1",
   "engines": {
-    "node": "24.14.x",
-    "npm": "11.12.x"
+    "node": "^20.19.0 || ^22.13.0 || >=24"
   },
   "scripts": {
     "build:sidecar": "node scripts/build-sidecar.mjs",


### PR DESCRIPTION
## Problem

The Obsidian preview scanner reports ~2,318 `no-unsafe-*` warnings against `main`, and its maintainer confirmed the dependency install **"immediately crashes."** This is a toolchain-pin problem, not a code problem.

With `engine-strict`, the narrow `"npm": "11.12.x"` engine is unsatisfiable on any runner not on that exact npm minor, so `npm ci` aborts with `EBADENGINE` **before** fetching the `obsidian` / `@codemirror/*` / `@types/node` typings. `eslint-plugin-obsidianmd` then lints via `projectService` against a program where those imports resolve to `any`, firing the `no-unsafe-*` family across all 28 `src` files that import them. Deleting those three type packages locally reproduces the scanner's exact counts.

## Fix

- Drop the `npm` engine (no dependency requires a specific npm) and widen `node` to the real toolchain floor — ESLint 10's supported range `^20.19.0 || ^22.13.0 || >=24`.
- Remove `packageManager` to also close the Corepack-provisioning crash path. CI pins npm via the `setup-node-npm` `upgrade-npm` step, not this field, so nothing breaks.
- Sync `package-lock.json` root `engines`; fix the now-stale `CONTRIBUTING.md` reference.

## Verification

- `npm ci` → clean, 372 packages.
- `npm run lint:obsidian` → 0 errors (only the pre-existing 1.13 settings-API advisory).

## Out of scope

Release binary size (CUDA archives ~1.5 GB, ~92% of the release) is a **separate** scanner concern — it drives the "malware/network scan not available" disclosures, not the install crash. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)