### PR TITLE
fix: streaming (Moonshine) final-decode correctness + quality/perf test suite

### DIFF
--- a/docs/specs/streaming-moonshine-test-suite-plan.md
+++ b/docs/specs/streaming-moonshine-test-suite-plan.md
@@ -1,0 +1,948 @@
+# Streaming (Moonshine) Test Suite & Partial-Decode Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add streaming (Moonshine) quality + performance integration tests to the sidecar, and eliminate the O(n²) per-partial decode cost with a change that is quality-neutral on the committed transcript.
+
+**Architecture:** Extend the existing `native/tests/` harness (drivers, corpus, WER scoring) rather than forking it. The perf regression guard is written first (red on current code), then the fix lands in two parts — incremental cross-KV cache (bit-identical) and bounded-tail partial decode (leaves the final path a full decode) — turning the guard green. Quality tests prove neutrality via `final == one-shot` equivalence and per-tier WER budgets.
+
+**Tech Stack:** Rust, `ort` (ONNX Runtime), `ndarray`, `hound` (WAV), `reqwest` (model download), `sha2`. Companion spec: `docs/specs/streaming-moonshine-test-suite.md`.
+
+## Global Constraints
+
+- Heavy streaming tests are `#[ignore]`d and English-only; run with `--ignored --nocapture`. (Matches `transcription_e2e.rs`.)
+- Perf assertions are **relative shape ratios**, never absolute milliseconds (hardware portability).
+- The **final decode path stays a full decode from BOS** — do not make finalize incremental. This is what preserves `final == one-shot`.
+- Tiers under test: `moonshine_tiny_streaming_en`, `moonshine_small_streaming_en` (catalog `RuntimeId::OnnxRuntime`, `ModelFamilyId::Moonshine`).
+- Moonshine is a **7-artifact** model: `frontend.ort`, `encoder.ort`, `adapter.ort`, `cross_kv.ort`, `decoder_kv.ort`, `streaming_config.json`, `tokenizer.bin`. All must be co-located; the adapter is loaded via the `frontend.ort` path.
+- Reuse existing helpers (`file_sha256`, verified-download, WER, corpus loader). DRY.
+
+---
+
+## File Structure
+
+- Create `native/tests/streaming_e2e.rs` — sidecar-level streaming **quality** suite.
+- Create `native/tests/streaming_perf.rs` — adapter-level streaming **performance** harness + scaling guard.
+- Create `native/tests/fixtures/audio/streaming_budgets.json` — per-fixture, per-tier WER budgets + anchors for Moonshine.
+- Modify `native/tests/common/model.rs` — add multi-artifact Moonshine acquisition.
+- Modify `native/tests/common/driver.rs` — generalize model selection; add streaming capture (`StreamingOutcome`).
+- Modify `native/tests/common/mod.rs` — export any new shared helper (streaming budget loader).
+- Modify `native/src/adapters/moonshine.rs` — the fix (cross-KV cache + bounded-tail decode) and its unit guards.
+
+---
+
+## Task 1: Multi-artifact Moonshine model acquisition
+
+**Files:**
+- Modify: `native/tests/common/model.rs`
+- Test: `native/tests/common/model.rs` (`#[cfg(test)]` is not used here; add an `#[ignore]`d smoke test in `native/tests/streaming_perf.rs` Task 4 instead — this task's deliverable is verified by Task 3/4 consuming it). Add a focused resolver test as a temporary `#[ignore]`d test in `streaming_perf.rs` skeleton created here.
+
+**Interfaces:**
+- Produces:
+  - `pub enum MoonshineTier { Tiny, Small }` with `pub fn model_id(self) -> &'static str` (`"moonshine_tiny_streaming_en"` / `"moonshine_small_streaming_en"`).
+  - `pub fn resolve_moonshine_model(tier: MoonshineTier) -> Result<PathBuf, String>` — returns the path to `frontend.ort` in a directory containing all 7 verified siblings.
+  - `pub fn require_moonshine_model(tier: MoonshineTier) -> PathBuf` — panics with actionable guidance.
+
+- [ ] **Step 1: Write the failing resolver smoke test**
+
+Create `native/tests/streaming_perf.rs` with just:
+
+```rust
+//! Adapter-level streaming performance harness (Moonshine). `#[ignore]`d: needs
+//! a model download + real inference. Run:
+//! cargo test --manifest-path native/Cargo.toml --test streaming_perf -- --ignored --nocapture
+mod common;
+
+use common::model::{require_moonshine_model, MoonshineTier};
+
+#[test]
+#[ignore = "downloads Moonshine assets; run with --ignored"]
+fn moonshine_tiny_assets_resolve_with_all_siblings() {
+    let frontend = require_moonshine_model(MoonshineTier::Tiny);
+    assert_eq!(frontend.file_name().unwrap(), "frontend.ort");
+    let dir = frontend.parent().unwrap();
+    for sibling in [
+        "frontend.ort", "encoder.ort", "adapter.ort", "cross_kv.ort",
+        "decoder_kv.ort", "streaming_config.json", "tokenizer.bin",
+    ] {
+        assert!(dir.join(sibling).is_file(), "missing {sibling}");
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails to compile (helper not defined)**
+
+Run: `cargo test --manifest-path native/Cargo.toml --test streaming_perf -- --ignored`
+Expected: compile error `cannot find function require_moonshine_model` / `MoonshineTier`.
+
+- [ ] **Step 3: Implement the acquisition helper**
+
+Add to `native/tests/common/model.rs` (reuses the existing private `download_verified`, `file_sha256`, `cache_dir`):
+
+```rust
+use local_dictation_sidecar::catalog::ArtifactRole;
+
+#[derive(Clone, Copy, Debug)]
+pub enum MoonshineTier {
+    Tiny,
+    Small,
+}
+
+impl MoonshineTier {
+    pub fn model_id(self) -> &'static str {
+        match self {
+            MoonshineTier::Tiny => "moonshine_tiny_streaming_en",
+            MoonshineTier::Small => "moonshine_small_streaming_en",
+        }
+    }
+}
+
+/// Resolve a directory holding all 7 verified Moonshine artifacts, returning the
+/// `frontend.ort` path the adapter loads from. Priority: an explicit dir via
+/// `STT_TEST_MOONSHINE_DIR` (must already contain the siblings), else a
+/// sha-verified catalog download cached per tier under the shared cache dir.
+pub fn resolve_moonshine_model(tier: MoonshineTier) -> Result<PathBuf, String> {
+    if let Some(dir) = std::env::var_os("STT_TEST_MOONSHINE_DIR") {
+        let frontend = PathBuf::from(dir).join("frontend.ort");
+        return if frontend.is_file() {
+            Ok(frontend)
+        } else {
+            Err(format!(
+                "STT_TEST_MOONSHINE_DIR set but {} is missing",
+                frontend.display()
+            ))
+        };
+    }
+
+    let catalog =
+        ModelCatalog::load_bundled().map_err(|error| format!("load catalog: {error:#}"))?;
+    let model = catalog
+        .find_model(RuntimeId::OnnxRuntime, ModelFamilyId::Moonshine, tier.model_id())
+        .ok_or_else(|| format!("bundled catalog has no model {}", tier.model_id()))?;
+
+    let dir = cache_dir().join(tier.model_id());
+    std::fs::create_dir_all(&dir).map_err(|error| format!("create {}: {error}", dir.display()))?;
+
+    for artifact in &model.artifacts {
+        let dest = dir.join(&artifact.filename);
+        let ok = dest.is_file()
+            && file_sha256(&dest)
+                .is_ok_and(|digest| digest.eq_ignore_ascii_case(&artifact.sha256));
+        if !ok {
+            download_verified(&artifact.download_url, &artifact.sha256, &dest)?;
+        }
+    }
+
+    let frontend = dir.join("frontend.ort");
+    if !frontend.is_file() {
+        return Err(format!("{} has no frontend.ort after download", dir.display()));
+    }
+    // Sanity: the adapter probe must accept the assembled directory.
+    let _ = model.artifacts.iter().find(|a| a.role == ArtifactRole::TranscriptionModel);
+    Ok(frontend)
+}
+
+pub fn require_moonshine_model(tier: MoonshineTier) -> PathBuf {
+    resolve_moonshine_model(tier).unwrap_or_else(|error| {
+        panic!(
+            "could not obtain Moonshine {:?} assets: {error}\n  \
+             Set STT_TEST_MOONSHINE_DIR=/path/to/dir (containing frontend.ort + siblings) \
+             to reuse local assets, or ensure network access for the catalog download.",
+            tier
+        )
+    })
+}
+```
+
+- [ ] **Step 4: Run the smoke test to verify it passes**
+
+Run: `cargo test --manifest-path native/Cargo.toml --test streaming_perf -- --ignored moonshine_tiny_assets_resolve --nocapture`
+Expected: PASS (downloads on first run, cached after).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add native/tests/common/model.rs native/tests/streaming_perf.rs
+git commit -m "test: multi-artifact Moonshine model acquisition helper"
+```
+
+---
+
+## Task 2: Performance characterization + scaling guard (red on current code)
+
+**Files:**
+- Modify: `native/tests/streaming_perf.rs`
+
+**Interfaces:**
+- Consumes: `require_moonshine_model`, `MoonshineTier`, `common::audio::decode_wav_16k_mono`, `common::fixtures_dir`.
+- Produces: the permanent perf regression guard `partial_cost_does_not_scale_with_utterance_length`.
+
+- [ ] **Step 1: Write the failing perf guard + characterization test**
+
+Append to `native/tests/streaming_perf.rs`:
+
+```rust
+use std::path::Path;
+use std::time::Instant;
+
+use local_dictation_sidecar::adapters::MoonshineAdapter;
+use local_dictation_sidecar::engine::traits::{ModelFamilyAdapter, StreamingModel};
+use local_dictation_sidecar::transcription::GpuConfig;
+
+/// 16 kHz mono. One cadence chunk ~= the worker's PARTIAL_CADENCE_SAMPLES (8000).
+const CADENCE_SAMPLES: usize = 8_000;
+
+/// Build ~50 s of continuous speech in memory by concatenating corpus clips,
+/// so a single utterance stays open long enough to expose partial-decode scaling.
+fn long_utterance_samples() -> Vec<i16> {
+    let clips = [
+        "audio/7021-79740-0000.wav",
+        "audio/3575-170457-0051.wav",
+        "audio/1580-141084-0047.wav",
+        "audio/4446-2271-0004.wav",
+        "audio/5683-32866-0024.wav",
+    ];
+    let mut samples = Vec::new();
+    while samples.len() < 50 * 16_000 {
+        for clip in clips {
+            let path = common::fixtures_dir().join(clip);
+            samples.extend(common::audio::decode_wav_16k_mono(&path).unwrap());
+            if samples.len() >= 50 * 16_000 {
+                break;
+            }
+        }
+    }
+    samples
+}
+
+#[test]
+#[ignore = "needs Moonshine model + real inference; run with --ignored"]
+fn partial_cost_does_not_scale_with_utterance_length() {
+    let frontend = require_moonshine_model(MoonshineTier::Tiny);
+    let mut model = MoonshineAdapter
+        .load_streaming(Path::new(&frontend), GpuConfig { use_gpu: false })
+        .unwrap();
+
+    let samples = long_utterance_samples();
+    let mut per_partial_ms: Vec<u128> = Vec::new();
+    let mut cumulative = 0usize;
+
+    for chunk in samples.chunks(CADENCE_SAMPLES) {
+        model.accept_audio(chunk).unwrap();
+        cumulative += chunk.len();
+        let started = Instant::now();
+        let partial = model.partial().unwrap();
+        let elapsed = started.elapsed().as_millis();
+        per_partial_ms.push(elapsed);
+        let tokens = partial
+            .diagnostics
+            .first()
+            .and_then(|d| d.token_count)
+            .unwrap_or(0);
+        eprintln!(
+            "[perf] t={:>4.1}s partial_ms={elapsed:>5} tokens={tokens}",
+            cumulative as f64 / 16_000.0
+        );
+    }
+
+    // Relative shape guard (hardware-portable): the average per-partial engine
+    // time over the second half of the utterance must not blow up versus the
+    // first half. O(n^2) partial decode makes this ratio grow without bound;
+    // the incremental fix keeps it near-flat.
+    let mid = per_partial_ms.len() / 2;
+    let avg = |slice: &[u128]| slice.iter().sum::<u128>() as f64 / slice.len().max(1) as f64;
+    let first_half = avg(&per_partial_ms[..mid]);
+    let second_half = avg(&per_partial_ms[mid..]);
+    let ratio = second_half / first_half.max(1.0);
+    eprintln!("[perf] first_half_avg_ms={first_half:.1} second_half_avg_ms={second_half:.1} ratio={ratio:.2}");
+
+    assert!(
+        ratio < 3.0,
+        "per-partial engine time scales with utterance length (ratio {ratio:.2} >= 3.0): \
+         partial decode is not incremental"
+    );
+}
+```
+
+- [ ] **Step 2: Run it against current code to confirm it FAILS**
+
+Run: `cargo test --manifest-path native/Cargo.toml --test streaming_perf -- --ignored partial_cost_does_not_scale --nocapture`
+Expected: FAIL — `ratio` well above 3.0 (per-partial time climbs as the utterance grows). This is the red test that Tasks 3–4 turn green. Note the printed ratio in the commit message.
+
+- [ ] **Step 3: Commit the red guard**
+
+```bash
+git add native/tests/streaming_perf.rs
+git commit -m "test: red perf guard — partial decode scales O(n^2) with utterance length"
+```
+
+---
+
+## Task 3: Incremental cross-KV cache (fix part A, bit-identical)
+
+**Files:**
+- Modify: `native/src/adapters/moonshine.rs`
+
+**Interfaces:**
+- Consumes: existing `OrtMoonshineInference`, `StreamingState`, `compute_cross_kv`, `encode_available`.
+- Produces: cross-KV that is projected per newly-appended memory frame and cached, with unchanged decoder-visible tensors.
+
+- [ ] **Step 1: Write the cross-KV equivalence unit test**
+
+In `moonshine.rs` `#[cfg(test)] mod tests`, add (env-gated like the existing local-model test):
+
+```rust
+#[test]
+#[ignore = "requires MOONSHINE_MODEL_PATH pointing to local streaming assets"]
+fn cross_kv_projection_is_per_frame_independent() {
+    let model_path = std::env::var("MOONSHINE_MODEL_PATH")
+        .expect("MOONSHINE_MODEL_PATH must point to frontend.ort");
+    let mut inf = OrtMoonshineInference::load(
+        Path::new(&model_path),
+        GpuConfig { use_gpu: false },
+    )
+    .unwrap();
+
+    // Build encoder memory from ~2 s of the fixture without finalizing.
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/audio/7021-79740-0000.wav");
+    let mut reader = hound::WavReader::open(fixture).unwrap();
+    let samples: Vec<i16> = reader.samples::<i16>().map(Result::unwrap).collect();
+    inf.accept_audio(&samples[..32_000]).unwrap();
+    inf.encode_available(false).unwrap();
+    assert!(inf.state.memory_len > 4, "need enough memory frames to split");
+
+    // Full projection over all memory.
+    let full = project_cross_kv_full(&mut inf.cross_kv, &inf.state.memory, inf.state.memory_len, &inf.config);
+    // Projection over a prefix of memory frames.
+    let half = inf.state.memory_len / 2;
+    let prefix_len = half * inf.config.decoder_dim;
+    let prefix = project_cross_kv_full(&mut inf.cross_kv, &inf.state.memory[..prefix_len], half, &inf.config);
+
+    // k_cross layout is [depth, 1, nheads, cross_len, head_dim]; the prefix must
+    // equal the full projection truncated to the first `half` cross positions.
+    assert_cross_prefix_matches(&full, &prefix, half, inf.state.memory_len, &inf.config);
+}
+```
+
+Add the two `#[cfg(test)]` helpers `project_cross_kv_full` (runs the `cross_kv` session over a given memory slice, returns `(k, v, cross_len)`) and `assert_cross_prefix_matches` (compares the per-head, per-depth slabs of the prefix against the first `half` positions of the full tensor, `assert!((a-b).abs() < 1e-4)`).
+
+- [ ] **Step 2: Run it to verify the assumption holds (and the test compiles)**
+
+Run: `MOONSHINE_MODEL_PATH=<frontend.ort> cargo test --manifest-path native/Cargo.toml -p local-dictation-sidecar cross_kv_projection_is_per_frame_independent -- --ignored --nocapture`
+Expected: PASS — proves cross-KV is per-frame independent, so incremental caching is lossless. (If it FAILS, stop: the incremental-cache design assumption is wrong and cause 1 cannot be optimized this way.)
+
+- [ ] **Step 3: Implement the incremental cache**
+
+In `StreamingState`, the cross-KV fields already exist (`k_cross`, `v_cross`, `cross_len`, `cross_kv_valid`). Change the semantics so they are an append-only cache keyed by `memory_len`:
+
+- Add `cross_kv_frames: usize` to `StreamingState` (how many memory frames are already projected into `k_cross`/`v_cross`). Initialize to 0 in `new`.
+- In `encode_available`, **remove** `self.state.cross_kv_valid = false;`.
+- Rewrite `compute_cross_kv` to project only the newly-appended memory frames and append per-depth/per-head into the cache:
+
+```rust
+fn compute_cross_kv(&mut self) -> Result<(), TranscriptionError> {
+    if self.state.cross_kv_frames == self.state.memory_len {
+        return Ok(());
+    }
+    if self.state.memory_len == 0 {
+        return Err(TranscriptionError::transcription_failure(
+            "Moonshine cross attention",
+            "encoder memory is empty",
+        ));
+    }
+
+    let new_frames = self.state.memory_len - self.state.cross_kv_frames;
+    let offset = self.state.cross_kv_frames * self.config.decoder_dim;
+    let slice = self.state.memory[offset..].to_vec();
+    let memory = value(
+        Array3::from_shape_vec((1, new_frames, self.config.decoder_dim), slice),
+        "cross attention memory (delta)",
+    )?;
+    let outputs = self
+        .cross_kv
+        .run(ort::inputs!["memory" => memory])
+        .map_err(|error| {
+            TranscriptionError::transcription_failure("Moonshine cross attention", &error)
+        })?;
+    let (shape, k_delta) = tensor_f32(output(&outputs, "k_cross")?, "k_cross")?;
+    if shape.len() != 5
+        || dimension(&shape, 0, "k_cross")? != self.config.depth
+        || dimension(&shape, 2, "k_cross")? != self.config.nheads
+        || dimension(&shape, 4, "k_cross")? != self.config.head_dim
+    {
+        return Err(shape_error("k_cross", &shape));
+    }
+    let delta_len = dimension(&shape, 3, "k_cross")?; // == new_frames
+    let expected = self.config.depth * self.config.nheads * delta_len * self.config.head_dim;
+    let v_delta = tensor_f32_data(output(&outputs, "v_cross")?, expected, "v_cross")?;
+    if k_delta.len() != expected {
+        return Err(shape_error("k_cross", &shape));
+    }
+
+    append_cross_kv(
+        &mut self.state.k_cross,
+        &k_delta,
+        self.state.cross_len,
+        delta_len,
+        self.config.depth * self.config.nheads,
+        self.config.head_dim,
+    );
+    append_cross_kv(
+        &mut self.state.v_cross,
+        &v_delta,
+        self.state.cross_len,
+        delta_len,
+        self.config.depth * self.config.nheads,
+        self.config.head_dim,
+    );
+    self.state.cross_len += delta_len;
+    self.state.cross_kv_frames = self.state.memory_len;
+    Ok(())
+}
+```
+
+Add a free function that splices `delta_len` new positions into each `[depth*nheads, seq, head_dim]` slab (the cache is laid out `[depth, 1, nheads, cross_len, head_dim]`, so growing `cross_len` means interleaving per slab, not a flat append):
+
+```rust
+/// Grow a `[slabs, old_len, head_dim]`-shaped flat buffer to `old_len + delta_len`
+/// by inserting each slab's delta rows after its existing rows. `src` is the delta
+/// laid out `[slabs, delta_len, head_dim]`.
+fn append_cross_kv(
+    dst: &mut Vec<f32>,
+    src: &[f32],
+    old_len: usize,
+    delta_len: usize,
+    slabs: usize,
+    head_dim: usize,
+) {
+    let new_len = old_len + delta_len;
+    let mut grown = vec![0.0_f32; slabs * new_len * head_dim];
+    for slab in 0..slabs {
+        let old_slab = slab * old_len * head_dim;
+        let new_slab = slab * new_len * head_dim;
+        let keep = old_len * head_dim;
+        grown[new_slab..new_slab + keep].copy_from_slice(&dst[old_slab..old_slab + keep]);
+        let src_slab = slab * delta_len * head_dim;
+        let add = delta_len * head_dim;
+        grown[new_slab + keep..new_slab + keep + add]
+            .copy_from_slice(&src[src_slab..src_slab + add]);
+    }
+    *dst = grown;
+}
+```
+
+Remove the now-unused `cross_kv_valid` field and its initializer.
+
+- [ ] **Step 4: Verify equivalence + the existing one-shot test still pass**
+
+Run: `MOONSHINE_MODEL_PATH=<frontend.ort> cargo test --manifest-path native/Cargo.toml -p local-dictation-sidecar moonshine -- --ignored --nocapture`
+Expected: PASS for both `cross_kv_projection_is_per_frame_independent` and `local_model_decodes_fixture_in_streaming_chunks` (`final == one_shot` still holds — cross-KV output is bit-identical).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add native/src/adapters/moonshine.rs
+git commit -m "perf: cache Moonshine cross-KV incrementally (bit-identical, O(new frames))"
+```
+
+---
+
+## Task 4: Bounded-tail partial decode (fix part B) + turn the perf guard green
+
+**Files:**
+- Modify: `native/src/adapters/moonshine.rs`
+
+**Interfaces:**
+- Consumes: `OrtMoonshineInference`, `decode_text`, `decode_step`, `reset_decoder`, `StreamingState`.
+- Produces: partial decode whose cost is O(tail window), with the final path unchanged.
+
+- [ ] **Step 1: Write the partial-stability unit test**
+
+In `moonshine.rs` tests (env-gated):
+
+```rust
+#[test]
+#[ignore = "requires MOONSHINE_MODEL_PATH pointing to local streaming assets"]
+fn partials_grow_as_bounded_prefix_and_final_matches_one_shot() {
+    let model_path = std::env::var("MOONSHINE_MODEL_PATH")
+        .expect("MOONSHINE_MODEL_PATH must point to frontend.ort");
+    let mut model = MoonshineAdapter
+        .load_streaming(Path::new(&model_path), GpuConfig { use_gpu: false })
+        .unwrap();
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/audio/7021-79740-0000.wav");
+    let samples: Vec<i16> = hound::WavReader::open(fixture)
+        .unwrap()
+        .samples::<i16>()
+        .map(Result::unwrap)
+        .collect();
+
+    let mut partials: Vec<String> = Vec::new();
+    for chunk in samples.chunks(8_000) {
+        model.accept_audio(chunk).unwrap();
+        let text = model
+            .partial()
+            .unwrap()
+            .segments
+            .first()
+            .map(|s| s.text.clone())
+            .unwrap_or_default();
+        if !text.is_empty() {
+            partials.push(text);
+        }
+    }
+    let final_text = model.finalize_utterance().unwrap().segments[0].text.clone();
+
+    // Committed region stability: each partial's first `committed_words` words
+    // (all but the last few tail words) must remain a prefix of the next partial.
+    for pair in partials.windows(2) {
+        let earlier: Vec<&str> = pair[0].split_whitespace().collect();
+        let later: Vec<&str> = pair[1].split_whitespace().collect();
+        let committed = earlier.len().saturating_sub(BOUNDED_TAIL_WORDS);
+        assert!(
+            later.len() >= committed
+                && earlier[..committed] == later[..committed],
+            "committed prefix changed:\n  {}\n  {}",
+            pair[0], pair[1]
+        );
+    }
+
+    // Neutrality: streamed final equals a one-shot decode of the same audio.
+    let mut one_shot = MoonshineAdapter
+        .load_streaming(Path::new(&model_path), GpuConfig { use_gpu: false })
+        .unwrap();
+    one_shot.accept_audio(&samples).unwrap();
+    assert_eq!(final_text, one_shot.finalize_utterance().unwrap().segments[0].text);
+}
+```
+
+Add `const BOUNDED_TAIL_WORDS: usize = 6;` near the test (an upper bound on how many trailing words may still revise; a loose ceiling on the token-level window below).
+
+- [ ] **Step 2: Run it to confirm the stability property FAILS on current code**
+
+Run: `MOONSHINE_MODEL_PATH=<frontend.ort> cargo test --manifest-path native/Cargo.toml -p local-dictation-sidecar partials_grow_as_bounded_prefix -- --ignored --nocapture`
+Expected: FAIL — current full-redecode can revise arbitrarily deep in the committed prefix (assertion trips), or (if it happens not to on this clip) it passes only incidentally. Either way, proceed; the fix makes the bound guaranteed.
+
+- [ ] **Step 3: Implement bounded-tail decode**
+
+Add a decode window constant and persistent per-utterance decoder state:
+
+```rust
+/// Tokens at the frontier that may still be revised on the next partial. Older
+/// tokens are committed: their self-KV is retained and never re-decoded. Keeps
+/// per-partial decode O(window) instead of O(total tokens).
+const PARTIAL_REDECODE_WINDOW_TOKENS: usize = 12;
+```
+
+Extend `StreamingState` with:
+
+```rust
+committed_tokens: Vec<i64>, // tokens generated and frozen (self-KV retained)
+```
+
+Initialize `committed_tokens: Vec::new()` in `StreamingState::new`.
+
+Split decoding into an incremental partial path and the unchanged final path. Replace the single `decode_text` with:
+
+```rust
+fn decode_partial(&mut self) -> Result<DecodedTranscript, TranscriptionError> {
+    if self.state.memory_len == 0 {
+        return Ok(DecodedTranscript { reached_eos: false, text: String::new(), token_count: 0 });
+    }
+    self.compute_cross_kv()?;
+
+    // Roll back the self-KV cache to the committed boundary, then re-decode the
+    // frontier window against the (now larger) cross-KV. Older committed tokens
+    // keep their cached self-KV and are never recomputed.
+    let commit = self
+        .state
+        .committed_tokens
+        .len()
+        .saturating_sub(PARTIAL_REDECODE_WINDOW_TOKENS);
+    self.truncate_self_kv(commit);
+    let mut generated = self.state.committed_tokens[..commit].to_vec();
+
+    let duration_seconds = self.state.sample_count as f32 / SAMPLE_RATE as f32;
+    let max_tokens = ((duration_seconds * MAX_TOKENS_PER_SECOND).ceil() as usize)
+        .min(self.config.max_seq_len);
+    let mut current = generated.last().copied().unwrap_or(self.config.bos_id);
+    let mut reached_eos = false;
+
+    while generated.len() < max_tokens {
+        let next = self.decode_step(current)?;
+        if next == self.config.eos_id {
+            reached_eos = true;
+            break;
+        }
+        generated.push(next);
+        current = next;
+    }
+
+    // Freeze everything but the frontier window as the new committed prefix.
+    let new_commit = generated.len().saturating_sub(PARTIAL_REDECODE_WINDOW_TOKENS);
+    self.state.committed_tokens = generated[..new_commit].to_vec();
+
+    Ok(DecodedTranscript {
+        reached_eos,
+        text: self.tokenizer.decode(&generated)?,
+        token_count: generated.len() as u32,
+    })
+}
+```
+
+Add `truncate_self_kv(&mut self, keep_tokens: usize)` that shrinks `k_self`/`v_self` (layout `[depth, 1, nheads, cache_seq_len, head_dim]`) to `keep_tokens` positions and sets `cache_seq_len = keep_tokens` — the inverse-layout analog of `append_cross_kv`. When `commit == 0` it clears the cache (equivalent to `reset_decoder`).
+
+Note: `decode_step` already appends to `k_self`/`v_self` and updates `cache_seq_len`; feeding `current = generated.last()` after truncation resumes generation correctly because the committed tokens' self-KV is retained.
+
+Keep the **final** path unchanged — `decode(is_final=true)` still calls a full `decode_text` (rename the existing body to `decode_final`, unchanged logic: `reset_decoder()` + decode from BOS over full memory). Wire `MoonshineInference::decode`:
+
+```rust
+fn decode(&mut self, is_final: bool) -> Result<DecodedTranscript, TranscriptionError> {
+    if is_final {
+        self.flush_pending_audio()?;
+        self.encode_available(true)?;
+        return self.decode_final();
+    }
+    self.encode_available(false)?;
+    self.decode_partial()
+}
+```
+
+In `reset()` (`StreamingState::new`) the `committed_tokens` reset comes for free.
+
+- [ ] **Step 4: Verify stability + one-shot pass, then the perf guard turns green**
+
+Run: `MOONSHINE_MODEL_PATH=<frontend.ort> cargo test --manifest-path native/Cargo.toml -p local-dictation-sidecar moonshine -- --ignored --nocapture`
+Expected: PASS — `partials_grow_as_bounded_prefix_and_final_matches_one_shot` and `local_model_decodes_fixture_in_streaming_chunks` both green.
+
+Run: `STT_TEST_MOONSHINE_DIR=<dir> cargo test --manifest-path native/Cargo.toml --test streaming_perf -- --ignored partial_cost_does_not_scale --nocapture`
+Expected: PASS — ratio now < 3.0 (per-partial time is flat). Record the before/after ratios.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add native/src/adapters/moonshine.rs
+git commit -m "perf: bounded-tail Moonshine partial decode — O(window), final unchanged"
+```
+
+---
+
+## Task 5: Generalize the driver for streaming + capture partials
+
+**Files:**
+- Modify: `native/tests/common/driver.rs`
+
+**Interfaces:**
+- Consumes: `AppState`, `Command::StartSession`, `Event::TranscriptReady { is_final, revision, .. }`, `SelectedModel::ExternalFile`.
+- Produces:
+  - `pub struct StreamingOutcome { pub partials: Vec<StreamingRevision>, pub final_text: String, pub errors: Vec<String>, pub stopped: bool }`
+  - `pub struct StreamingRevision { pub revision: u32, pub text: String, pub processing_ms: u64 }`
+  - `pub fn stream_in_process(model: SelectedModel, frames: &[Vec<u8>]) -> StreamingOutcome`
+
+- [ ] **Step 1: Write the failing streaming-driver test**
+
+Add to `native/tests/streaming_e2e.rs` (created here):
+
+```rust
+mod common;
+
+use common::model::{require_moonshine_model, MoonshineTier};
+use common::{audio, driver};
+use local_dictation_sidecar::engine::{ModelFamilyId, RuntimeId};
+use local_dictation_sidecar::protocol::SelectedModel;
+
+fn moonshine_selection(frontend: &std::path::Path) -> SelectedModel {
+    SelectedModel::ExternalFile {
+        runtime_id: RuntimeId::OnnxRuntime,
+        family_id: ModelFamilyId::Moonshine,
+        file_path: frontend.display().to_string(),
+    }
+}
+
+#[test]
+#[ignore = "needs Moonshine model + real inference; run with --ignored"]
+fn streaming_emits_partials_then_a_final() {
+    let frontend = require_moonshine_model(MoonshineTier::Tiny);
+    let samples =
+        audio::decode_wav_16k_mono(&common::fixtures_dir().join("audio/7021-79740-0000.wav")).unwrap();
+    let frames = audio::fixture_frames_with_trailing_silence(&samples);
+
+    let outcome = driver::stream_in_process(moonshine_selection(&frontend), &frames);
+
+    assert!(outcome.stopped, "session should stop");
+    assert!(outcome.errors.is_empty(), "errors: {:?}", outcome.errors);
+    assert!(!outcome.partials.is_empty(), "expected at least one partial");
+    assert!(!outcome.final_text.trim().is_empty(), "expected a final transcript");
+    // Revisions are monotonically increasing.
+    let revs: Vec<u32> = outcome.partials.iter().map(|p| p.revision).collect();
+    assert!(revs.windows(2).all(|w| w[1] > w[0]), "revisions must increase: {revs:?}");
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails to compile (`stream_in_process` missing)**
+
+Run: `cargo test --manifest-path native/Cargo.toml --test streaming_e2e -- --ignored`
+Expected: compile error — `stream_in_process` / `StreamingOutcome` not found.
+
+- [ ] **Step 3: Implement `stream_in_process` and refactor `start_session`**
+
+In `driver.rs`, extract the model-selection so both whisper and streaming callers share one path:
+
+- Change `start_session_command` to take `model_selection: SelectedModel` instead of a `model_path: &Path` (and drop the hardcoded whisper `SelectedModel`). Update `transcribe_in_process`/`diarize_in_process` to build the whisper selection and pass it, preserving their public signatures (construct `SelectedModel::ExternalFile { runtime_id: RuntimeId::WhisperCpp, family_id: ModelFamilyId::Whisper, file_path: .. }` internally).
+- Add the streaming driver + outcome:
+
+```rust
+#[derive(Debug, Default, Clone)]
+pub struct StreamingRevision {
+    pub revision: u32,
+    pub text: String,
+    pub processing_ms: u64,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct StreamingOutcome {
+    pub partials: Vec<StreamingRevision>,
+    pub final_text: String,
+    pub errors: Vec<String>,
+    pub stopped: bool,
+}
+
+pub fn stream_in_process(model: SelectedModel, frames: &[Vec<u8>]) -> StreamingOutcome {
+    let catalog = ModelCatalog::load_bundled().expect("bundled catalog should load");
+    let mut app = AppState::new("streaming-e2e", catalog);
+    let session_id = Uuid::new_v4().to_string();
+    let mut outcome = StreamingOutcome::default();
+
+    let (_flow, events) = app.handle_command(Command::StartSession {
+        acceleration_preference: AccelerationPreference::CpuOnly,
+        diarization_enabled: false,
+        include_system_audio: false,
+        language: "en".to_string(),
+        mode: ListeningMode::AlwaysOn,
+        model_selection: model,
+        model_store_path_override: None,
+        session_start_unix_ms: SESSION_START_UNIX_MS,
+        session_id: session_id.clone(),
+        speaking_style: SpeakingStyle::Patient,
+    });
+    apply_streaming_events(&mut app, events, &mut outcome);
+
+    for frame in frames {
+        let events = app.handle_audio_frame(AudioFrame {
+            frame_bytes: frame.clone(),
+            session_id: session_id.clone(),
+        });
+        apply_streaming_events(&mut app, events, &mut outcome);
+        let drained = app.drain_pending_outputs();
+        apply_streaming_events(&mut app, drained, &mut outcome);
+    }
+
+    let (_flow, events) = app.handle_command(Command::StopSession { session_id: session_id.clone() });
+    apply_streaming_events(&mut app, events, &mut outcome);
+
+    let deadline = Instant::now() + DRIVE_TIMEOUT;
+    while !outcome.stopped && Instant::now() < deadline {
+        let events = app.drain_pending_outputs();
+        if events.is_empty() {
+            thread::sleep(POLL_INTERVAL);
+            continue;
+        }
+        apply_streaming_events(&mut app, events, &mut outcome);
+    }
+    outcome
+}
+
+fn apply_streaming_events(app: &mut AppState, events: Vec<Event>, outcome: &mut StreamingOutcome) {
+    for event in events {
+        match event {
+            Event::ContextRequest { correlation_id, .. } => {
+                let (_flow, more) = app.handle_command(Command::ContextResponse {
+                    correlation_id,
+                    context: None,
+                });
+                apply_streaming_events(app, more, outcome);
+            }
+            Event::TranscriptReady { is_final, revision, text, processing_duration_ms, .. } => {
+                let trimmed = text.trim().to_string();
+                if is_final {
+                    if !trimmed.is_empty() {
+                        outcome.final_text = trimmed;
+                    }
+                } else {
+                    outcome.partials.push(StreamingRevision {
+                        revision,
+                        text: trimmed,
+                        processing_ms: processing_duration_ms,
+                    });
+                }
+            }
+            Event::SessionStopped { .. } => outcome.stopped = true,
+            Event::Error { code, message, .. } => outcome.errors.push(format!("{code}: {message}")),
+            _ => {}
+        }
+    }
+}
+```
+
+(Confirm the exact `Event::TranscriptReady` field set against `native/src/protocol.rs:410` and destructure with `..`.)
+
+- [ ] **Step 4: Run the streaming-driver test to verify it passes**
+
+Run: `cargo test --manifest-path native/Cargo.toml --test streaming_e2e -- --ignored streaming_emits_partials_then_a_final --nocapture`
+Expected: PASS. Also run the whisper suite to confirm the refactor didn't break it:
+`STT_TEST_WHISPER_MODEL=<model> cargo test --manifest-path native/Cargo.toml --test transcription_e2e -- --ignored`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add native/tests/common/driver.rs native/tests/streaming_e2e.rs
+git commit -m "test: streaming sidecar driver with partial-timeline capture"
+```
+
+---
+
+## Task 6: Streaming quality suite (WER, final==one-shot, EOS, silence) per tier
+
+**Files:**
+- Create: `native/tests/fixtures/audio/streaming_budgets.json`
+- Modify: `native/tests/common/mod.rs`, `native/tests/streaming_e2e.rs`
+
+**Interfaces:**
+- Consumes: `common::manifest::Corpus`, `common::text::word_error_rate`, `driver::stream_in_process`, `require_moonshine_model`.
+- Produces: `pub struct StreamingBudgets` loader in `common` (fixture id + tier → `max_wer`, `anchors`).
+
+- [ ] **Step 1: Author the streaming budgets file**
+
+Create `native/tests/fixtures/audio/streaming_budgets.json`. Seed with **provisional** budgets, then Step 4 tightens them from observed WER. Reuse the corpus's `reference` text (do not duplicate it here):
+
+```json
+{
+  "tiers": {
+    "tiny":  { "default_max_wer": 0.35 },
+    "small": { "default_max_wer": 0.25 }
+  },
+  "fixtures": [
+    { "id": "7021-79740-0000", "anchors": ["the"] },
+    { "id": "3575-170457-0051", "anchors": [] },
+    { "id": "1580-141084-0047", "anchors": [] },
+    { "id": "5683-32866-0024", "anchors": [] },
+    { "id": "3729-6852-0040", "anchors": [] },
+    { "id": "4446-2271-0004", "anchors": [] },
+    { "id": "4992-23283-0005", "anchors": [] }
+  ]
+}
+```
+
+- [ ] **Step 2: Write the failing per-tier quality test**
+
+Add to `streaming_e2e.rs`:
+
+```rust
+use common::manifest::Corpus;
+use common::text::word_error_rate;
+
+const SAMPLES_PER_MS: usize = 16;
+
+fn run_quality_for_tier(tier: MoonshineTier, default_max_wer: f64) {
+    let frontend = require_moonshine_model(tier);
+    let corpus = Corpus::load();
+    let mut failures = Vec::new();
+
+    for fixture in &corpus.fixtures {
+        let samples = audio::decode_wav_16k_mono(&fixture.audio_path()).unwrap();
+        let frames = audio::fixture_frames_with_trailing_silence(&samples);
+        let outcome = driver::stream_in_process(moonshine_selection(&frontend), &frames);
+
+        let wer = word_error_rate(&fixture.reference, &outcome.final_text);
+        eprintln!("[{:?}][{}] wer={:.3} (budget {:.3})\n  ref: {}\n  got: {}",
+            tier, fixture.id, wer, default_max_wer, fixture.reference, outcome.final_text);
+
+        if wer > default_max_wer {
+            failures.push(format!("{}: wer {:.3} > {:.3}", fixture.id, wer, default_max_wer));
+        }
+        for anchor in &fixture.anchors {
+            if !outcome.final_text.to_lowercase().contains(&anchor.to_lowercase()) {
+                failures.push(format!("{}: missing anchor {anchor:?}", fixture.id));
+            }
+        }
+    }
+    assert!(failures.is_empty(), "streaming quality failures:\n  {}", failures.join("\n  "));
+}
+
+#[test]
+#[ignore = "needs Moonshine tiny model; run with --ignored"]
+fn streaming_quality_tiny_within_budget() {
+    run_quality_for_tier(MoonshineTier::Tiny, 0.35);
+}
+
+#[test]
+#[ignore = "needs Moonshine small model; run with --ignored"]
+fn streaming_quality_small_within_budget() {
+    run_quality_for_tier(MoonshineTier::Small, 0.25);
+}
+```
+
+Add the `final == one-shot` corpus gate and the silence gate:
+
+```rust
+#[test]
+#[ignore = "needs Moonshine tiny model; run with --ignored"]
+fn streaming_final_equals_one_shot_across_corpus() {
+    let frontend = require_moonshine_model(MoonshineTier::Tiny);
+    for fixture in &Corpus::load().fixtures {
+        let samples = audio::decode_wav_16k_mono(&fixture.audio_path()).unwrap();
+        let chunked = driver::stream_in_process(
+            moonshine_selection(&frontend),
+            &audio::fixture_frames_with_trailing_silence(&samples),
+        );
+        // One-shot: a single frame carrying the whole clip.
+        let one_shot = driver::stream_in_process(
+            moonshine_selection(&frontend),
+            &audio::fixture_frames_with_trailing_silence(&samples),
+        );
+        assert_eq!(chunked.final_text, one_shot.final_text, "fixture {}", fixture.id);
+    }
+}
+
+#[test]
+#[ignore = "needs Moonshine tiny model; run with --ignored"]
+fn streaming_silence_produces_no_transcript() {
+    let frontend = require_moonshine_model(MoonshineTier::Tiny);
+    let silence = vec![0_i16; 16_000 * 3];
+    let outcome = driver::stream_in_process(
+        moonshine_selection(&frontend),
+        &audio::fixture_frames_with_trailing_silence(&silence),
+    );
+    assert!(outcome.final_text.trim().is_empty(), "silence hallucinated: {:?}", outcome.final_text);
+}
+```
+
+- [ ] **Step 3: Run to verify (models download on first run)**
+
+Run: `cargo test --manifest-path native/Cargo.toml --test streaming_e2e -- --ignored --nocapture`
+Expected: quality tests execute; the printed WER lines reveal real accuracy.
+
+- [ ] **Step 4: Tighten budgets from observed WER, then re-run**
+
+Set each tier's `default_max_wer` just above the worst observed WER (with headroom, mirroring `manifest.json`'s per-fixture budgets). If a specific fixture is an outlier, promote it to a per-fixture override in `streaming_budgets.json` and have `run_quality_for_tier` consult it. Re-run until green and non-vacuous.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add native/tests/fixtures/audio/streaming_budgets.json native/tests/common/mod.rs native/tests/streaming_e2e.rs
+git commit -m "test: Moonshine streaming quality suite (WER, one-shot equivalence, silence) tiny+small"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Multi-artifact acquisition → Task 1. cross-KV cache (fix A) → Task 3. Bounded-tail decode (fix B) → Task 4. Perf characterize+guard (D2) → Task 2 (red) + Task 4 (green). Driver generalization + partial capture → Task 5. Quality: WER/anchors, final==one-shot, EOS/silence → Task 6 (+ the adapter one-shot in Tasks 3–4). Tiers tiny+small (D3) → Tasks 1 & 6. Bounded-tail (D4) → Task 4. Risks table guards → cross-KV equivalence (Task 3 Step 1), final==one-shot (Tasks 4 & 6). No final-path change (constraint) → Task 4 keeps `decode_final` full. ✅ All spec sections have a task.
+- EOS-reached assertion from the spec's quality list is thin here — fold a `decode_reached_eos == Some(true)` check into Task 6's `run_quality_for_tier` per fixture (diagnostics are on the final `EngineTranscriptOutput`; expose via the driver if needed, otherwise assert at the adapter level in Task 4). **Action:** add that assertion in Task 6 Step 2 alongside anchors.
+
+**Placeholder scan:** No TBD/TODO; every code step carries real code. The two `#[cfg(test)]` helpers in Task 3 (`project_cross_kv_full`, `assert_cross_prefix_matches`) and `truncate_self_kv` in Task 4 are described with exact shape/layout semantics — implement them as the layout inverse of `append_cross_kv`.
+
+**Type consistency:** `MoonshineTier`, `require_moonshine_model`, `stream_in_process`, `StreamingOutcome`/`StreamingRevision`, `moonshine_selection` names are used identically across tasks. `append_cross_kv`/`truncate_self_kv` are paired inverse layout ops. `PARTIAL_REDECODE_WINDOW_TOKENS` (code) vs `BOUNDED_TAIL_WORDS` (test ceiling) are intentionally distinct (token window vs word ceiling).

--- a/docs/specs/streaming-moonshine-test-suite-plan.md
+++ b/docs/specs/streaming-moonshine-test-suite-plan.md
@@ -1,5 +1,14 @@
 # Streaming (Moonshine) Test Suite & Partial-Decode Fix — Implementation Plan
 
+> **⚠️ Implementation deviated from this plan — see "Implementation outcome" in the
+> [spec](streaming-moonshine-test-suite.md) for the authoritative record.** In short:
+> Task 3's incremental cross-KV cache was **reverted** (the tests proved the projection
+> is position-dependent, so the cache corrupted the final decode); the perf win comes
+> entirely from Task 4's bounded-tail decode; and a bug the tests surfaced — partials
+> corrupting the final via divergent encoder memory — was fixed by re-encoding the full
+> memory at finalize (`reset_encoder_emission`, not in this plan). The task steps below
+> are preserved as the original pre-implementation guide.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add streaming (Moonshine) quality + performance integration tests to the sidecar, and eliminate the O(n²) per-partial decode cost with a change that is quality-neutral on the committed transcript.

--- a/docs/specs/streaming-moonshine-test-suite.md
+++ b/docs/specs/streaming-moonshine-test-suite.md
@@ -1,6 +1,7 @@
 # Spec: Streaming (Moonshine) Quality + Performance Test Suite & Partial-Decode Fix
 
-Status: approved for implementation (design decisions locked with the maintainer, below)
+Status: implemented — with two design assumptions falsified during implementation
+(see **Implementation outcome** below). The suite's guards caught both.
 Branch: `test/streaming-moonshine-tests`
 Companion plan: `docs/specs/streaming-moonshine-test-suite-plan.md`
 
@@ -18,6 +19,71 @@ This branch does two things, together:
    the committed transcript by construction, gated by the new quality tests.
 
 The corpus exercises **Moonshine tiny + small** streaming tiers (both catalog models).
+
+## Implementation outcome (what shipped vs. what was designed)
+
+> This section is authoritative where it conflicts with the original design
+> narrative below. The design sections are kept as the reasoning record — and
+> because the two risks they flagged are exactly what fired.
+
+The tests were built first (TDD) and immediately falsified **two** assumptions the
+design leaned on. Both were caught by guards this spec had already listed as risks.
+
+### Finding 1 — cross-KV projection is position-dependent → Fix A reverted
+
+Design cause 1 assumed `k_cross`/`v_cross` are a pure per-frame linear projection of
+encoder memory, so an incremental cache (project only new frames, append) would be
+bit-identical. **False.** The equivalence guard, strengthened to also check a
+*nonzero-offset* suffix, showed a slice projected at absolute offset `i` does **not**
+match the same positions of the full projection (max abs diff ≈ 0.29 on `jfk`): the
+model position-encodes the cross-attention keys. Appending per-delta projections
+corrupts K/V, and because `compute_cross_kv` feeds *both* partial and final decode,
+it corrupted the committed transcript (`jfk` final decoded to **empty**).
+
+**Decision:** revert Fix A entirely. `compute_cross_kv` re-projects the full memory on
+change (cached via `cross_kv_valid` until memory grows). A correct incremental cache
+would need a position-aware cross-KV graph and is deferred as future work. The
+characterization test `cross_kv_projection_is_position_dependent` documents the
+constraint and guards against re-attempting the cache. **Fix A was not needed for the
+perf win** (see Finding 3).
+
+### Finding 2 — partials corrupt the final via divergent encoder memory → real bug fixed
+
+The design's load-bearing claim — "the final transcript is always a fresh full decode,
+so partials cannot affect committed accuracy" — was **also false**, and this was a
+pre-existing latent bug in the shipped engine, not a new regression. `partial()` runs
+`encode_available(false)`, which emits stable encoder frames incrementally through a
+sliding window and holds back the lookahead tail. At finalize, `encode_available(true)`
+only **appended the remaining tail** to that incrementally-built memory rather than
+re-encoding — so the final decode consumed a streaming *approximation* of memory
+(observed max frame diff ≈ 0.84 vs. a one-shot encode), which for `jfk` produced an
+empty final. Isolation probe: `jfk` final is correct fed one-shot **and** correct fed
+in chunks *without* partials, but **empty** fed in chunks *with* partials. Since live
+dictation always requests partials, real final transcripts were exposed.
+
+**Fix:** `decode()` now calls `reset_encoder_emission()` before the final encode,
+discarding the approximate memory and re-encoding all accumulated features in one pass —
+exactly what the one-shot path does. This makes the final decode independent of whether
+or how often partials were requested, so `final == one-shot` now holds *by construction*
+and is proven corpus-wide. This is the branch's most important quality fix.
+
+### Finding 3 — Fix B alone carries the entire perf win
+
+Bounded-tail partial decode (Fix B, kept) is sound and independent of Fix A. With Fix A
+reverted, the perf guard's second-half/first-half per-partial ratio is **1.87** (red
+baseline 4.26, threshold 3.0) — statistically identical to the 1.93 measured with both
+fixes. The cross-KV re-projection is O(memory) per partial but is not the dominant term;
+the quadratic blow-up was the full BOS re-decode, which Fix B bounds.
+
+### Net shipped change
+
+- **Reverted:** incremental cross-KV cache (unsound).
+- **Kept:** bounded-tail partial decode (the perf fix).
+- **Added:** full-memory re-encode at finalize (`reset_encoder_emission`) — fixes a
+  real, pre-existing empty/garbled-final bug.
+- **Tests:** quality (WER + anchors, tiny+small), `final == one-shot` corpus gate,
+  partial stability, EOS/silence, and the relative perf guard — all passing on tiny
+  and small.
 
 ## Decisions and reasoning (locked with the maintainer)
 
@@ -87,45 +153,58 @@ cap engages (and even then each partial redecodes 448 tokens). This is exactly t
 
 ## Why the fix is quality-neutral on the committed transcript
 
-The load-bearing insight: **the final transcript is always a fresh full decode.**
-`finalize_utterance` → `decode_text` resets the decoder and re-decodes the whole
+> **Superseded by Finding 2.** The premise below — that the final decode is
+> automatically independent of the partials — held for the *decoder* (it does reset
+> and re-decode from BOS) but **not** for the *encoder memory* the final decode reads.
+> Partials incrementally emitted memory that the final path then appended to rather
+> than re-encoding, so partials *did* change the committed transcript. The
+> `reset_encoder_emission` fix (Finding 2) restores the guarantee — the reasoning
+> below is now true *because* of that fix, not by default.
+
+The intended insight: **the final transcript is always a fresh full decode.**
+`finalize_utterance` → `decode_final` resets the decoder and re-decodes the whole
 utterance from BOS regardless of anything the partials did. Partials are a *live
 preview* superseded via the revision protocol (`is_final` / `revision`,
 `native/src/protocol.rs`).
 
-Therefore **any optimization to the partial path cannot change the accuracy of the
-committed text.** The O(n²) lives entirely in the preview path.
+The intent was that **any optimization to the partial path cannot change the accuracy
+of the committed text.** That now holds only because the final path also re-encodes
+memory from scratch (Finding 2); it was not true as originally shipped.
 
-- **cross-KV cache (cause 1)** is bit-identical by construction — helps both partial
-  and final, changes no output anywhere.
-- **bounded-tail partial decode (cause 2)** changes only intermediate previews, never
-  the final, because we leave the final path as a full decode. The only measurable
-  effect is on how previews revise mid-utterance, which bounded-tail keeps near-nil.
+- **bounded-tail partial decode (cause 2, kept)** changes only intermediate previews,
+  never the final, because the final path is a full decode over a full re-encode. The
+  only measurable effect is on how previews revise mid-utterance, which bounded-tail
+  keeps near-nil.
+- **cross-KV cache (cause 1, reverted)** was assumed bit-identical; it was not
+  (Finding 1).
 
 The quality suite *proves* this rather than asserting it: `final == one-shot`
-equivalence and the per-fixture WER budgets must hold through the fix.
+equivalence and the per-fixture WER budgets hold through the shipped fixes.
 
 ## The fix (`native/src/adapters/moonshine.rs`)
 
-**(A) Incremental cross-KV cache.** Cache projected `k_cross`/`v_cross` and their
-`cross_len`. In `encode_available`, after extending `memory` by `new_frames`, project
-only the new memory slice through the `cross_kv` graph and append to the cache; remove
-the blanket `cross_kv_valid = false` invalidation. Guarded by an equivalence test:
-`cross_kv(memory)[..n] == cross_kv(memory[..n])` (validates the position-independence
-assumption). Turns O(memory) per partial into O(new frames).
+**(A) Incremental cross-KV cache — designed, then REVERTED (Finding 1).** The plan was
+to project only the new memory slice through `cross_kv` and append. The equivalence
+guard falsified the position-independence assumption, so `compute_cross_kv` keeps
+re-projecting the full memory (cached via `cross_kv_valid` until memory grows). Not
+shipped.
 
-**(B) Bounded-tail partial decode.** Persist the generated token sequence and self-KV
-cache across partials on the open utterance. Each partial:
-- keeps the committed prefix (tokens older than a lookback window `W`) and their
-  self-KV,
+**(B) Bounded-tail partial decode — SHIPPED.** Persist the generated token sequence and
+self-KV cache across partials on the open utterance. Each partial:
+- keeps the committed prefix (tokens older than a lookback window
+  `PARTIAL_REDECODE_WINDOW_TOKENS`) and their self-KV,
 - truncates self-KV to the commit boundary,
-- re-decodes only the tail against the now-larger cross-KV, up to the token cap.
+- re-decodes only the tail against the current cross-KV, up to the token cap.
 
-`W` is a tuning constant (order of a few seconds of tokens) validated by the
-partial-stability test. Turns O(total tokens) per partial into O(`W`).
+The window is a tuning constant (a few seconds of tokens) validated by the
+partial-stability test. Turns O(total tokens) per partial into O(window). This is the
+entire perf win (Finding 3).
 
-**Final path unchanged.** `finalize_utterance` still full-decodes from BOS, so
-`final == one-shot` holds automatically and the equivalence test is the guard.
+**(C) Full-memory re-encode at finalize — SHIPPED (Finding 2).** `decode()` calls
+`reset_encoder_emission()` before the final encode, so `finalize_utterance`
+re-encodes all features in one pass and full-decodes from BOS over authoritative
+memory. This is what makes `final == one-shot` actually true; the equivalence test is
+the guard.
 
 ## Test surface (extends the existing harness)
 
@@ -180,13 +259,13 @@ corpus clips — no new committed audio asset), fed in 0.5 s cadence chunks, cal
 
 ## Risks and their guards
 
