### PR TITLE
Fix remote LLM toggle dependency

### DIFF
--- a/src/settings/plugin-settings.ts
+++ b/src/settings/plugin-settings.ts
@@ -350,6 +350,12 @@ export function resetLlmPostprocessDefaults(settings: PluginSettings): PluginSet
   };
 }
 
+export function isRemoteLlmEffectivelyEnabled(
+  settings: Pick<PluginSettings, 'llmFeaturesEnabled' | 'llmRemoteFeaturesEnabled'>,
+): boolean {
+  return settings.llmFeaturesEnabled && settings.llmRemoteFeaturesEnabled;
+}
+
 export function shouldRefreshLlmSidebar(previous: PluginSettings, next: PluginSettings): boolean {
   return previous.llmRemoteFeaturesEnabled !== next.llmRemoteFeaturesEnabled;
 }

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -23,6 +23,7 @@ import {
   type DictationAnchor,
   isDictationAnchor,
   isListeningMode,
+  isRemoteLlmEffectivelyEnabled,
   isSpeakingStyle,
   isTimestampClock,
   isTimestampDensity,
@@ -250,10 +251,18 @@ export class LocalSttSettingTab extends PluginSettingTab {
       });
     });
 
-    addToggleSetting(llmCard, this.access, {
-      name: 'Enable remote LLM',
-      desc: 'Allow transcript text and included note context to be sent to OpenRouter. Audio is never sent.',
-      key: 'llmRemoteFeaturesEnabled',
+    const remoteLlmSetting = new Setting(llmCard)
+      .setName('Enable remote LLM')
+      .setDesc(
+        'Allow transcript text and included note context to be sent to OpenRouter. Audio is never sent.',
+      );
+    remoteLlmSetting.addToggle((toggle) => {
+      toggle.setValue(isRemoteLlmEffectivelyEnabled(settings));
+      toggle.setDisabled(!settings.llmFeaturesEnabled);
+      toggle.onChange(async (value) => {
+        if (!this.dependencies.getSettings().llmFeaturesEnabled) return;
+        await this.access.persistOne('llmRemoteFeaturesEnabled', value);
+      });
     });
 
     // --- Engine options ---

--- a/test/plugin-settings.test.ts
+++ b/test/plugin-settings.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../src/llm/presets';
 import {
   DEFAULT_PLUGIN_SETTINGS,
+  isRemoteLlmEffectivelyEnabled,
   LLM_USER_PRESET_MAX_COUNT,
   LLM_USER_PRESET_MAX_DESCRIPTION_CHARS,
   LLM_USER_PRESET_MAX_LABEL_CHARS,
@@ -265,6 +266,20 @@ describe('resolvePluginSettings', () => {
         developerMode: true,
       }),
     ).toBe(false);
+  });
+
+  it.each([
+    ['both enabled', true, true, true],
+    ['global enabled and remote disabled', true, false, false],
+    ['global disabled and remote enabled', false, true, false],
+    ['both disabled', false, false, false],
+  ] as const)('resolves effective remote LLM availability when %s', (_label, llmFeaturesEnabled, llmRemoteFeaturesEnabled, expected) => {
+    expect(
+      isRemoteLlmEffectivelyEnabled({
+        llmFeaturesEnabled,
+        llmRemoteFeaturesEnabled,
+      }),
+    ).toBe(expected);
   });
 
   it('migrates the legacy single Ollama model into per-provider model storage', () => {


### PR DESCRIPTION
## Summary
- Make the remote LLM Settings toggle display as off and disabled when global LLM features are off
- Preserve `llmRemoteFeaturesEnabled` as the remembered remote preference so re-enabling LLM restores the prior remote choice
- Add a small effective-availability helper with focused coverage

Closes #191.

## Tests
- `npm run typecheck`
- `npx biome check src/settings/plugin-settings.ts src/settings/settings-tab.ts test/plugin-settings.test.ts`
- `npx vitest run test/plugin-settings.test.ts`