-| Risk | Guard |
-| --- | --- |
-| cross-KV is not actually per-frame position-independent | `cross_kv(memory)[..n] == cross_kv(memory[..n])` equivalence test — fix is gated on it |
-| Stable frames encoded during partials differ from the final encode | `final == one-shot` corpus test (end-to-end invariant) |
-| Bounded-tail corrupts decode or destabilizes previews | partial-stability test + finals-match + no-panic |
-| Perf guard flakes on slow/loaded CI | relative shape ratios, not absolute ms; `#[ignore]`d, run with `--ignored` |
-| Model download flakiness / cost | sha-verified cache reuse; env override to point at local assets; suite is opt-in |
+| Risk | Guard | Outcome |
+| --- | --- | --- |
+| cross-KV is not actually per-frame position-independent | `cross_kv_projection_is_position_dependent` equivalence test | **FIRED** (Finding 1) — Fix A reverted |
+| Stable frames encoded during partials differ from the final encode | `final == one-shot` corpus test (end-to-end invariant) | **FIRED** (Finding 2) — fixed via `reset_encoder_emission` |
+| Bounded-tail corrupts decode or destabilizes previews | partial-stability test + finals-match + no-panic | held |
+| Perf guard flakes on slow/loaded CI | relative shape ratios, not absolute ms; `#[ignore]`d, run with `--ignored` | held (ratio 1.87) |
+| Model download flakiness / cost | sha-verified cache reuse; env override to point at local assets; suite is opt-in | held |
 
 ## Non-goals
 
@@ -194,7 +273,11 @@ corpus clips — no new committed audio asset), fed in 0.5 s cadence chunks, cal
   maintainer flagged wanting more streaming models later; that is explicitly out of
   scope here. This branch stays focused on Moonshine quality/perf.
 - Moonshine medium tier.
-- Any change to the final-decode path or the wire/revision protocol.
+- Any change to the wire/revision protocol. (The final-decode path *was* changed —
+  Finding 2 forces a full re-encode at finalize — because the corpus test proved it was
+  producing wrong committed output. The original "no final-path change" intent was
+  incompatible with correctness.)
+- A correct incremental cross-KV cache (deferred; needs a position-aware graph).
 
 ## Run command (documented in the test file)
 

--- a/docs/specs/streaming-moonshine-test-suite.md
+++ b/docs/specs/streaming-moonshine-test-suite.md
@@ -1,0 +1,203 @@
+# Spec: Streaming (Moonshine) Quality + Performance Test Suite & Partial-Decode Fix
+
+Status: approved for implementation (design decisions locked with the maintainer, below)
+Branch: `test/streaming-moonshine-tests`
+Companion plan: `docs/specs/streaming-moonshine-test-suite-plan.md`
+
+## Summary
+
+We shipped the Moonshine v2 streaming engine (`native/src/adapters/moonshine.rs`)
+for live dictation. It works, but partial decoding gets **heavier the longer an
+utterance runs without being finalized** — a real O(n²) cost, confirmed in code.
+
+This branch does two things, together:
+
+1. **Adds streaming integration tests to the sidecar** — quality *and* performance —
+   layered onto the existing `native/tests/` harness rather than forking it.
+2. **Fixes the O(n²) partial-decode cost** with a change that is quality-neutral on
+   the committed transcript by construction, gated by the new quality tests.
+
+The corpus exercises **Moonshine tiny + small** streaming tiers (both catalog models).
+
+## Decisions and reasoning (locked with the maintainer)
+
+These four decisions frame the whole design.
+
+### D1 — Scope: tests + fix in the same branch
+
+The performance symptom is real and the fix is well-bounded, so we do both here.
+The perf tests are written to fail on the current code and pass after the fix (TDD),
+then remain as a permanent regression guard.
+
+### D2 — Perf gate: characterize + **relative** scaling guard (not absolute ms)
+
+Absolute latency budgets are not portable across CI/dev hardware. Instead:
+
+- **Characterization** (always prints): a table of `(cumulative_secs, partial_ms,
+  decode_tokens, cross_kv_ms)` per partial, so a human can see the scaling curve.
+- **Guard** (asserts): per-partial engine time in the *second half* of a long
+  utterance stays within a small factor (≈2–3×) of the *first half*, and cumulative
+  partial work is ~linear. This is hardware-portable: it measures *shape*, not speed.
+  Current code violates it (per-partial time grows with cumulative length); the fix
+  satisfies it.
+
+### D3 — Tiers: Moonshine **tiny + small**
+
+`moonshine_tiny_streaming_en` (fast, 34M) and `moonshine_small_streaming_en` from the
+bundled catalog. Medium is out of scope for the suite (same code path; not worth the
+extra download/runtime). Tiny is the primary fast-feedback tier; small gives a
+quality/latency comparison point.
+
+### D4 — Partials: **bounded-tail re-decode**
+
+For the fix, live-preview partials keep committed self-KV for older tokens and
+re-decode only a recent tail window each partial. This preserves revision exactly
+where revision actually happens (the last few words) at O(n) cost. The alternative
+(append-only) was rejected as slightly lossier on preview revision for no real code
+saving; cross-KV-cache-only was rejected as an incomplete fix.
+
+## The performance problem (grounded in code)
+
+`native/src/adapters/moonshine.rs`, driven by the worker's partial cadence
+(`PARTIAL_CADENCE_MS = 500`, `PARTIAL_CADENCE_SAMPLES = 8_000`, `native/src/worker.rs`).
+
+**Cheap / already incremental (leave alone):** the frontend
+(`process_frontend_chunk`), encoder windowing (`encode_available`), and adapter all
+advance by *new frames only*.
+
+**The O(n²), two independent causes:**
+
+1. **cross-KV recompute** — `compute_cross_kv` (moonshine.rs:722) reprojects K/V over
+   the *entire* encoder `memory` whenever memory grows (`cross_kv_valid` is set false
+   in every `encode_available`). But `k_cross`/`v_cross` are a **per-frame linear
+   projection** of memory with no cross-frame mixing, and memory only grows by
+   *appending stable frames* (partials encode only frames older than
+   `total_lookahead`, so committed frames never change). So the K/V for existing
+   frames are **bit-for-bit identical** whether you project the whole memory or only
+   the new slice — the recompute is pure waste.
+
+2. **full re-decode from BOS every partial** — `decode_text` (moonshine.rs:841) calls
+   `reset_decoder()` and regenerates *every* token from BOS on each `partial()`, up to
+   `duration_secs × MAX_TOKENS_PER_SECOND(6.5)` tokens (capped at `max_seq_len = 448`).
+
+Across an un-finalized utterance of length *T*, the worker fires ~*T*/0.5 s partials,
+each costing O(*T*) → **cumulative O(T²)**, bounded only past ~69 s when the 448-token
+cap engages (and even then each partial redecodes 448 tokens). This is exactly the
+"gets very heavy as I keep talking" symptom.
+
+## Why the fix is quality-neutral on the committed transcript
+
+The load-bearing insight: **the final transcript is always a fresh full decode.**
+`finalize_utterance` → `decode_text` resets the decoder and re-decodes the whole
+utterance from BOS regardless of anything the partials did. Partials are a *live
+preview* superseded via the revision protocol (`is_final` / `revision`,
+`native/src/protocol.rs`).
+
+Therefore **any optimization to the partial path cannot change the accuracy of the
+committed text.** The O(n²) lives entirely in the preview path.
+
+- **cross-KV cache (cause 1)** is bit-identical by construction — helps both partial
+  and final, changes no output anywhere.
+- **bounded-tail partial decode (cause 2)** changes only intermediate previews, never
+  the final, because we leave the final path as a full decode. The only measurable
+  effect is on how previews revise mid-utterance, which bounded-tail keeps near-nil.
+
+The quality suite *proves* this rather than asserting it: `final == one-shot`
+equivalence and the per-fixture WER budgets must hold through the fix.
+
+## The fix (`native/src/adapters/moonshine.rs`)
+
+**(A) Incremental cross-KV cache.** Cache projected `k_cross`/`v_cross` and their
+`cross_len`. In `encode_available`, after extending `memory` by `new_frames`, project
+only the new memory slice through the `cross_kv` graph and append to the cache; remove
+the blanket `cross_kv_valid = false` invalidation. Guarded by an equivalence test:
+`cross_kv(memory)[..n] == cross_kv(memory[..n])` (validates the position-independence
+assumption). Turns O(memory) per partial into O(new frames).
+
+**(B) Bounded-tail partial decode.** Persist the generated token sequence and self-KV
+cache across partials on the open utterance. Each partial:
+- keeps the committed prefix (tokens older than a lookback window `W`) and their
+  self-KV,
+- truncates self-KV to the commit boundary,
+- re-decodes only the tail against the now-larger cross-KV, up to the token cap.
+
+`W` is a tuning constant (order of a few seconds of tokens) validated by the
+partial-stability test. Turns O(total tokens) per partial into O(`W`).
+
+**Final path unchanged.** `finalize_utterance` still full-decodes from BOS, so
+`final == one-shot` holds automatically and the equivalence test is the guard.
+
+## Test surface (extends the existing harness)
+
+New file `native/tests/streaming_e2e.rs`, mirroring `transcription_e2e.rs`. All heavy
+tests are `#[ignore]`d (need model download + real inference) with a documented run
+command, per the existing convention.
+
+Shared-harness changes under `native/tests/common/`:
+
+- **`model.rs`** — add `require_moonshine_model(tier)`. Moonshine is a **7-sibling**
+  catalog model (`frontend.ort` + encoder/adapter/cross_kv/decoder_kv/streaming_config/
+  tokenizer). Download *all* artifacts into a per-tier dir, sha-verify + cache each
+  (reusing the existing `file_sha256` / verified-download machinery), return the
+  `frontend.ort` path. Same priority ladder as whisper: env override → cache → catalog.
+- **`driver.rs`** — generalize `start_session_command` / `start_session_json` to accept
+  a model selection (runtime/family/path) instead of hardcoded whisper. Add
+  streaming-aware capture: a `StreamingOutcome` that records the **partial timeline**
+  (`is_final == false` events with `revision` and per-partial `processing_duration_ms`)
+  distinctly from the **final** transcript. `Event::TranscriptReady` already carries
+  `is_final` + `revision` (`native/src/protocol.rs:410`).
+- Reuse `text.rs` (WER), `manifest.rs` (corpus), `audio.rs` (wav decode + framing)
+  unchanged.
+- **`streaming_budgets.json`** (new, `native/tests/fixtures/audio/`) — per-fixture,
+  per-tier WER budgets + anchor words for Moonshine. Kept separate from the whisper
+  corpus's `manifest.json` so the two engines' budgets don't entangle; audio +
+  reference text are reused from the shared corpus.
+
+## Quality tests (sidecar e2e, in-process driver, per tier, over the corpus)
+
+1. **WER + anchors** per fixture against the streaming budgets.
+2. **`final == one-shot`** — streamed-in-chunks final equals feed-all-then-finalize.
+   Promotes the currently-`#[ignore]`d unit assertion
+   (`local_model_decodes_fixture_in_streaming_chunks`) to a corpus-wide gate. This is
+   the fix's neutrality proof.
+3. **Partial stability** — the committed (non-tail) prefix across successive partials
+   grows monotonically within a bounded backtrack. Directly validates that bounded-tail
+   doesn't destabilize previews.
+4. **EOS reached** on well-formed clips (`decode_reached_eos`), and **silence → empty**
+   (no hallucination on trailing silence).
+
+## Performance harness + guard (adapter-level, precise)
+
+Drives `MoonshineAdapter::load_streaming` directly (isolating the engine from VAD/worker
+noise) with a long single utterance (~40–60 s, assembled **in-memory** by concatenating
+corpus clips — no new committed audio asset), fed in 0.5 s cadence chunks, calling
+`partial()` at each cadence and `finalize_utterance()` once at the end.
+
+- **Characterization** (always prints): per-partial `(cumulative_secs, partial_ms,
+  decode_tokens, cross_kv_ms)`.
+- **Guard** (asserts, per D2): second-half per-partial engine time ≤ small factor ×
+  first-half; cumulative partial work ~linear. Fails on current code, passes after fix.
+
+## Risks and their guards
+
+| Risk | Guard |
+| --- | --- |
+| cross-KV is not actually per-frame position-independent | `cross_kv(memory)[..n] == cross_kv(memory[..n])` equivalence test — fix is gated on it |
+| Stable frames encoded during partials differ from the final encode | `final == one-shot` corpus test (end-to-end invariant) |
+| Bounded-tail corrupts decode or destabilizes previews | partial-stability test + finals-match + no-panic |
+| Perf guard flakes on slow/loaded CI | relative shape ratios, not absolute ms; `#[ignore]`d, run with `--ignored` |
+| Model download flakiness / cost | sha-verified cache reuse; env override to point at local assets; suite is opt-in |
+
+## Non-goals
+
+- Generalizing the streaming adapter interface for *future* streaming engines. The
+  maintainer flagged wanting more streaming models later; that is explicitly out of
+  scope here. This branch stays focused on Moonshine quality/perf.
+- Moonshine medium tier.
+- Any change to the final-decode path or the wire/revision protocol.
+
+## Run command (documented in the test file)
+
+```sh
+cargo test --manifest-path native/Cargo.toml --test streaming_e2e -- --ignored --nocapture
+```

--- a/native/src/adapters/moonshine.rs
+++ b/native/src/adapters/moonshine.rs
@@ -437,7 +437,7 @@ struct StreamingState {
     cache_seq_len: usize,
     conv1_buffer: Vec<f32>,
     conv2_buffer: Vec<f32>,
-    cross_kv_valid: bool,
+    cross_kv_frames: usize,
     cross_len: usize,
     encoder_frames_emitted: usize,
     frame_count: i64,
@@ -462,7 +462,7 @@ impl StreamingState {
             cache_seq_len: 0,
             conv1_buffer: vec![0.0; config.d_model_frontend * 4],
             conv2_buffer: vec![0.0; config.c1 * 4],
-            cross_kv_valid: false,
+            cross_kv_frames: 0,
             cross_len: 0,
             encoder_frames_emitted: 0,
             frame_count: 0,
@@ -715,12 +715,11 @@ impl OrtMoonshineInference {
         self.state.memory_len += new_frames;
         self.state.encoder_frames_emitted = stable_count;
         self.state.adapter_pos_offset += new_frames as i64;
-        self.state.cross_kv_valid = false;
         Ok(())
     }
 
     fn compute_cross_kv(&mut self) -> Result<(), TranscriptionError> {
-        if self.state.cross_kv_valid {
+        if self.state.cross_kv_frames == self.state.memory_len {
             return Ok(());
         }
         if self.state.memory_len == 0 {
@@ -730,12 +729,14 @@ impl OrtMoonshineInference {
             ));
         }
 
+        let new_frames = self.state.memory_len - self.state.cross_kv_frames;
+        let offset = self.state.cross_kv_frames * self.config.decoder_dim;
         let memory = value(
             Array3::from_shape_vec(
-                (1, self.state.memory_len, self.config.decoder_dim),
-                self.state.memory.clone(),
+                (1, new_frames, self.config.decoder_dim),
+                self.state.memory[offset..].to_vec(),
             ),
-            "cross attention memory",
+            "cross attention memory (delta)",
         )?;
         let outputs = self
             .cross_kv
@@ -743,7 +744,7 @@ impl OrtMoonshineInference {
             .map_err(|error| {
                 TranscriptionError::transcription_failure("Moonshine cross attention", &error)
             })?;
-        let (shape, k_cross) = tensor_f32(output(&outputs, "k_cross")?, "k_cross")?;
+        let (shape, k_delta) = tensor_f32(output(&outputs, "k_cross")?, "k_cross")?;
         if shape.len() != 5
             || dimension(&shape, 0, "k_cross")? != self.config.depth
             || dimension(&shape, 2, "k_cross")? != self.config.nheads
@@ -751,17 +752,35 @@ impl OrtMoonshineInference {
         {
             return Err(shape_error("k_cross", &shape));
         }
-        let cross_len = dimension(&shape, 3, "k_cross")?;
-        let expected = self.config.depth * self.config.nheads * cross_len * self.config.head_dim;
-        let v_cross = tensor_f32_data(output(&outputs, "v_cross")?, expected, "v_cross")?;
-        if k_cross.len() != expected {
+        let delta_len = dimension(&shape, 3, "k_cross")?;
+        if delta_len != new_frames {
+            return Err(shape_error("k_cross", &shape));
+        }
+        let expected = self.config.depth * self.config.nheads * delta_len * self.config.head_dim;
+        let v_delta = tensor_f32_data(output(&outputs, "v_cross")?, expected, "v_cross")?;
+        if k_delta.len() != expected {
             return Err(shape_error("k_cross", &shape));
         }
 
-        self.state.k_cross = k_cross;
-        self.state.v_cross = v_cross;
-        self.state.cross_len = cross_len;
-        self.state.cross_kv_valid = true;
+        let slabs = self.config.depth * self.config.nheads;
+        append_cross_kv(
+            &mut self.state.k_cross,
+            &k_delta,
+            self.state.cross_len,
+            delta_len,
+            slabs,
+            self.config.head_dim,
+        );
+        append_cross_kv(
+            &mut self.state.v_cross,
+            &v_delta,
+            self.state.cross_len,
+            delta_len,
+            slabs,
+            self.config.head_dim,
+        );
+        self.state.cross_len += delta_len;
+        self.state.cross_kv_frames = self.state.memory_len;
         Ok(())
     }
 
@@ -871,6 +890,35 @@ impl OrtMoonshineInference {
             token_count: generated.len() as u32,
         })
     }
+}
+
+/// Grow a `[slabs, old_len, head_dim]` flat buffer by interleaving each slab's
+/// `[delta_len, head_dim]` rows after that slab's existing rows.
+fn append_cross_kv(
+    dst: &mut Vec<f32>,
+    src: &[f32],
+    old_len: usize,
+    delta_len: usize,
+    slabs: usize,
+    head_dim: usize,
+) {
+    debug_assert_eq!(dst.len(), slabs * old_len * head_dim);
+    debug_assert_eq!(src.len(), slabs * delta_len * head_dim);
+
+    let new_len = old_len + delta_len;
+    let mut grown = vec![0.0_f32; slabs * new_len * head_dim];
+    for slab in 0..slabs {
+        let old_slab = slab * old_len * head_dim;
+        let new_slab = slab * new_len * head_dim;
+        let keep = old_len * head_dim;
+        grown[new_slab..new_slab + keep].copy_from_slice(&dst[old_slab..old_slab + keep]);
+
+        let src_slab = slab * delta_len * head_dim;
+        let add = delta_len * head_dim;
+        grown[new_slab + keep..new_slab + keep + add]
+            .copy_from_slice(&src[src_slab..src_slab + add]);
+    }
+    *dst = grown;
 }
 
 impl MoonshineInference for OrtMoonshineInference {
@@ -1024,6 +1072,16 @@ mod tests {
     }
 
     #[test]
+    fn append_cross_kv_preserves_each_slab() {
+        let mut cache = vec![1.0, 2.0, 10.0, 20.0];
+        let delta = vec![3.0, 30.0];
+
+        append_cross_kv(&mut cache, &delta, 2, 1, 2, 1);
+
+        assert_eq!(cache, vec![1.0, 2.0, 3.0, 10.0, 20.0, 30.0]);
+    }
+
+    #[test]
     fn probe_reports_missing_sibling() {
         let root = temp_dir("missing-sibling");
         fs::create_dir_all(&root).unwrap();
@@ -1056,6 +1114,55 @@ mod tests {
 
     #[test]
     #[ignore = "requires MOONSHINE_MODEL_PATH pointing to local streaming assets"]
+    fn cross_kv_projection_is_per_frame_independent() {
+        let model_path = std::env::var("MOONSHINE_MODEL_PATH")
+            .expect("MOONSHINE_MODEL_PATH must point to frontend.ort");
+        let mut inference =
+            OrtMoonshineInference::load(Path::new(&model_path), GpuConfig { use_gpu: false })
+                .unwrap();
+
+        let fixture =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/audio/7021-79740-0000.wav");
+        let samples: Vec<i16> = hound::WavReader::open(fixture)
+            .unwrap()
+            .samples::<i16>()
+            .map(Result::unwrap)
+            .collect();
+        inference.accept_audio(&samples[..32_000]).unwrap();
+        inference.encode_available(false).unwrap();
+        assert!(
+            inference.state.memory_len > 4,
+            "need enough memory frames to split"
+        );
+
+        let full = project_cross_kv_full(
+            &mut inference.cross_kv,
+            &inference.state.memory,
+            inference.state.memory_len,
+            &inference.config,
+        )
+        .unwrap();
+        let half = inference.state.memory_len / 2;
+        let prefix_len = half * inference.config.decoder_dim;
+        let prefix = project_cross_kv_full(
+            &mut inference.cross_kv,
+            &inference.state.memory[..prefix_len],
+            half,
+            &inference.config,
+        )
+        .unwrap();
+
+        assert_cross_prefix_matches(
+            &full,
+            &prefix,
+            half,
+            inference.state.memory_len,
+            &inference.config,
+        );
+    }
+
+    #[test]
+    #[ignore = "requires MOONSHINE_MODEL_PATH pointing to local streaming assets"]
     fn local_model_decodes_fixture_in_streaming_chunks() {
         let model_path = std::env::var("MOONSHINE_MODEL_PATH")
             .expect("MOONSHINE_MODEL_PATH must point to frontend.ort");
@@ -1084,6 +1191,67 @@ mod tests {
         assert!(!final_output.segments[0].text.trim().is_empty());
         assert_eq!(final_output.segments[0].end_ms, samples.len() as u64 / 16);
         assert_eq!(final_output, one_shot_output);
+    }
+
+    fn project_cross_kv_full(
+        session: &mut Session,
+        memory: &[f32],
+        memory_len: usize,
+        config: &MoonshineConfig,
+    ) -> Result<(Vec<f32>, Vec<f32>, usize), TranscriptionError> {
+        let memory = value(
+            Array3::from_shape_vec((1, memory_len, config.decoder_dim), memory.to_vec()),
+            "test cross attention memory",
+        )?;
+        let outputs = session
+            .run(ort::inputs!["memory" => memory])
+            .map_err(|error| {
+                TranscriptionError::transcription_failure("test Moonshine cross attention", &error)
+            })?;
+        let (shape, k_cross) = tensor_f32(output(&outputs, "k_cross")?, "k_cross")?;
+        if shape.len() != 5
+            || dimension(&shape, 0, "k_cross")? != config.depth
+            || dimension(&shape, 2, "k_cross")? != config.nheads
+            || dimension(&shape, 4, "k_cross")? != config.head_dim
+        {
+            return Err(shape_error("k_cross", &shape));
+        }
+        let cross_len = dimension(&shape, 3, "k_cross")?;
+        let expected = config.depth * config.nheads * cross_len * config.head_dim;
+        let v_cross = tensor_f32_data(output(&outputs, "v_cross")?, expected, "v_cross")?;
+        if k_cross.len() != expected {
+            return Err(shape_error("k_cross", &shape));
+        }
+        Ok((k_cross, v_cross, cross_len))
+    }
+
+    fn assert_cross_prefix_matches(
+        full: &(Vec<f32>, Vec<f32>, usize),
+        prefix: &(Vec<f32>, Vec<f32>, usize),
+        prefix_len: usize,
+        full_len: usize,
+        config: &MoonshineConfig,
+    ) {
+        assert_eq!(full.2, full_len);
+        assert_eq!(prefix.2, prefix_len);
+        let slabs = config.depth * config.nheads;
+
+        for slab in 0..slabs {
+            for position in 0..prefix_len {
+                for channel in 0..config.head_dim {
+                    let full_index = (slab * full_len + position) * config.head_dim + channel;
+                    let prefix_index = (slab * prefix_len + position) * config.head_dim + channel;
+                    assert!(
+                        (full.0[full_index] - prefix.0[prefix_index]).abs() < 1.0e-4,
+                        "k_cross differs at slab {slab}, position {position}, channel {channel}"
+                    );
+                    assert!(
+                        (full.1[full_index] - prefix.1[prefix_index]).abs() < 1.0e-4,
+                        "v_cross differs at slab {slab}, position {position}, channel {channel}"
+                    );
+                }
+            }
+        }
     }
 
     #[derive(Default)]

--- a/native/src/adapters/moonshine.rs
+++ b/native/src/adapters/moonshine.rs
@@ -18,6 +18,8 @@ use crate::transcription::{
 const SAMPLE_RATE: usize = 16_000;
 const FRONTEND_CHUNK_SAMPLES: usize = 1_280;
 const MAX_TOKENS_PER_SECOND: f32 = 6.5;
+/// Tokens at the partial frontier that may be revised as encoder memory grows.
+const PARTIAL_REDECODE_WINDOW_TOKENS: usize = 12;
 
 const FRONTEND_FILENAME: &str = "frontend.ort";
 const ENCODER_FILENAME: &str = "encoder.ort";
@@ -445,6 +447,7 @@ struct StreamingState {
     k_self: Vec<f32>,
     memory: Vec<f32>,
     memory_len: usize,
+    partial_tokens: Vec<i64>,
     pending_audio: Vec<f32>,
     sample_buffer: Vec<f32>,
     sample_count: usize,
@@ -470,6 +473,7 @@ impl StreamingState {
             k_self: Vec::new(),
             memory: Vec::new(),
             memory_len: 0,
+            partial_tokens: Vec::new(),
             pending_audio: Vec::new(),
             sample_buffer: vec![0.0; 79],
             sample_count: 0,
@@ -790,6 +794,31 @@ impl OrtMoonshineInference {
         self.state.v_self.clear();
     }
 
+    fn truncate_self_kv(&mut self, keep_tokens: usize) {
+        debug_assert!(keep_tokens <= self.state.cache_seq_len);
+        let old_len = self.state.cache_seq_len;
+        let slabs = self.config.depth * self.config.nheads;
+        let head_dim = self.config.head_dim;
+        debug_assert_eq!(self.state.k_self.len(), slabs * old_len * head_dim);
+        debug_assert_eq!(self.state.v_self.len(), slabs * old_len * head_dim);
+
+        let truncate = |cache: &[f32]| {
+            let mut kept = vec![0.0_f32; slabs * keep_tokens * head_dim];
+            for slab in 0..slabs {
+                let source_start = slab * old_len * head_dim;
+                let target_start = slab * keep_tokens * head_dim;
+                let count = keep_tokens * head_dim;
+                kept[target_start..target_start + count]
+                    .copy_from_slice(&cache[source_start..source_start + count]);
+            }
+            kept
+        };
+
+        self.state.k_self = truncate(&self.state.k_self);
+        self.state.v_self = truncate(&self.state.v_self);
+        self.state.cache_seq_len = keep_tokens;
+    }
+
     fn decode_step(&mut self, token: i64) -> Result<i64, TranscriptionError> {
         self.compute_cross_kv()?;
         let token = value(Array2::from_shape_vec((1, 1), vec![token]), "decoder token")?;
@@ -857,7 +886,49 @@ impl OrtMoonshineInference {
             })
     }
 
-    fn decode_text(&mut self) -> Result<DecodedTranscript, TranscriptionError> {
+    fn decode_partial(&mut self) -> Result<DecodedTranscript, TranscriptionError> {
+        if self.state.memory_len == 0 {
+            return Ok(DecodedTranscript {
+                reached_eos: false,
+                text: String::new(),
+                token_count: 0,
+            });
+        }
+
+        self.compute_cross_kv()?;
+        let commit = self
+            .state
+            .partial_tokens
+            .len()
+            .saturating_sub(PARTIAL_REDECODE_WINDOW_TOKENS);
+        self.truncate_self_kv(commit);
+        let mut generated = self.state.partial_tokens[..commit].to_vec();
+
+        let duration_seconds = self.state.sample_count as f32 / SAMPLE_RATE as f32;
+        let max_tokens = ((duration_seconds * MAX_TOKENS_PER_SECOND).ceil() as usize)
+            .min(self.config.max_seq_len);
+        let mut current = generated.last().copied().unwrap_or(self.config.bos_id);
+        let mut reached_eos = false;
+
+        while generated.len() < max_tokens {
+            let next = self.decode_step(current)?;
+            if next == self.config.eos_id {
+                reached_eos = true;
+                break;
+            }
+            generated.push(next);
+            current = next;
+        }
+
+        self.state.partial_tokens.clone_from(&generated);
+        Ok(DecodedTranscript {
+            reached_eos,
+            text: self.tokenizer.decode(&generated)?,
+            token_count: generated.len() as u32,
+        })
+    }
+
+    fn decode_final(&mut self) -> Result<DecodedTranscript, TranscriptionError> {
         if self.state.memory_len == 0 {
             return Ok(DecodedTranscript {
                 reached_eos: false,
@@ -933,9 +1004,11 @@ impl MoonshineInference for OrtMoonshineInference {
     fn decode(&mut self, is_final: bool) -> Result<DecodedTranscript, TranscriptionError> {
         if is_final {
             self.flush_pending_audio()?;
+            self.encode_available(true)?;
+            return self.decode_final();
         }
-        self.encode_available(is_final)?;
-        self.decode_text()
+        self.encode_available(false)?;
+        self.decode_partial()
     }
 
     fn reset(&mut self) {
@@ -1031,6 +1104,8 @@ mod tests {
 
     use super::*;
 
+    const BOUNDED_TAIL_WORDS: usize = 6;
+
     #[test]
     fn capabilities_describe_streaming_english_output() {
         let adapter = MoonshineAdapter;
@@ -1110,6 +1185,60 @@ mod tests {
         assert_eq!(final_output.segments[0].text, "fixture final.");
         assert_eq!(final_output.segments[0].end_ms, 1_000);
         assert_eq!(model.partial().unwrap().segments, Vec::new());
+    }
+
+    #[test]
+    #[ignore = "requires MOONSHINE_MODEL_PATH pointing to local streaming assets"]
+    fn partials_grow_as_bounded_prefix_and_final_matches_one_shot() {
+        let model_path = std::env::var("MOONSHINE_MODEL_PATH")
+            .expect("MOONSHINE_MODEL_PATH must point to frontend.ort");
+        let mut model = MoonshineAdapter
+            .load_streaming(Path::new(&model_path), GpuConfig { use_gpu: false })
+            .unwrap();
+        let fixture =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/audio/7021-79740-0000.wav");
+        let samples: Vec<i16> = hound::WavReader::open(fixture)
+            .unwrap()
+            .samples::<i16>()
+            .map(Result::unwrap)
+            .collect();
+
+        let mut partials = Vec::new();
+        for chunk in samples.chunks(8_000) {
+            model.accept_audio(chunk).unwrap();
+            let text = model
+                .partial()
+                .unwrap()
+                .segments
+                .first()
+                .map(|segment| segment.text.clone())
+                .unwrap_or_default();
+            if !text.is_empty() {
+                partials.push(text);
+            }
+        }
+        let final_text = model.finalize_utterance().unwrap().segments[0].text.clone();
+
+        for pair in partials.windows(2) {
+            let earlier: Vec<&str> = pair[0].split_whitespace().collect();
+            let later: Vec<&str> = pair[1].split_whitespace().collect();
+            let committed = earlier.len().saturating_sub(BOUNDED_TAIL_WORDS);
+            assert!(
+                later.len() >= committed && earlier[..committed] == later[..committed],
+                "committed prefix changed:\n  {}\n  {}",
+                pair[0],
+                pair[1]
+            );
+        }
+
+        let mut one_shot = MoonshineAdapter
+            .load_streaming(Path::new(&model_path), GpuConfig { use_gpu: false })
+            .unwrap();
+        one_shot.accept_audio(&samples).unwrap();
+        let one_shot_text = one_shot.finalize_utterance().unwrap().segments[0]
+            .text
+            .clone();
+        assert_eq!(final_text, one_shot_text);
     }
 
     #[test]

--- a/native/src/adapters/moonshine.rs
+++ b/native/src/adapters/moonshine.rs
@@ -439,7 +439,7 @@ struct StreamingState {
     cache_seq_len: usize,
     conv1_buffer: Vec<f32>,
     conv2_buffer: Vec<f32>,
-    cross_kv_frames: usize,
+    cross_kv_valid: bool,
     cross_len: usize,
     encoder_frames_emitted: usize,
     frame_count: i64,
@@ -465,7 +465,7 @@ impl StreamingState {
             cache_seq_len: 0,
             conv1_buffer: vec![0.0; config.d_model_frontend * 4],
             conv2_buffer: vec![0.0; config.c1 * 4],
-            cross_kv_frames: 0,
+            cross_kv_valid: false,
             cross_len: 0,
             encoder_frames_emitted: 0,
             frame_count: 0,
@@ -719,11 +719,25 @@ impl OrtMoonshineInference {
         self.state.memory_len += new_frames;
         self.state.encoder_frames_emitted = stable_count;
         self.state.adapter_pos_offset += new_frames as i64;
+        self.state.cross_kv_valid = false;
         Ok(())
     }
 
+    /// Project the full encoder memory into cross-attention K/V.
+    ///
+    /// This re-projects the *entire* memory whenever a new frame arrives rather
+    /// than caching prior frames and appending only the delta. The cross-KV
+    /// projection is position-dependent (the model applies rotary position
+    /// encoding to the keys), so a slice projected at absolute offset `i` does
+    /// not equal the same slice projected as a fresh sequence — appending
+    /// per-delta projections yields numerically different K/V that corrupts the
+    /// decode (an incremental cache produced an empty final transcript on the
+    /// `jfk` fixture). See `docs/specs/streaming-moonshine-test-suite.md` for
+    /// the investigation. The per-partial cost of this projection is bounded by
+    /// caching the result until memory changes; making it incremental requires
+    /// a position-aware cross-KV model and is deferred.
     fn compute_cross_kv(&mut self) -> Result<(), TranscriptionError> {
-        if self.state.cross_kv_frames == self.state.memory_len {
+        if self.state.cross_kv_valid {
             return Ok(());
         }
         if self.state.memory_len == 0 {
@@ -733,14 +747,12 @@ impl OrtMoonshineInference {
             ));
         }
 
-        let new_frames = self.state.memory_len - self.state.cross_kv_frames;
-        let offset = self.state.cross_kv_frames * self.config.decoder_dim;
         let memory = value(
             Array3::from_shape_vec(
-                (1, new_frames, self.config.decoder_dim),
-                self.state.memory[offset..].to_vec(),
+                (1, self.state.memory_len, self.config.decoder_dim),
+                self.state.memory.clone(),
             ),
-            "cross attention memory (delta)",
+            "cross attention memory",
         )?;
         let outputs = self
             .cross_kv
@@ -748,7 +760,7 @@ impl OrtMoonshineInference {
             .map_err(|error| {
                 TranscriptionError::transcription_failure("Moonshine cross attention", &error)
             })?;
-        let (shape, k_delta) = tensor_f32(output(&outputs, "k_cross")?, "k_cross")?;
+        let (shape, k_cross) = tensor_f32(output(&outputs, "k_cross")?, "k_cross")?;
         if shape.len() != 5
             || dimension(&shape, 0, "k_cross")? != self.config.depth
             || dimension(&shape, 2, "k_cross")? != self.config.nheads
@@ -756,35 +768,17 @@ impl OrtMoonshineInference {
         {
             return Err(shape_error("k_cross", &shape));
         }
-        let delta_len = dimension(&shape, 3, "k_cross")?;
-        if delta_len != new_frames {
-            return Err(shape_error("k_cross", &shape));
-        }
-        let expected = self.config.depth * self.config.nheads * delta_len * self.config.head_dim;
-        let v_delta = tensor_f32_data(output(&outputs, "v_cross")?, expected, "v_cross")?;
-        if k_delta.len() != expected {
+        let cross_len = dimension(&shape, 3, "k_cross")?;
+        let expected = self.config.depth * self.config.nheads * cross_len * self.config.head_dim;
+        let v_cross = tensor_f32_data(output(&outputs, "v_cross")?, expected, "v_cross")?;
+        if k_cross.len() != expected {
             return Err(shape_error("k_cross", &shape));
         }
 
-        let slabs = self.config.depth * self.config.nheads;
-        append_cross_kv(
-            &mut self.state.k_cross,
-            &k_delta,
-            self.state.cross_len,
-            delta_len,
-            slabs,
-            self.config.head_dim,
-        );
-        append_cross_kv(
-            &mut self.state.v_cross,
-            &v_delta,
-            self.state.cross_len,
-            delta_len,
-            slabs,
-            self.config.head_dim,
-        );
-        self.state.cross_len += delta_len;
-        self.state.cross_kv_frames = self.state.memory_len;
+        self.state.k_cross = k_cross;
+        self.state.v_cross = v_cross;
+        self.state.cross_len = cross_len;
+        self.state.cross_kv_valid = true;
         Ok(())
     }
 
@@ -792,6 +786,32 @@ impl OrtMoonshineInference {
         self.state.cache_seq_len = 0;
         self.state.k_self.clear();
         self.state.v_self.clear();
+    }
+
+    /// Discard incrementally-emitted encoder memory so the next
+    /// `encode_available` re-encodes the whole feature sequence in one pass.
+    ///
+    /// Partial decodes call `encode_available(false)`, which emits stable frames
+    /// through a sliding window as audio arrives and holds back the lookahead
+    /// tail. The resulting memory is a streaming *approximation* — it diverges
+    /// from a single full-sequence encode (observed max frame difference ~0.84
+    /// on the `jfk` fixture, enough to make the final decode emit an empty
+    /// transcript). The committed/final transcript must be authoritative, so
+    /// before the final decode we drop the approximate memory and re-encode all
+    /// accumulated features exactly as the one-shot path does. The frontend
+    /// features themselves are untouched; only the encoder→adapter emission
+    /// state is reset. This makes the final decode independent of whether (or
+    /// how often) partials were requested. See
+    /// `docs/specs/streaming-moonshine-test-suite.md`.
+    fn reset_encoder_emission(&mut self) {
+        self.state.memory.clear();
+        self.state.memory_len = 0;
+        self.state.encoder_frames_emitted = 0;
+        self.state.adapter_pos_offset = 0;
+        self.state.cross_kv_valid = false;
+        self.state.cross_len = 0;
+        self.state.k_cross.clear();
+        self.state.v_cross.clear();
     }
 
     fn truncate_self_kv(&mut self, keep_tokens: usize) {
@@ -963,35 +983,6 @@ impl OrtMoonshineInference {
     }
 }
 
-/// Grow a `[slabs, old_len, head_dim]` flat buffer by interleaving each slab's
-/// `[delta_len, head_dim]` rows after that slab's existing rows.
-fn append_cross_kv(
-    dst: &mut Vec<f32>,
-    src: &[f32],
-    old_len: usize,
-    delta_len: usize,
-    slabs: usize,
-    head_dim: usize,
-) {
-    debug_assert_eq!(dst.len(), slabs * old_len * head_dim);
-    debug_assert_eq!(src.len(), slabs * delta_len * head_dim);
-
-    let new_len = old_len + delta_len;
-    let mut grown = vec![0.0_f32; slabs * new_len * head_dim];
-    for slab in 0..slabs {
-        let old_slab = slab * old_len * head_dim;
-        let new_slab = slab * new_len * head_dim;
-        let keep = old_len * head_dim;
-        grown[new_slab..new_slab + keep].copy_from_slice(&dst[old_slab..old_slab + keep]);
-
-        let src_slab = slab * delta_len * head_dim;
-        let add = delta_len * head_dim;
-        grown[new_slab + keep..new_slab + keep + add]
-            .copy_from_slice(&src[src_slab..src_slab + add]);
-    }
-    *dst = grown;
-}
-
 impl MoonshineInference for OrtMoonshineInference {
     fn accept_audio(&mut self, samples: &[i16]) -> Result<(), TranscriptionError> {
         self.state.sample_count += samples.len();
@@ -1004,6 +995,7 @@ impl MoonshineInference for OrtMoonshineInference {
     fn decode(&mut self, is_final: bool) -> Result<DecodedTranscript, TranscriptionError> {
         if is_final {
             self.flush_pending_audio()?;
+            self.reset_encoder_emission();
             self.encode_available(true)?;
             return self.decode_final();
         }
@@ -1147,16 +1139,6 @@ mod tests {
     }
 
     #[test]
-    fn append_cross_kv_preserves_each_slab() {
-        let mut cache = vec![1.0, 2.0, 10.0, 20.0];
-        let delta = vec![3.0, 30.0];
-
-        append_cross_kv(&mut cache, &delta, 2, 1, 2, 1);
-
-        assert_eq!(cache, vec![1.0, 2.0, 3.0, 10.0, 20.0, 30.0]);
-    }
-
-    #[test]
     fn probe_reports_missing_sibling() {
         let root = temp_dir("missing-sibling");
         fs::create_dir_all(&root).unwrap();
@@ -1241,9 +1223,18 @@ mod tests {
         assert_eq!(final_text, one_shot_text);
     }
 
+    /// Characterizes why the cross-KV projection cannot be cached incrementally.
+    ///
+    /// A prefix slice projected on its own matches the full projection (it sits
+    /// at the same absolute offsets), but a suffix slice projected as a fresh
+    /// sequence does *not* match the corresponding positions of the full
+    /// projection — the model position-encodes the keys, so absolute offset
+    /// matters. This is the evidence behind `compute_cross_kv` re-projecting the
+    /// whole memory each time; appending per-delta projections corrupts the
+    /// decode. See `docs/specs/streaming-moonshine-test-suite.md`.
     #[test]
     #[ignore = "requires MOONSHINE_MODEL_PATH pointing to local streaming assets"]
-    fn cross_kv_projection_is_per_frame_independent() {
+    fn cross_kv_projection_is_position_dependent() {
         let model_path = std::env::var("MOONSHINE_MODEL_PATH")
             .expect("MOONSHINE_MODEL_PATH must point to frontend.ort");
         let mut inference =
@@ -1280,13 +1271,40 @@ mod tests {
             &inference.config,
         )
         .unwrap();
+        let suffix = project_cross_kv_full(
+            &mut inference.cross_kv,
+            &inference.state.memory[prefix_len..],
+            inference.state.memory_len - half,
+            &inference.config,
+        )
+        .unwrap();
 
-        assert_cross_prefix_matches(
+        // A prefix at offset 0 reproduces the full projection exactly.
+        let prefix_diff = cross_slice_max_abs_diff(
             &full,
             &prefix,
+            0,
             half,
             inference.state.memory_len,
             &inference.config,
+        );
+        assert!(
+            prefix_diff < 1.0e-4,
+            "prefix projection should match full projection, got max diff {prefix_diff}"
+        );
+
+        // A suffix at a nonzero offset does not — incremental caching is invalid.
+        let suffix_diff = cross_slice_max_abs_diff(
+            &full,
+            &suffix,
+            half,
+            inference.state.memory_len - half,
+            inference.state.memory_len,
+            &inference.config,
+        );
+        assert!(
+            suffix_diff > 1.0e-2,
+            "suffix projection should diverge from full (position-dependent), got max diff {suffix_diff}"
         );
     }
 
@@ -1354,33 +1372,33 @@ mod tests {
         Ok((k_cross, v_cross, cross_len))
     }
 
-    fn assert_cross_prefix_matches(
+    /// Max absolute difference between a projected slice and the corresponding
+    /// `[start, start + slice_len)` window of the full projection, across k and v.
+    fn cross_slice_max_abs_diff(
         full: &(Vec<f32>, Vec<f32>, usize),
-        prefix: &(Vec<f32>, Vec<f32>, usize),
-        prefix_len: usize,
+        slice: &(Vec<f32>, Vec<f32>, usize),
+        start: usize,
+        slice_len: usize,
         full_len: usize,
         config: &MoonshineConfig,
-    ) {
+    ) -> f32 {
         assert_eq!(full.2, full_len);
-        assert_eq!(prefix.2, prefix_len);
+        assert_eq!(slice.2, slice_len);
         let slabs = config.depth * config.nheads;
+        let mut max_diff = 0.0_f32;
 
         for slab in 0..slabs {
-            for position in 0..prefix_len {
+            for position in 0..slice_len {
                 for channel in 0..config.head_dim {
-                    let full_index = (slab * full_len + position) * config.head_dim + channel;
-                    let prefix_index = (slab * prefix_len + position) * config.head_dim + channel;
-                    assert!(
-                        (full.0[full_index] - prefix.0[prefix_index]).abs() < 1.0e-4,
-                        "k_cross differs at slab {slab}, position {position}, channel {channel}"
-                    );
-                    assert!(
-                        (full.1[full_index] - prefix.1[prefix_index]).abs() < 1.0e-4,
-                        "v_cross differs at slab {slab}, position {position}, channel {channel}"
-                    );
+                    let full_index =
+                        (slab * full_len + start + position) * config.head_dim + channel;
+                    let slice_index = (slab * slice_len + position) * config.head_dim + channel;
+                    max_diff = max_diff.max((full.0[full_index] - slice.0[slice_index]).abs());
+                    max_diff = max_diff.max((full.1[full_index] - slice.1[slice_index]).abs());
                 }
             }
         }
+        max_diff
     }
 
     #[derive(Default)]

--- a/native/src/adapters/moonshine.rs
+++ b/native/src/adapters/moonshine.rs
@@ -354,6 +354,7 @@ impl MoonshineTokenizer {
     }
 }
 
+#[derive(Default)]
 struct DecodedTranscript {
     reached_eos: bool,
     text: String,
@@ -723,19 +724,9 @@ impl OrtMoonshineInference {
         Ok(())
     }
 
-    /// Project the full encoder memory into cross-attention K/V.
-    ///
-    /// This re-projects the *entire* memory whenever a new frame arrives rather
-    /// than caching prior frames and appending only the delta. The cross-KV
-    /// projection is position-dependent (the model applies rotary position
-    /// encoding to the keys), so a slice projected at absolute offset `i` does
-    /// not equal the same slice projected as a fresh sequence — appending
-    /// per-delta projections yields numerically different K/V that corrupts the
-    /// decode (an incremental cache produced an empty final transcript on the
-    /// `jfk` fixture). See `docs/specs/streaming-moonshine-test-suite.md` for
-    /// the investigation. The per-partial cost of this projection is bounded by
-    /// caching the result until memory changes; making it incremental requires
-    /// a position-aware cross-KV model and is deferred.
+    /// Project all encoder memory whenever it changes. Cross-KV keys are
+    /// position-dependent, so projecting and appending only new frames corrupts
+    /// decoding. See `docs/specs/streaming-moonshine-test-suite.md`.
     fn compute_cross_kv(&mut self) -> Result<(), TranscriptionError> {
         if self.state.cross_kv_valid {
             return Ok(());
@@ -788,21 +779,9 @@ impl OrtMoonshineInference {
         self.state.v_self.clear();
     }
 
-    /// Discard incrementally-emitted encoder memory so the next
-    /// `encode_available` re-encodes the whole feature sequence in one pass.
-    ///
-    /// Partial decodes call `encode_available(false)`, which emits stable frames
-    /// through a sliding window as audio arrives and holds back the lookahead
-    /// tail. The resulting memory is a streaming *approximation* — it diverges
-    /// from a single full-sequence encode (observed max frame difference ~0.84
-    /// on the `jfk` fixture, enough to make the final decode emit an empty
-    /// transcript). The committed/final transcript must be authoritative, so
-    /// before the final decode we drop the approximate memory and re-encode all
-    /// accumulated features exactly as the one-shot path does. The frontend
-    /// features themselves are untouched; only the encoder→adapter emission
-    /// state is reset. This makes the final decode independent of whether (or
-    /// how often) partials were requested. See
-    /// `docs/specs/streaming-moonshine-test-suite.md`.
+    /// Discard approximate streaming memory so finalization re-encodes all
+    /// accumulated features exactly as the one-shot path does. This keeps final
+    /// output independent of partial cadence.
     fn reset_encoder_emission(&mut self) {
         self.state.memory.clear();
         self.state.memory_len = 0;
@@ -906,24 +885,10 @@ impl OrtMoonshineInference {
             })
     }
 
-    fn decode_partial(&mut self) -> Result<DecodedTranscript, TranscriptionError> {
-        if self.state.memory_len == 0 {
-            return Ok(DecodedTranscript {
-                reached_eos: false,
-                text: String::new(),
-                token_count: 0,
-            });
-        }
-
-        self.compute_cross_kv()?;
-        let commit = self
-            .state
-            .partial_tokens
-            .len()
-            .saturating_sub(PARTIAL_REDECODE_WINDOW_TOKENS);
-        self.truncate_self_kv(commit);
-        let mut generated = self.state.partial_tokens[..commit].to_vec();
-
+    fn generate_tokens(
+        &mut self,
+        mut generated: Vec<i64>,
+    ) -> Result<(Vec<i64>, bool), TranscriptionError> {
         let duration_seconds = self.state.sample_count as f32 / SAMPLE_RATE as f32;
         let max_tokens = ((duration_seconds * MAX_TOKENS_PER_SECOND).ceil() as usize)
             .min(self.config.max_seq_len);
@@ -940,46 +905,48 @@ impl OrtMoonshineInference {
             current = next;
         }
 
-        self.state.partial_tokens.clone_from(&generated);
+        Ok((generated, reached_eos))
+    }
+
+    fn decoded_transcript(
+        &self,
+        generated: &[i64],
+        reached_eos: bool,
+    ) -> Result<DecodedTranscript, TranscriptionError> {
         Ok(DecodedTranscript {
             reached_eos,
-            text: self.tokenizer.decode(&generated)?,
+            text: self.tokenizer.decode(generated)?,
             token_count: generated.len() as u32,
         })
     }
 
+    fn decode_partial(&mut self) -> Result<DecodedTranscript, TranscriptionError> {
+        if self.state.memory_len == 0 {
+            return Ok(DecodedTranscript::default());
+        }
+
+        self.compute_cross_kv()?;
+        let commit = self
+            .state
+            .partial_tokens
+            .len()
+            .saturating_sub(PARTIAL_REDECODE_WINDOW_TOKENS);
+        self.truncate_self_kv(commit);
+        let (generated, reached_eos) =
+            self.generate_tokens(self.state.partial_tokens[..commit].to_vec())?;
+
+        self.state.partial_tokens.clone_from(&generated);
+        self.decoded_transcript(&generated, reached_eos)
+    }
+
     fn decode_final(&mut self) -> Result<DecodedTranscript, TranscriptionError> {
         if self.state.memory_len == 0 {
-            return Ok(DecodedTranscript {
-                reached_eos: false,
-                text: String::new(),
-                token_count: 0,
-            });
+            return Ok(DecodedTranscript::default());
         }
 
         self.reset_decoder();
-        let duration_seconds = self.state.sample_count as f32 / SAMPLE_RATE as f32;
-        let max_tokens = ((duration_seconds * MAX_TOKENS_PER_SECOND).ceil() as usize)
-            .min(self.config.max_seq_len);
-        let mut generated = Vec::new();
-        let mut current = self.config.bos_id;
-        let mut reached_eos = false;
-
-        for _ in 0..max_tokens {
-            let next = self.decode_step(current)?;
-            if next == self.config.eos_id {
-                reached_eos = true;
-                break;
-            }
-            generated.push(next);
-            current = next;
-        }
-
-        Ok(DecodedTranscript {
-            reached_eos,
-            text: self.tokenizer.decode(&generated)?,
-            token_count: generated.len() as u32,
-        })
+        let (generated, reached_eos) = self.generate_tokens(Vec::new())?;
+        self.decoded_transcript(&generated, reached_eos)
     }
 }
 
@@ -1096,8 +1063,6 @@ mod tests {
 
     use super::*;
 
-    const BOUNDED_TAIL_WORDS: usize = 6;
-
     #[test]
     fn capabilities_describe_streaming_english_output() {
         let adapter = MoonshineAdapter;
@@ -1169,60 +1134,6 @@ mod tests {
         assert_eq!(model.partial().unwrap().segments, Vec::new());
     }
 
-    #[test]
-    #[ignore = "requires MOONSHINE_MODEL_PATH pointing to local streaming assets"]
-    fn partials_grow_as_bounded_prefix_and_final_matches_one_shot() {
-        let model_path = std::env::var("MOONSHINE_MODEL_PATH")
-            .expect("MOONSHINE_MODEL_PATH must point to frontend.ort");
-        let mut model = MoonshineAdapter
-            .load_streaming(Path::new(&model_path), GpuConfig { use_gpu: false })
-            .unwrap();
-        let fixture =
-            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/audio/7021-79740-0000.wav");
-        let samples: Vec<i16> = hound::WavReader::open(fixture)
-            .unwrap()
-            .samples::<i16>()
-            .map(Result::unwrap)
-            .collect();
-
-        let mut partials = Vec::new();
-        for chunk in samples.chunks(8_000) {
-            model.accept_audio(chunk).unwrap();
-            let text = model
-                .partial()
-                .unwrap()
-                .segments
-                .first()
-                .map(|segment| segment.text.clone())
-                .unwrap_or_default();
-            if !text.is_empty() {
-                partials.push(text);
-            }
-        }
-        let final_text = model.finalize_utterance().unwrap().segments[0].text.clone();
-
-        for pair in partials.windows(2) {
-            let earlier: Vec<&str> = pair[0].split_whitespace().collect();
-            let later: Vec<&str> = pair[1].split_whitespace().collect();
-            let committed = earlier.len().saturating_sub(BOUNDED_TAIL_WORDS);
-            assert!(
-                later.len() >= committed && earlier[..committed] == later[..committed],
-                "committed prefix changed:\n  {}\n  {}",
-                pair[0],
-                pair[1]
-            );
-        }
-
-        let mut one_shot = MoonshineAdapter
-            .load_streaming(Path::new(&model_path), GpuConfig { use_gpu: false })
-            .unwrap();
-        one_shot.accept_audio(&samples).unwrap();
-        let one_shot_text = one_shot.finalize_utterance().unwrap().segments[0]
-            .text
-            .clone();
-        assert_eq!(final_text, one_shot_text);
-    }
-
     /// Characterizes why the cross-KV projection cannot be cached incrementally.
     ///
     /// A prefix slice projected on its own matches the full projection (it sits
@@ -1255,39 +1166,17 @@ mod tests {
             "need enough memory frames to split"
         );
 
-        let full = project_cross_kv_full(
-            &mut inference.cross_kv,
-            &inference.state.memory,
-            inference.state.memory_len,
-            &inference.config,
-        )
-        .unwrap();
-        let half = inference.state.memory_len / 2;
+        let memory = inference.state.memory.clone();
+        let memory_len = inference.state.memory_len;
+        let full = project_cross_kv(&mut inference, &memory, memory_len);
+        let half = memory_len / 2;
         let prefix_len = half * inference.config.decoder_dim;
-        let prefix = project_cross_kv_full(
-            &mut inference.cross_kv,
-            &inference.state.memory[..prefix_len],
-            half,
-            &inference.config,
-        )
-        .unwrap();
-        let suffix = project_cross_kv_full(
-            &mut inference.cross_kv,
-            &inference.state.memory[prefix_len..],
-            inference.state.memory_len - half,
-            &inference.config,
-        )
-        .unwrap();
+        let prefix = project_cross_kv(&mut inference, &memory[..prefix_len], half);
+        let suffix = project_cross_kv(&mut inference, &memory[prefix_len..], memory_len - half);
 
         // A prefix at offset 0 reproduces the full projection exactly.
-        let prefix_diff = cross_slice_max_abs_diff(
-            &full,
-            &prefix,
-            0,
-            half,
-            inference.state.memory_len,
-            &inference.config,
-        );
+        let prefix_diff =
+            cross_slice_max_abs_diff(&full, &prefix, 0, half, memory_len, &inference.config);
         assert!(
             prefix_diff < 1.0e-4,
             "prefix projection should match full projection, got max diff {prefix_diff}"
@@ -1298,8 +1187,8 @@ mod tests {
             &full,
             &suffix,
             half,
-            inference.state.memory_len - half,
-            inference.state.memory_len,
+            memory_len - half,
+            memory_len,
             &inference.config,
         );
         assert!(
@@ -1340,36 +1229,20 @@ mod tests {
         assert_eq!(final_output, one_shot_output);
     }
 
-    fn project_cross_kv_full(
-        session: &mut Session,
+    fn project_cross_kv(
+        inference: &mut OrtMoonshineInference,
         memory: &[f32],
         memory_len: usize,
-        config: &MoonshineConfig,
-    ) -> Result<(Vec<f32>, Vec<f32>, usize), TranscriptionError> {
-        let memory = value(
-            Array3::from_shape_vec((1, memory_len, config.decoder_dim), memory.to_vec()),
-            "test cross attention memory",
-        )?;
-        let outputs = session
-            .run(ort::inputs!["memory" => memory])
-            .map_err(|error| {
-                TranscriptionError::transcription_failure("test Moonshine cross attention", &error)
-            })?;
-        let (shape, k_cross) = tensor_f32(output(&outputs, "k_cross")?, "k_cross")?;
-        if shape.len() != 5
-            || dimension(&shape, 0, "k_cross")? != config.depth
-            || dimension(&shape, 2, "k_cross")? != config.nheads
-            || dimension(&shape, 4, "k_cross")? != config.head_dim
-        {
-            return Err(shape_error("k_cross", &shape));
-        }
-        let cross_len = dimension(&shape, 3, "k_cross")?;
-        let expected = config.depth * config.nheads * cross_len * config.head_dim;
-        let v_cross = tensor_f32_data(output(&outputs, "v_cross")?, expected, "v_cross")?;
-        if k_cross.len() != expected {
-            return Err(shape_error("k_cross", &shape));
-        }
-        Ok((k_cross, v_cross, cross_len))
+    ) -> (Vec<f32>, Vec<f32>, usize) {
+        inference.state.memory = memory.to_vec();
+        inference.state.memory_len = memory_len;
+        inference.state.cross_kv_valid = false;
+        inference.compute_cross_kv().unwrap();
+        (
+            inference.state.k_cross.clone(),
+            inference.state.v_cross.clone(),
+            inference.state.cross_len,
+        )
     }
 
     /// Max absolute difference between a projected slice and the corresponding

--- a/native/tests/common/driver.rs
+++ b/native/tests/common/driver.rs
@@ -41,6 +41,8 @@ const FRAME_HEADER_LEN: usize = 5;
 /// headroom for slow/loaded CI hosts.
 const DRIVE_TIMEOUT: Duration = Duration::from_secs(180);
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
+const STREAMING_CADENCE_FRAMES: usize = 25;
+const STREAMING_CADENCE_DELAY: Duration = Duration::from_millis(500);
 
 const SESSION_START_UNIX_MS: u64 = 1_700_000_000_000;
 
@@ -70,6 +72,21 @@ pub struct TranscriptionOutcome {
     pub errors: Vec<String>,
 }
 
+#[derive(Debug, Default, Clone)]
+pub struct StreamingRevision {
+    pub revision: u32,
+    pub text: String,
+    pub processing_ms: u64,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct StreamingOutcome {
+    pub partials: Vec<StreamingRevision>,
+    pub final_text: String,
+    pub errors: Vec<String>,
+    pub stopped: bool,
+}
+
 // ---------------------------------------------------------------------------
 // In-process driver
 // ---------------------------------------------------------------------------
@@ -81,7 +98,7 @@ pub fn transcribe_in_process(
     frames: &[Vec<u8>],
     style: SpeakingStyle,
 ) -> TranscriptionOutcome {
-    run_in_process(model_path, frames, style, false)
+    run_in_process(whisper_selection(model_path), frames, style, false)
 }
 
 /// Like [`transcribe_in_process`] but with diarization on, so each utterance in
@@ -91,11 +108,11 @@ pub fn diarize_in_process(
     frames: &[Vec<u8>],
     style: SpeakingStyle,
 ) -> TranscriptionOutcome {
-    run_in_process(model_path, frames, style, true)
+    run_in_process(whisper_selection(model_path), frames, style, true)
 }
 
 fn run_in_process(
-    model_path: &Path,
+    model_selection: SelectedModel,
     frames: &[Vec<u8>],
     style: SpeakingStyle,
     diarization_enabled: bool,
@@ -107,7 +124,7 @@ fn run_in_process(
 
     let (_flow, events) = app.handle_command(start_session_command(
         &session_id,
-        model_path,
+        model_selection,
         style,
         diarization_enabled,
     ));
@@ -138,6 +155,57 @@ fn run_in_process(
             continue;
         }
         apply_events(&mut app, events, &mut outcome);
+    }
+
+    outcome
+}
+
+pub fn stream_in_process(model: SelectedModel, frames: &[Vec<u8>]) -> StreamingOutcome {
+    let catalog = ModelCatalog::load_bundled().expect("bundled catalog should load");
+    let mut app = AppState::new("streaming-e2e", catalog);
+    let session_id = Uuid::new_v4().to_string();
+    let mut outcome = StreamingOutcome::default();
+
+    let (_flow, events) = app.handle_command(start_session_command(
+        &session_id,
+        model,
+        SpeakingStyle::Patient,
+        false,
+    ));
+    apply_streaming_events(&mut app, events, &mut outcome);
+
+    let mut cadence_has_audio = false;
+    for (index, frame) in frames.iter().enumerate() {
+        let events = app.handle_audio_frame(AudioFrame {
+            frame_bytes: frame.clone(),
+            session_id: session_id.clone(),
+        });
+        apply_streaming_events(&mut app, events, &mut outcome);
+        let drained = app.drain_pending_outputs();
+        apply_streaming_events(&mut app, drained, &mut outcome);
+
+        cadence_has_audio |= frame.iter().any(|byte| *byte != 0);
+        if (index + 1) % STREAMING_CADENCE_FRAMES == 0 {
+            if cadence_has_audio {
+                thread::sleep(STREAMING_CADENCE_DELAY);
+            }
+            cadence_has_audio = false;
+        }
+    }
+
+    let (_flow, events) = app.handle_command(Command::StopSession {
+        session_id: session_id.clone(),
+    });
+    apply_streaming_events(&mut app, events, &mut outcome);
+
+    let deadline = Instant::now() + DRIVE_TIMEOUT;
+    while !outcome.stopped && Instant::now() < deadline {
+        let events = app.drain_pending_outputs();
+        if events.is_empty() {
+            thread::sleep(POLL_INTERVAL);
+            continue;
+        }
+        apply_streaming_events(&mut app, events, &mut outcome);
     }
 
     outcome
@@ -181,9 +249,48 @@ fn apply_events(app: &mut AppState, events: Vec<Event>, outcome: &mut Transcript
     }
 }
 
+fn apply_streaming_events(app: &mut AppState, events: Vec<Event>, outcome: &mut StreamingOutcome) {
+    for event in events {
+        match event {
+            Event::ContextRequest { correlation_id, .. } => {
+                let (_flow, more) = app.handle_command(Command::ContextResponse {
+                    correlation_id,
+                    context: None,
+                });
+                apply_streaming_events(app, more, outcome);
+            }
+            Event::TranscriptReady {
+                is_final,
+                processing_duration_ms,
+                revision,
+                text,
+                ..
+            } => {
+                let text = text.trim().to_string();
+                if is_final {
+                    if !text.is_empty() {
+                        outcome.final_text = text;
+                    }
+                } else {
+                    outcome.partials.push(StreamingRevision {
+                        revision,
+                        text,
+                        processing_ms: processing_duration_ms,
+                    });
+                }
+            }
+            Event::SessionStopped { .. } => outcome.stopped = true,
+            Event::Error { code, message, .. } => {
+                outcome.errors.push(format!("{code}: {message}"));
+            }
+            _ => {}
+        }
+    }
+}
+
 fn start_session_command(
     session_id: &str,
-    model_path: &Path,
+    model_selection: SelectedModel,
     style: SpeakingStyle,
     diarization_enabled: bool,
 ) -> Command {
@@ -193,15 +300,19 @@ fn start_session_command(
         include_system_audio: false,
         language: "en".to_string(),
         mode: ListeningMode::AlwaysOn,
-        model_selection: SelectedModel::ExternalFile {
-            runtime_id: RuntimeId::WhisperCpp,
-            family_id: ModelFamilyId::Whisper,
-            file_path: model_path.display().to_string(),
-        },
+        model_selection,
         model_store_path_override: None,
         session_start_unix_ms: SESSION_START_UNIX_MS,
         session_id: session_id.to_string(),
         speaking_style: style,
+    }
+}
+
+fn whisper_selection(model_path: &Path) -> SelectedModel {
+    SelectedModel::ExternalFile {
+        runtime_id: RuntimeId::WhisperCpp,
+        family_id: ModelFamilyId::Whisper,
+        file_path: model_path.display().to_string(),
     }
 }
 
@@ -263,9 +374,10 @@ fn run_via_process(
         }
     });
 
+    let model_selection = whisper_selection(model_path);
     write_command_frame(
         &mut stdin,
-        &start_session_json(&session_id, model_path, style, diarization_enabled),
+        &start_session_json(&session_id, &model_selection, style, diarization_enabled),
     );
     for frame in frames {
         write_audio_frame(&mut stdin, &session_id, frame);
@@ -357,7 +469,7 @@ fn apply_json_event(
 
 fn start_session_json(
     session_id: &str,
-    model_path: &Path,
+    model_selection: &SelectedModel,
     style: SpeakingStyle,
     diarization_enabled: bool,
 ) -> serde_json::Value {
@@ -369,12 +481,7 @@ fn start_session_json(
         "accelerationPreference": "cpu_only",
         "diarizationEnabled": diarization_enabled,
         "speakingStyle": speaking_style_wire(style),
-        "modelSelection": {
-            "kind": "external_file",
-            "runtimeId": "whisper_cpp",
-            "familyId": "whisper",
-            "filePath": model_path.display().to_string(),
-        },
+        "modelSelection": model_selection,
         "sessionStartUnixMs": SESSION_START_UNIX_MS,
     })
 }

--- a/native/tests/common/mod.rs
+++ b/native/tests/common/mod.rs
@@ -23,6 +23,8 @@ pub mod text;
 
 use std::path::PathBuf;
 
+use serde::Deserialize;
+
 /// Absolute path to the crate root (`native/`), from `CARGO_MANIFEST_DIR`.
 pub fn crate_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -31,4 +33,62 @@ pub fn crate_dir() -> PathBuf {
 /// Absolute path to the test fixtures directory (`native/tests/fixtures`).
 pub fn fixtures_dir() -> PathBuf {
     crate_dir().join("tests").join("fixtures")
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StreamingBudgets {
+    pub tiers: std::collections::HashMap<String, StreamingTierBudget>,
+    pub fixtures: Vec<StreamingFixtureBudget>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StreamingTierBudget {
+    pub default_max_wer: f64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StreamingFixtureBudget {
+    pub id: String,
+    #[serde(default)]
+    pub anchors: Vec<String>,
+    #[serde(default)]
+    pub max_wer: std::collections::HashMap<String, f64>,
+}
+
+impl StreamingBudgets {
+    pub fn load() -> Self {
+        let path = fixtures_dir().join("audio").join("streaming_budgets.json");
+        let json = std::fs::read_to_string(&path).unwrap_or_else(|error| {
+            panic!(
+                "failed to read streaming budgets {}: {error}",
+                path.display()
+            )
+        });
+        serde_json::from_str(&json).unwrap_or_else(|error| {
+            panic!(
+                "failed to parse streaming budgets {}: {error}",
+                path.display()
+            )
+        })
+    }
+
+    pub fn fixture(&self, fixture_id: &str) -> &StreamingFixtureBudget {
+        self.fixtures
+            .iter()
+            .find(|fixture| fixture.id == fixture_id)
+            .unwrap_or_else(|| panic!("no streaming budget for fixture {fixture_id}"))
+    }
+
+    pub fn max_wer(&self, tier: &str, fixture_id: &str) -> f64 {
+        self.fixture(fixture_id)
+            .max_wer
+            .get(tier)
+            .copied()
+            .unwrap_or_else(|| {
+                self.tiers
+                    .get(tier)
+                    .unwrap_or_else(|| panic!("no streaming budget tier {tier}"))
+                    .default_max_wer
+            })
+    }
 }

--- a/native/tests/common/model.rs
+++ b/native/tests/common/model.rs
@@ -12,6 +12,16 @@ use local_dictation_sidecar::catalog::ModelCatalog;
 use local_dictation_sidecar::engine::{ModelFamilyId, RuntimeId};
 use sha2::{Digest, Sha256};
 
+const MOONSHINE_SIBLINGS: &[&str] = &[
+    "frontend.ort",
+    "encoder.ort",
+    "adapter.ort",
+    "cross_kv.ort",
+    "decoder_kv.ort",
+    "streaming_config.json",
+    "tokenizer.bin",
+];
+
 /// Smallest bundled whisper model — fast to download and load on CPU, which
 /// keeps the suite cheap while still exercising the real inference path.
 pub const TEST_MODEL_ID: &str = "whisper_tiny_en_q8_0";
@@ -65,6 +75,85 @@ pub fn require_whisper_model() -> PathBuf {
              ensure network access so the bundled catalog model can be downloaded."
         )
     })
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum MoonshineTier {
+    Tiny,
+    Small,
+}
+
+impl MoonshineTier {
+    pub fn model_id(self) -> &'static str {
+        match self {
+            Self::Tiny => "moonshine_tiny_streaming_en",
+            Self::Small => "moonshine_small_streaming_en",
+        }
+    }
+}
+
+/// Resolve the `frontend.ort` entry point for a complete Moonshine model.
+///
+/// An explicit `STT_TEST_MOONSHINE_DIR` takes priority. Otherwise all catalog
+/// artifacts are sha-verified and cached in a per-tier directory.
+pub fn resolve_moonshine_model(tier: MoonshineTier) -> Result<PathBuf, String> {
+    if let Some(dir) = std::env::var_os("STT_TEST_MOONSHINE_DIR") {
+        let dir = PathBuf::from(dir);
+        verify_moonshine_siblings(&dir)?;
+        return Ok(dir.join("frontend.ort"));
+    }
+
+    let catalog =
+        ModelCatalog::load_bundled().map_err(|error| format!("load catalog: {error:#}"))?;
+    let model = catalog
+        .find_model(
+            RuntimeId::OnnxRuntime,
+            ModelFamilyId::Moonshine,
+            tier.model_id(),
+        )
+        .ok_or_else(|| format!("bundled catalog has no model {}", tier.model_id()))?;
+
+    let dir = cache_dir().join(tier.model_id());
+    std::fs::create_dir_all(&dir).map_err(|error| format!("create {}: {error}", dir.display()))?;
+
+    for artifact in &model.artifacts {
+        let dest = dir.join(&artifact.filename);
+        let verified = dest.is_file()
+            && file_sha256(&dest).is_ok_and(|digest| digest.eq_ignore_ascii_case(&artifact.sha256));
+        if !verified {
+            download_verified(&artifact.download_url, &artifact.sha256, &dest)?;
+        }
+    }
+
+    verify_moonshine_siblings(&dir)?;
+    Ok(dir.join("frontend.ort"))
+}
+
+pub fn require_moonshine_model(tier: MoonshineTier) -> PathBuf {
+    resolve_moonshine_model(tier).unwrap_or_else(|error| {
+        panic!(
+            "could not obtain Moonshine {tier:?} assets: {error}\n  \
+             Set STT_TEST_MOONSHINE_DIR=/path/to/dir (containing frontend.ort + siblings) \
+             to reuse local assets, or ensure network access for the catalog download."
+        )
+    })
+}
+
+fn verify_moonshine_siblings(dir: &Path) -> Result<(), String> {
+    let missing: Vec<&str> = MOONSHINE_SIBLINGS
+        .iter()
+        .copied()
+        .filter(|filename| !dir.join(filename).is_file())
+        .collect();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "Moonshine model directory {} is missing: {}",
+            dir.display(),
+            missing.join(", ")
+        ))
+    }
 }
 
 fn cache_dir() -> PathBuf {

--- a/native/tests/fixtures/audio/streaming_budgets.json
+++ b/native/tests/fixtures/audio/streaming_budgets.json
@@ -1,0 +1,24 @@
+{
+  "tiers": {
+    "tiny": { "default_max_wer": 0.22 },
+    "small": { "default_max_wer": 0.12 }
+  },
+  "fixtures": [
+    { "id": "jfk", "anchors": ["country"] },
+    { "id": "7021-79740-0000", "anchors": ["children"] },
+    { "id": "3575-170457-0051", "anchors": [] },
+    { "id": "1580-141084-0047", "anchors": [] },
+    {
+      "id": "5683-32866-0024",
+      "anchors": [],
+      "max_wer": { "tiny": 0.75 }
+    },
+    { "id": "3729-6852-0040", "anchors": [] },
+    {
+      "id": "4446-2271-0004",
+      "anchors": [],
+      "max_wer": { "tiny": 0.3 }
+    },
+    { "id": "4992-23283-0005", "anchors": [] }
+  ]
+}

--- a/native/tests/streaming_e2e.rs
+++ b/native/tests/streaming_e2e.rs
@@ -1,0 +1,51 @@
+//! Sidecar-level Moonshine streaming quality suite. `#[ignore]`d: needs model
+//! downloads and real inference. Run:
+//! cargo test --manifest-path native/Cargo.toml --features engine-moonshine \
+//!   --test streaming_e2e -- --ignored --nocapture
+
+mod common;
+
+use common::model::{MoonshineTier, require_moonshine_model};
+use common::{audio, driver};
+use local_dictation_sidecar::engine::{ModelFamilyId, RuntimeId};
+use local_dictation_sidecar::protocol::SelectedModel;
+
+fn moonshine_selection(frontend: &std::path::Path) -> SelectedModel {
+    SelectedModel::ExternalFile {
+        runtime_id: RuntimeId::OnnxRuntime,
+        family_id: ModelFamilyId::Moonshine,
+        file_path: frontend.display().to_string(),
+    }
+}
+
+#[test]
+#[ignore = "needs Moonshine model + real inference; run with --ignored"]
+fn streaming_emits_partials_then_a_final() {
+    let frontend = require_moonshine_model(MoonshineTier::Tiny);
+    let samples =
+        audio::decode_wav_16k_mono(&common::fixtures_dir().join("audio/7021-79740-0000.wav"))
+            .unwrap();
+    let frames = audio::fixture_frames_with_trailing_silence(&samples);
+
+    let outcome = driver::stream_in_process(moonshine_selection(&frontend), &frames);
+
+    assert!(outcome.stopped, "session should stop");
+    assert!(outcome.errors.is_empty(), "errors: {:?}", outcome.errors);
+    assert!(
+        !outcome.partials.is_empty(),
+        "expected at least one partial"
+    );
+    assert!(
+        !outcome.final_text.trim().is_empty(),
+        "expected a final transcript"
+    );
+    let revisions: Vec<u32> = outcome
+        .partials
+        .iter()
+        .map(|partial| partial.revision)
+        .collect();
+    assert!(
+        revisions.windows(2).all(|pair| pair[1] > pair[0]),
+        "revisions must increase: {revisions:?}"
+    );
+}

--- a/native/tests/streaming_e2e.rs
+++ b/native/tests/streaming_e2e.rs
@@ -5,10 +5,22 @@
 
 mod common;
 
+use std::collections::HashSet;
+
+use common::manifest::Corpus;
 use common::model::{MoonshineTier, require_moonshine_model};
+use common::text::{missing_anchors, word_error_rate};
 use common::{audio, driver};
+#[cfg(feature = "engine-moonshine")]
+use local_dictation_sidecar::adapters::moonshine::MoonshineAdapter;
+#[cfg(feature = "engine-moonshine")]
+use local_dictation_sidecar::engine::traits::ModelFamilyAdapter;
 use local_dictation_sidecar::engine::{ModelFamilyId, RuntimeId};
 use local_dictation_sidecar::protocol::SelectedModel;
+#[cfg(feature = "engine-moonshine")]
+use local_dictation_sidecar::transcription::GpuConfig;
+
+const MAX_PARTIAL_BACKTRACK_WORDS: usize = 12;
 
 fn moonshine_selection(frontend: &std::path::Path) -> SelectedModel {
     SelectedModel::ExternalFile {
@@ -47,5 +59,170 @@ fn streaming_emits_partials_then_a_final() {
     assert!(
         revisions.windows(2).all(|pair| pair[1] > pair[0]),
         "revisions must increase: {revisions:?}"
+    );
+}
+
+#[test]
+fn streaming_budgets_cover_the_corpus() {
+    let corpus_ids: HashSet<String> = Corpus::load()
+        .fixtures
+        .into_iter()
+        .map(|fixture| fixture.id)
+        .collect();
+    let budgets = common::StreamingBudgets::load();
+    let budget_ids: HashSet<String> = budgets
+        .fixtures
+        .iter()
+        .map(|fixture| fixture.id.clone())
+        .collect();
+
+    assert_eq!(budget_ids, corpus_ids);
+    for (tier, budget) in &budgets.tiers {
+        assert!(
+            (0.0..1.0).contains(&budget.default_max_wer),
+            "{tier} default WER must be non-vacuous"
+        );
+    }
+}
+
+fn tier_key(tier: MoonshineTier) -> &'static str {
+    match tier {
+        MoonshineTier::Tiny => "tiny",
+        MoonshineTier::Small => "small",
+    }
+}
+
+fn partial_stability_failures(
+    fixture_id: &str,
+    partials: &[driver::StreamingRevision],
+) -> Vec<String> {
+    let mut failures = Vec::new();
+    for pair in partials.windows(2) {
+        let earlier: Vec<&str> = pair[0].text.split_whitespace().collect();
+        let later: Vec<&str> = pair[1].text.split_whitespace().collect();
+        let committed = earlier.len().saturating_sub(MAX_PARTIAL_BACKTRACK_WORDS);
+        if later.len() < committed || earlier[..committed] != later[..committed] {
+            failures.push(format!(
+                "{fixture_id}: partial revision {} changed committed prefix at revision {}",
+                pair[0].revision, pair[1].revision
+            ));
+        }
+    }
+    failures
+}
+
+fn run_quality_for_tier(tier: MoonshineTier) {
+    let frontend = require_moonshine_model(tier);
+    let corpus = Corpus::load();
+    let budgets = common::StreamingBudgets::load();
+    let tier_key = tier_key(tier);
+    let mut failures = Vec::new();
+
+    for fixture in &corpus.fixtures {
+        let samples = audio::decode_wav_16k_mono(&fixture.audio_path()).unwrap();
+        let frames = audio::fixture_frames_with_trailing_silence(&samples);
+        let outcome = driver::stream_in_process(moonshine_selection(&frontend), &frames);
+        let max_wer = budgets.max_wer(tier_key, &fixture.id);
+        let wer = word_error_rate(&fixture.reference, &outcome.final_text);
+        eprintln!(
+            "[{tier:?}][{}] wer={wer:.3} (budget {max_wer:.3})\n  ref: {}\n  got: {}",
+            fixture.id, fixture.reference, outcome.final_text
+        );
+
+        if !outcome.stopped {
+            failures.push(format!("{}: session did not stop", fixture.id));
+        }
+        if !outcome.errors.is_empty() {
+            failures.push(format!("{}: errors: {:?}", fixture.id, outcome.errors));
+        }
+        if outcome.final_text.trim().is_empty() {
+            failures.push(format!("{}: empty final transcript", fixture.id));
+        }
+        if wer > max_wer {
+            failures.push(format!(
+                "{}: WER {wer:.3} exceeded {max_wer:.3}",
+                fixture.id
+            ));
+        }
+        let missing = missing_anchors(&outcome.final_text, &budgets.fixture(&fixture.id).anchors);
+        if !missing.is_empty() {
+            failures.push(format!("{}: missing anchors {missing:?}", fixture.id));
+        }
+        failures.extend(partial_stability_failures(&fixture.id, &outcome.partials));
+    }
+
+    assert!(
+        failures.is_empty(),
+        "streaming quality failures:\n  {}",
+        failures.join("\n  ")
+    );
+}
+
+#[test]
+#[ignore = "needs Moonshine tiny model; run with --ignored"]
+fn streaming_quality_tiny_within_budget() {
+    run_quality_for_tier(MoonshineTier::Tiny);
+}
+
+#[test]
+#[ignore = "needs Moonshine small model; run with --ignored"]
+fn streaming_quality_small_within_budget() {
+    run_quality_for_tier(MoonshineTier::Small);
+}
+
+#[cfg(feature = "engine-moonshine")]
+#[test]
+#[ignore = "needs Moonshine tiny model; run with --ignored"]
+fn streaming_final_equals_one_shot_across_corpus_and_reaches_eos() {
+    let frontend = require_moonshine_model(MoonshineTier::Tiny);
+
+    for fixture in &Corpus::load().fixtures {
+        let samples = audio::decode_wav_16k_mono(&fixture.audio_path()).unwrap();
+        let mut chunked = MoonshineAdapter
+            .load_streaming(frontend.as_path(), GpuConfig { use_gpu: false })
+            .unwrap();
+        for chunk in samples.chunks(8_000) {
+            chunked.accept_audio(chunk).unwrap();
+            chunked.partial().unwrap();
+        }
+        let chunked_final = chunked.finalize_utterance().unwrap();
+
+        let mut one_shot = MoonshineAdapter
+            .load_streaming(frontend.as_path(), GpuConfig { use_gpu: false })
+            .unwrap();
+        one_shot.accept_audio(&samples).unwrap();
+        let one_shot_final = one_shot.finalize_utterance().unwrap();
+
+        assert_eq!(
+            chunked_final, one_shot_final,
+            "final output changed after partials for fixture {}",
+            fixture.id
+        );
+        assert_eq!(
+            chunked_final
+                .diagnostics
+                .first()
+                .and_then(|diagnostics| diagnostics.decode_reached_eos),
+            Some(true),
+            "final decode did not reach EOS for fixture {}",
+            fixture.id
+        );
+    }
+}
+
+#[test]
+#[ignore = "needs Moonshine tiny model; run with --ignored"]
+fn streaming_silence_produces_no_transcript() {
+    let frontend = require_moonshine_model(MoonshineTier::Tiny);
+    let silence = vec![0_i16; 16_000 * 3];
+    let outcome = driver::stream_in_process(
+        moonshine_selection(&frontend),
+        &audio::fixture_frames_with_trailing_silence(&silence),
+    );
+    assert!(outcome.errors.is_empty(), "errors: {:?}", outcome.errors);
+    assert!(
+        outcome.final_text.trim().is_empty(),
+        "silence hallucinated: {:?}",
+        outcome.final_text
     );
 }

--- a/native/tests/streaming_perf.rs
+++ b/native/tests/streaming_perf.rs
@@ -4,7 +4,37 @@
 
 mod common;
 
+use std::time::Instant;
+
 use common::model::{MoonshineTier, require_moonshine_model};
+use local_dictation_sidecar::adapters::moonshine::MoonshineAdapter;
+use local_dictation_sidecar::engine::traits::ModelFamilyAdapter;
+use local_dictation_sidecar::transcription::GpuConfig;
+
+/// 16 kHz mono. One cadence chunk matches the worker's partial cadence.
+const CADENCE_SAMPLES: usize = 8_000;
+
+/// Build about 50 seconds of continuous speech without adding an audio asset.
+fn long_utterance_samples() -> Vec<i16> {
+    let clips = [
+        "audio/7021-79740-0000.wav",
+        "audio/3575-170457-0051.wav",
+        "audio/1580-141084-0047.wav",
+        "audio/4446-2271-0004.wav",
+        "audio/5683-32866-0024.wav",
+    ];
+    let mut samples = Vec::new();
+    while samples.len() < 50 * 16_000 {
+        for clip in clips {
+            let path = common::fixtures_dir().join(clip);
+            samples.extend(common::audio::decode_wav_16k_mono(&path).unwrap());
+            if samples.len() >= 50 * 16_000 {
+                break;
+            }
+        }
+    }
+    samples
+}
 
 #[test]
 #[ignore = "downloads Moonshine assets; run with --ignored"]
@@ -23,4 +53,51 @@ fn moonshine_tiny_assets_resolve_with_all_siblings() {
     ] {
         assert!(dir.join(sibling).is_file(), "missing {sibling}");
     }
+}
+
+#[test]
+#[ignore = "needs Moonshine model + real inference; run with --ignored"]
+fn partial_cost_does_not_scale_with_utterance_length() {
+    let frontend = require_moonshine_model(MoonshineTier::Tiny);
+    let mut model = MoonshineAdapter
+        .load_streaming(frontend.as_path(), GpuConfig { use_gpu: false })
+        .unwrap();
+
+    let samples = long_utterance_samples();
+    let mut per_partial_ms: Vec<u128> = Vec::new();
+    let mut cumulative = 0usize;
+
+    for chunk in samples.chunks(CADENCE_SAMPLES) {
+        model.accept_audio(chunk).unwrap();
+        cumulative += chunk.len();
+        let started = Instant::now();
+        let partial = model.partial().unwrap();
+        let elapsed = started.elapsed().as_millis();
+        per_partial_ms.push(elapsed);
+        let tokens = partial
+            .diagnostics
+            .first()
+            .and_then(|diagnostics| diagnostics.token_count)
+            .unwrap_or(0);
+        eprintln!(
+            "[perf] t={:>4.1}s partial_ms={elapsed:>5} tokens={tokens}",
+            cumulative as f64 / 16_000.0
+        );
+    }
+
+    let mid = per_partial_ms.len() / 2;
+    let avg = |slice: &[u128]| slice.iter().sum::<u128>() as f64 / slice.len().max(1) as f64;
+    let first_half = avg(&per_partial_ms[..mid]);
+    let second_half = avg(&per_partial_ms[mid..]);
+    let ratio = second_half / first_half.max(1.0);
+    eprintln!(
+        "[perf] first_half_avg_ms={first_half:.1} \
+         second_half_avg_ms={second_half:.1} ratio={ratio:.2}"
+    );
+
+    assert!(
+        ratio < 3.0,
+        "per-partial engine time scales with utterance length (ratio {ratio:.2} >= 3.0): \
+         partial decode is not incremental"
+    );
 }

--- a/native/tests/streaming_perf.rs
+++ b/native/tests/streaming_perf.rs
@@ -37,25 +37,6 @@ fn long_utterance_samples() -> Vec<i16> {
 }
 
 #[test]
-#[ignore = "downloads Moonshine assets; run with --ignored"]
-fn moonshine_tiny_assets_resolve_with_all_siblings() {
-    let frontend = require_moonshine_model(MoonshineTier::Tiny);
-    assert_eq!(frontend.file_name().unwrap(), "frontend.ort");
-    let dir = frontend.parent().unwrap();
-    for sibling in [
-        "frontend.ort",
-        "encoder.ort",
-        "adapter.ort",
-        "cross_kv.ort",
-        "decoder_kv.ort",
-        "streaming_config.json",
-        "tokenizer.bin",
-    ] {
-        assert!(dir.join(sibling).is_file(), "missing {sibling}");
-    }
-}
-
-#[test]
 #[ignore = "needs Moonshine model + real inference; run with --ignored"]
 fn partial_cost_does_not_scale_with_utterance_length() {
     let frontend = require_moonshine_model(MoonshineTier::Tiny);

--- a/native/tests/streaming_perf.rs
+++ b/native/tests/streaming_perf.rs
@@ -1,0 +1,26 @@
+//! Adapter-level streaming performance harness (Moonshine). `#[ignore]`d: needs
+//! a model download + real inference. Run:
+//! cargo test --manifest-path native/Cargo.toml --test streaming_perf -- --ignored --nocapture
+
+mod common;
+
+use common::model::{MoonshineTier, require_moonshine_model};
+
+#[test]
+#[ignore = "downloads Moonshine assets; run with --ignored"]
+fn moonshine_tiny_assets_resolve_with_all_siblings() {
+    let frontend = require_moonshine_model(MoonshineTier::Tiny);
+    assert_eq!(frontend.file_name().unwrap(), "frontend.ort");
+    let dir = frontend.parent().unwrap();
+    for sibling in [
+        "frontend.ort",
+        "encoder.ort",
+        "adapter.ort",
+        "cross_kv.ort",
+        "decoder_kv.ort",
+        "streaming_config.json",
+        "tokenizer.bin",
+    ] {
+        assert!(dir.join(sibling).is_file(), "missing {sibling}");
+    }
+}


### PR DESCRIPTION
## What this is

Streaming (Moonshine) **quality + performance integration tests** for the sidecar, plus the partial-decode perf fix they were written to guard. Layered onto the existing `native/tests/` harness rather than forking it. Covers both catalog tiers (`moonshine_tiny_streaming_en`, `moonshine_small_streaming_en`).

The tests did their job: they **falsified two assumptions** the design leaned on and surfaced a **pre-existing, user-facing correctness bug**. Both were caught by guards the spec had already listed as risks. Full record: [`docs/specs/streaming-moonshine-test-suite.md`](../blob/test/streaming-moonshine-tests/docs/specs/streaming-moonshine-test-suite.md) → *Implementation outcome*.

## The performance problem

Moonshine partial decoding got heavier the longer an utterance ran without finalizing — the worker fires a partial every 500 ms, and each `partial()` re-decoded the whole transcript from BOS over growing encoder memory. Cumulative cost was super-linear ("gets very heavy as I keep talking").

## What shipped

| Change | Status | Why |
| --- | --- | --- |
| **Bounded-tail partial decode** | ✅ shipped | Keep committed self-KV, re-decode only a recent tail window each partial. This is the entire perf win. |
| **Full-memory re-encode at finalize** (`reset_encoder_emission`) | ✅ shipped | Fixes a real bug (below). Makes `final == one-shot` true by construction. |
| **Incremental cross-KV cache** | ❌ reverted | Unsound — the projection is position-dependent (below). |

### Finding 1 — cross-KV projection is position-dependent → Fix A reverted

The planned incremental cross-KV cache assumed the K/V projection is per-frame independent, so new memory frames could be projected and appended. The equivalence guard — strengthened to check a **nonzero-offset suffix** — proved otherwise: a slice projected at absolute offset `i` doesn't match the full projection's positions there (max abs diff ≈ 0.29 on `jfk`). The model position-encodes the cross-attention keys. Since `compute_cross_kv` feeds **both** partial and final decode, the corrupted K/V decoded `jfk`'s *final* to **empty**.

→ Reverted. `compute_cross_kv` re-projects full memory on change. The test is repurposed into `cross_kv_projection_is_position_dependent`, which documents the constraint and guards re-attempts. **Fix A was never needed for the perf win** (Finding 3).

### Finding 2 — partials corrupted the final via divergent encoder memory → real bug fixed

The design's load-bearing claim — "the final is always a fresh full decode, so partials can't affect committed accuracy" — held for the *decoder* but **not the encoder memory it reads**. `partial()` emits stable encoder frames incrementally through a sliding window (holding back the lookahead tail); finalize then only **appended the tail** instead of re-encoding, so the final decode consumed a streaming *approximation* of memory (max frame diff ≈ 0.84 on `jfk`) → empty final.

Isolation probe on `jfk`: correct fed one-shot, correct fed in chunks **without** partials, **empty** in chunks **with** partials. Live dictation always requests partials → real committed transcripts were affected. This is a pre-existing engine bug, not a regression from this branch.

→ `decode()` now calls `reset_encoder_emission()` before the final encode, re-encoding all features in one pass exactly like the one-shot path. `final == one-shot` now holds and is proven corpus-wide. **This is the branch's most important quality fix.**

### Finding 3 — Fix B alone carries the perf win

With Fix A reverted, the perf guard's second-half/first-half per-partial ratio is **1.87** (red baseline **4.26**, threshold 3.0) — identical to the 1.93 measured with both fixes. The quadratic blow-up was the full BOS re-decode, which bounded-tail bounds; the cross-KV re-projection was never the dominant term.

## Test surface (extends the existing harness)

- `native/tests/streaming_e2e.rs` — quality: per-fixture WER + anchors (tiny+small), `final == one-shot` corpus gate, partial stability, EOS-reached, silence→empty, and a non-ignored `streaming_budgets_cover_the_corpus` sync check.
- `native/tests/streaming_perf.rs` — adapter-level characterization + **relative** scaling guard (hardware-portable; asserts shape, not ms).
- `native/tests/common/` — multi-artifact Moonshine acquisition (`require_moonshine_model`, 7 sha-verified siblings), generalized model selection + partial-timeline capture in the driver, `StreamingBudgets` loader.
- `native/tests/fixtures/audio/streaming_budgets.json` — per-fixture/per-tier WER budgets + anchors. Budget overrides (5683 tiny 0.75, 4446 tiny 0.30) characterize the tiny model's honest ceiling per decision **D2** (guard egregious regression, not enforce tight WER on a weak tier).

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets --features engine-cohere-transcribe,engine-moonshine,engine-whisper -- -D warnings`, and the full non-ignored `cargo test` — all green (the `check:rust` CI gate).
- Heavy `--ignored` streaming suite run locally against tiny **and** small assets: quality within budget both tiers, `final == one-shot` across all 8 fixtures, perf guard ratio 1.87.

## Locked design decisions (unchanged)

**D1** tests + fix same branch · **D2** relative scaling guard, not absolute ms · **D3** tiny + small tiers · **D4** bounded-tail re-decode.

## Deferred / non-goals

- A **correct** incremental cross-KV cache — needs a position-aware graph; deferred.
- Generalizing the adapter for future streaming engines (explicitly out of scope).
- Moonshine medium tier. No wire/revision-protocol changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
