### PR TITLE
Add smart paragraph timing settings

### DIFF
--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -81,6 +81,8 @@ interface ActiveSessionSnapshot {
   modelSelection: NonNullable<PluginSettings['selectedModel']>;
   modelStorePathOverride: string;
   sessionStartUnixMs: number;
+  smartParagraphLineBreakPauseMs: PluginSettings['smartParagraphLineBreakPauseMs'];
+  smartParagraphParagraphPauseMs: PluginSettings['smartParagraphParagraphPauseMs'];
   speakingStyle: PluginSettings['speakingStyle'];
   timestamps: TranscriptRenderOptions['timestamps'];
   transcriptFormatting: PluginSettings['transcriptFormatting'];
@@ -261,6 +263,8 @@ export class DictationSessionController {
         },
         placement: { anchor: snapshot.dictationAnchor },
         rendererOptions: {
+          smartParagraphLineBreakPauseMs: snapshot.smartParagraphLineBreakPauseMs,
+          smartParagraphParagraphPauseMs: snapshot.smartParagraphParagraphPauseMs,
           timestamps: snapshot.timestamps,
           transcriptFormatting: snapshot.transcriptFormatting,
         },
@@ -1246,6 +1250,8 @@ function createSessionSnapshot(
     modelSelection: selectedModel,
     modelStorePathOverride: settings.modelStorePathOverride,
     sessionStartUnixMs,
+    smartParagraphLineBreakPauseMs: settings.smartParagraphLineBreakPauseMs,
+    smartParagraphParagraphPauseMs: settings.smartParagraphParagraphPauseMs,
     speakingStyle: settings.speakingStyle,
     timestamps: {
       clock: settings.timestampClock,

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -16,7 +16,7 @@ import { type LlmCleanupFailure, type LlmProviderId, ProviderError } from '../ll
 import type { LlmRouter } from '../llm/router';
 import type { Session } from '../session/session';
 import type { StageId, StageOutcome, TranscriptRevision } from '../session/session-journal';
-import type { PluginSettings } from '../settings/plugin-settings';
+import type { PluginSettings, SmartParagraphPauseSettings } from '../settings/plugin-settings';
 import { formatErrorMessage } from '../shared/format-utils';
 import type { PluginLogger } from '../shared/plugin-logger';
 import { truncateLeadingText } from '../shared/text-truncation';
@@ -81,8 +81,7 @@ interface ActiveSessionSnapshot {
   modelSelection: NonNullable<PluginSettings['selectedModel']>;
   modelStorePathOverride: string;
   sessionStartUnixMs: number;
-  smartParagraphLineBreakPauseMs: PluginSettings['smartParagraphLineBreakPauseMs'];
-  smartParagraphParagraphPauseMs: PluginSettings['smartParagraphParagraphPauseMs'];
+  smartParagraphPauses: SmartParagraphPauseSettings;
   speakingStyle: PluginSettings['speakingStyle'];
   timestamps: TranscriptRenderOptions['timestamps'];
   transcriptFormatting: PluginSettings['transcriptFormatting'];
@@ -263,8 +262,7 @@ export class DictationSessionController {
         },
         placement: { anchor: snapshot.dictationAnchor },
         rendererOptions: {
-          smartParagraphLineBreakPauseMs: snapshot.smartParagraphLineBreakPauseMs,
-          smartParagraphParagraphPauseMs: snapshot.smartParagraphParagraphPauseMs,
+          smartParagraphPauses: snapshot.smartParagraphPauses,
           timestamps: snapshot.timestamps,
           transcriptFormatting: snapshot.transcriptFormatting,
         },
@@ -1250,8 +1248,10 @@ function createSessionSnapshot(
     modelSelection: selectedModel,
     modelStorePathOverride: settings.modelStorePathOverride,
     sessionStartUnixMs,
-    smartParagraphLineBreakPauseMs: settings.smartParagraphLineBreakPauseMs,
-    smartParagraphParagraphPauseMs: settings.smartParagraphParagraphPauseMs,
+    smartParagraphPauses: {
+      lineBreakPauseMs: settings.smartParagraphLineBreakPauseMs,
+      paragraphPauseMs: settings.smartParagraphParagraphPauseMs,
+    },
     speakingStyle: settings.speakingStyle,
     timestamps: {
       clock: settings.timestampClock,

--- a/src/settings/plugin-settings.ts
+++ b/src/settings/plugin-settings.ts
@@ -49,6 +49,10 @@ export const DEFAULT_TIMESTAMP_SPARSE_INTERVAL_MS = 30_000;
 export const MIN_TIMESTAMP_SPARSE_INTERVAL_MS = 10_000;
 export const MAX_TIMESTAMP_SPARSE_INTERVAL_MS = 600_000;
 
+export const DEFAULT_SMART_PARAGRAPH_PAUSE_MS = 3_000;
+export const MIN_SMART_PARAGRAPH_PAUSE_MS = 500;
+export const MAX_SMART_PARAGRAPH_PAUSE_MS = 30_000;
+
 export const SPEAKING_STYLES = [
   'responsive',
   'balanced',
@@ -128,6 +132,8 @@ export interface PluginSettings {
   sidecarPathOverride: string;
   sidecarRequestTimeoutSeconds: number;
   sidecarStartupTimeoutSeconds: number;
+  smartParagraphLineBreakPauseMs: number;
+  smartParagraphParagraphPauseMs: number;
   speakingStyle: SpeakingStyle;
   timestampClock: TimestampClock;
   timestampDensity: TimestampDensity;
@@ -176,6 +182,8 @@ export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
   sidecarPathOverride: '',
   sidecarRequestTimeoutSeconds: 300,
   sidecarStartupTimeoutSeconds: 4,
+  smartParagraphLineBreakPauseMs: DEFAULT_SMART_PARAGRAPH_PAUSE_MS,
+  smartParagraphParagraphPauseMs: DEFAULT_SMART_PARAGRAPH_PAUSE_MS,
   speakingStyle: 'balanced',
   timestampClock: 'elapsed',
   timestampDensity: 'sparse',
@@ -189,6 +197,10 @@ export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
 
 export function resolvePluginSettings(data: unknown): PluginSettings {
   const raw = isRecord(data) ? data : {};
+  const smartParagraphPauses = normalizeSmartParagraphPauseSettings({
+    lineBreakPauseMs: raw.smartParagraphLineBreakPauseMs,
+    paragraphPauseMs: raw.smartParagraphParagraphPauseMs,
+  });
   const { activeRef, userPresets } = migrateLlmPresetState({
     legacyPrompt: raw.llmPostprocessPrompt,
     storedRef: raw.llmPostprocessActivePresetRef,
@@ -300,6 +312,8 @@ export function resolvePluginSettings(data: unknown): PluginSettings {
       raw.sidecarStartupTimeoutSeconds,
       DEFAULT_PLUGIN_SETTINGS.sidecarStartupTimeoutSeconds,
     ),
+    smartParagraphLineBreakPauseMs: smartParagraphPauses.lineBreakPauseMs,
+    smartParagraphParagraphPauseMs: smartParagraphPauses.paragraphPauseMs,
     speakingStyle: isSpeakingStyle(raw.speakingStyle)
       ? raw.speakingStyle
       : DEFAULT_PLUGIN_SETTINGS.speakingStyle,
@@ -331,6 +345,34 @@ export function resolvePluginSettings(data: unknown): PluginSettings {
       DEFAULT_PLUGIN_SETTINGS.useLlmNoteContext,
     ),
     useNoteAsContext: readBoolean(raw.useNoteAsContext, DEFAULT_PLUGIN_SETTINGS.useNoteAsContext),
+  };
+}
+
+export interface SmartParagraphPauseSettings {
+  lineBreakPauseMs: number;
+  paragraphPauseMs: number;
+}
+
+export function normalizeSmartParagraphPauseSettings(value: {
+  lineBreakPauseMs: unknown;
+  paragraphPauseMs: unknown;
+}): SmartParagraphPauseSettings {
+  const paragraphPauseMs = readClampedInteger(
+    value.paragraphPauseMs,
+    DEFAULT_PLUGIN_SETTINGS.smartParagraphParagraphPauseMs,
+    MIN_SMART_PARAGRAPH_PAUSE_MS,
+    MAX_SMART_PARAGRAPH_PAUSE_MS,
+  );
+  const lineBreakPauseMs = readClampedInteger(
+    value.lineBreakPauseMs,
+    DEFAULT_PLUGIN_SETTINGS.smartParagraphLineBreakPauseMs,
+    MIN_SMART_PARAGRAPH_PAUSE_MS,
+    MAX_SMART_PARAGRAPH_PAUSE_MS,
+  );
+
+  return {
+    lineBreakPauseMs: Math.min(lineBreakPauseMs, paragraphPauseMs),
+    paragraphPauseMs,
   };
 }
 

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -38,7 +38,6 @@ import {
   addEnumSetting,
   addTextSetting,
   addToggleSetting,
-  appendInfoTooltip,
   createSettingGroup,
   type DropdownOption,
   type SettingAccess,
@@ -326,21 +325,15 @@ export class LocalSttSettingTab extends PluginSettingTab {
   }
 
   private renderTranscriptFormattingSetting(parent: HTMLElement): void {
-    const setting = new Setting(parent)
-      .setName('Transcript formatting')
-      .setDesc('How phrases are joined together.')
-      .addDropdown((dropdown) => {
-        for (const option of TRANSCRIPT_FORMATTING_OPTIONS) {
-          dropdown.addOption(option.value, option.label);
-        }
-        dropdown.setValue(this.dependencies.getSettings().transcriptFormatting);
-        dropdown.onChange(async (value) => {
-          if (!isTranscriptFormattingMode(value)) return;
-          await this.access.persistOne('transcriptFormatting', value);
-        });
-      });
+    const setting = addEnumSetting(parent, this.access, {
+      name: 'Transcript formatting',
+      desc: 'How phrases are joined together.',
+      tooltip: 'Smart paragraphs use longer pauses as line or paragraph breaks.',
+      key: 'transcriptFormatting',
+      options: TRANSCRIPT_FORMATTING_OPTIONS,
+      isValid: isTranscriptFormattingMode,
+    });
 
-    appendInfoTooltip(setting, 'Smart paragraphs use longer pauses as line or paragraph breaks.');
     setting.addExtraButton((button) => {
       button
         .setIcon('sliders-horizontal')

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -38,6 +38,7 @@ import {
   addEnumSetting,
   addTextSetting,
   addToggleSetting,
+  appendInfoTooltip,
   createSettingGroup,
   type DropdownOption,
   type SettingAccess,
@@ -47,6 +48,7 @@ import {
   type SidecarInstallActionDeps,
   SidecarSettingsSection,
 } from './sidecar-settings-section';
+import { SmartParagraphSettingsModal } from './smart-paragraph-settings-modal';
 
 interface SettingsTabDependencies {
   getSettings: () => PluginSettings;
@@ -210,14 +212,7 @@ export class LocalSttSettingTab extends PluginSettingTab {
       isValid: isDictationAnchor,
     });
 
-    addEnumSetting(outputCard, this.access, {
-      name: 'Transcript formatting',
-      desc: 'How phrases are joined together.',
-      tooltip: 'Smart paragraphs use longer pauses as paragraph breaks.',
-      key: 'transcriptFormatting',
-      options: TRANSCRIPT_FORMATTING_OPTIONS,
-      isValid: isTranscriptFormattingMode,
-    });
+    this.renderTranscriptFormattingSetting(outputCard);
 
     const diarizationSetting = addToggleSetting(outputCard, this.access, {
       name: 'Speaker labels (diarization)',
@@ -328,6 +323,40 @@ export class LocalSttSettingTab extends PluginSettingTab {
     this.disposeMissingSidecarBanner?.();
     this.disposeMissingSidecarBanner = null;
     this.missingSidecarProgressEl = null;
+  }
+
+  private renderTranscriptFormattingSetting(parent: HTMLElement): void {
+    const setting = new Setting(parent)
+      .setName('Transcript formatting')
+      .setDesc('How phrases are joined together.')
+      .addDropdown((dropdown) => {
+        for (const option of TRANSCRIPT_FORMATTING_OPTIONS) {
+          dropdown.addOption(option.value, option.label);
+        }
+        dropdown.setValue(this.dependencies.getSettings().transcriptFormatting);
+        dropdown.onChange(async (value) => {
+          if (!isTranscriptFormattingMode(value)) return;
+          await this.access.persistOne('transcriptFormatting', value);
+        });
+      });
+
+    appendInfoTooltip(setting, 'Smart paragraphs use longer pauses as line or paragraph breaks.');
+    setting.addExtraButton((button) => {
+      button
+        .setIcon('sliders-horizontal')
+        .setTooltip('Smart paragraph settings')
+        .onClick(() => {
+          new SmartParagraphSettingsModal(this.app, {
+            getSettings: () => this.dependencies.getSettings(),
+            onSave: () => {
+              this.display();
+            },
+            saveSettings: async (settings) => {
+              await this.dependencies.saveSettings(settings);
+            },
+          }).open();
+        });
+    });
   }
 
   private renderTimestampSettings(parent: HTMLElement, settings: PluginSettings): void {

--- a/src/settings/smart-paragraph-settings-modal.ts
+++ b/src/settings/smart-paragraph-settings-modal.ts
@@ -1,0 +1,172 @@
+import type { App } from 'obsidian';
+import { Modal, Setting } from 'obsidian';
+
+import {
+  DEFAULT_PLUGIN_SETTINGS,
+  MAX_SMART_PARAGRAPH_PAUSE_MS,
+  MIN_SMART_PARAGRAPH_PAUSE_MS,
+  type PluginSettings,
+  resolvePluginSettings,
+  type SmartParagraphPauseSettings,
+} from './plugin-settings';
+
+interface SmartParagraphSettingsModalDependencies {
+  getSettings: () => PluginSettings;
+  onSave?: () => void;
+  saveSettings: (settings: PluginSettings) => Promise<void>;
+}
+
+const MIN_PAUSE_SECONDS = MIN_SMART_PARAGRAPH_PAUSE_MS / 1000;
+const MAX_PAUSE_SECONDS = MAX_SMART_PARAGRAPH_PAUSE_MS / 1000;
+
+export class SmartParagraphSettingsModal extends Modal {
+  private draft: SmartParagraphPauseSettings;
+  private lineBreakInputEl: HTMLInputElement | null = null;
+  private paragraphInputEl: HTMLInputElement | null = null;
+
+  constructor(
+    app: App,
+    private readonly deps: SmartParagraphSettingsModalDependencies,
+  ) {
+    super(app);
+    this.draft = draftFromSettings(deps.getSettings());
+  }
+
+  override onOpen(): void {
+    this.titleEl.setText('Smart paragraph settings');
+    this.render();
+  }
+
+  override onClose(): void {
+    this.contentEl.empty();
+    this.lineBreakInputEl = null;
+    this.paragraphInputEl = null;
+  }
+
+  private render(): void {
+    this.contentEl.empty();
+    this.lineBreakInputEl = null;
+    this.paragraphInputEl = null;
+
+    this.addSecondsSetting({
+      desc: `Seconds before a single line break (${MIN_PAUSE_SECONDS}-${MAX_PAUSE_SECONDS}).`,
+      input: (inputEl) => {
+        this.lineBreakInputEl = inputEl;
+      },
+      name: 'Line break pause',
+      onChange: (value) => {
+        this.draft = { ...this.draft, lineBreakPauseMs: value };
+      },
+      value: this.draft.lineBreakPauseMs,
+    });
+
+    this.addSecondsSetting({
+      desc: `Seconds before a paragraph break (${MIN_PAUSE_SECONDS}-${MAX_PAUSE_SECONDS}).`,
+      input: (inputEl) => {
+        this.paragraphInputEl = inputEl;
+      },
+      name: 'Paragraph pause',
+      onChange: (value) => {
+        this.draft = { ...this.draft, paragraphPauseMs: value };
+      },
+      value: this.draft.paragraphPauseMs,
+    });
+
+    new Setting(this.contentEl)
+      .addButton((button) => {
+        button.setButtonText('Reset').onClick(() => {
+          this.draft = {
+            lineBreakPauseMs: DEFAULT_PLUGIN_SETTINGS.smartParagraphLineBreakPauseMs,
+            paragraphPauseMs: DEFAULT_PLUGIN_SETTINGS.smartParagraphParagraphPauseMs,
+          };
+          this.updateInputValues();
+        });
+      })
+      .addButton((button) => {
+        button.setButtonText('Cancel').onClick(() => {
+          this.close();
+        });
+      })
+      .addButton((button) => {
+        button
+          .setCta()
+          .setButtonText('Save')
+          .onClick(() => {
+            void this.handleSave();
+          });
+      });
+  }
+
+  private addSecondsSetting(options: {
+    desc: string;
+    input: (inputEl: HTMLInputElement) => void;
+    name: string;
+    onChange: (value: number) => void;
+    value: number;
+  }): void {
+    new Setting(this.contentEl)
+      .setName(options.name)
+      .setDesc(options.desc)
+      .addText((text) => {
+        text.inputEl.type = 'number';
+        text.inputEl.min = String(MIN_PAUSE_SECONDS);
+        text.inputEl.max = String(MAX_PAUSE_SECONDS);
+        text.inputEl.step = '0.1';
+        text.setValue(formatSeconds(options.value));
+        options.input(text.inputEl);
+        text.onChange((value) => {
+          const pauseMs = parseSecondsToMs(value);
+          if (pauseMs === null) return;
+          options.onChange(pauseMs);
+        });
+      });
+  }
+
+  private updateInputValues(): void {
+    if (this.lineBreakInputEl !== null) {
+      this.lineBreakInputEl.value = formatSeconds(this.draft.lineBreakPauseMs);
+    }
+    if (this.paragraphInputEl !== null) {
+      this.paragraphInputEl.value = formatSeconds(this.draft.paragraphPauseMs);
+    }
+  }
+
+  private async handleSave(): Promise<void> {
+    const normalizedSettings = resolvePluginSettings({
+      ...this.deps.getSettings(),
+      smartParagraphLineBreakPauseMs: this.draft.lineBreakPauseMs,
+      smartParagraphParagraphPauseMs: this.draft.paragraphPauseMs,
+    });
+
+    await this.deps.saveSettings(normalizedSettings);
+    this.draft = draftFromSettings(normalizedSettings);
+    this.updateInputValues();
+    this.deps.onSave?.();
+    this.close();
+  }
+}
+
+function draftFromSettings(settings: PluginSettings): SmartParagraphPauseSettings {
+  return {
+    lineBreakPauseMs: settings.smartParagraphLineBreakPauseMs,
+    paragraphPauseMs: settings.smartParagraphParagraphPauseMs,
+  };
+}
+
+function parseSecondsToMs(value: string): number | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const seconds = Number(trimmed);
+  if (!Number.isFinite(seconds)) {
+    return null;
+  }
+
+  return Math.round(seconds * 1000);
+}
+
+function formatSeconds(milliseconds: number): string {
+  return Number((milliseconds / 1000).toFixed(3)).toString();
+}

--- a/src/settings/smart-paragraph-settings-modal.ts
+++ b/src/settings/smart-paragraph-settings-modal.ts
@@ -5,8 +5,8 @@ import {
   DEFAULT_PLUGIN_SETTINGS,
   MAX_SMART_PARAGRAPH_PAUSE_MS,
   MIN_SMART_PARAGRAPH_PAUSE_MS,
+  normalizeSmartParagraphPauseSettings,
   type PluginSettings,
-  resolvePluginSettings,
   type SmartParagraphPauseSettings,
 } from './plugin-settings';
 
@@ -21,8 +21,6 @@ const MAX_PAUSE_SECONDS = MAX_SMART_PARAGRAPH_PAUSE_MS / 1000;
 
 export class SmartParagraphSettingsModal extends Modal {
   private draft: SmartParagraphPauseSettings;
-  private lineBreakInputEl: HTMLInputElement | null = null;
-  private paragraphInputEl: HTMLInputElement | null = null;
 
   constructor(
     app: App,
@@ -39,20 +37,13 @@ export class SmartParagraphSettingsModal extends Modal {
 
   override onClose(): void {
     this.contentEl.empty();
-    this.lineBreakInputEl = null;
-    this.paragraphInputEl = null;
   }
 
   private render(): void {
     this.contentEl.empty();
-    this.lineBreakInputEl = null;
-    this.paragraphInputEl = null;
 
     this.addSecondsSetting({
       desc: `Seconds before a single line break (${MIN_PAUSE_SECONDS}-${MAX_PAUSE_SECONDS}).`,
-      input: (inputEl) => {
-        this.lineBreakInputEl = inputEl;
-      },
       name: 'Line break pause',
       onChange: (value) => {
         this.draft = { ...this.draft, lineBreakPauseMs: value };
@@ -62,9 +53,6 @@ export class SmartParagraphSettingsModal extends Modal {
 
     this.addSecondsSetting({
       desc: `Seconds before a paragraph break (${MIN_PAUSE_SECONDS}-${MAX_PAUSE_SECONDS}).`,
-      input: (inputEl) => {
-        this.paragraphInputEl = inputEl;
-      },
       name: 'Paragraph pause',
       onChange: (value) => {
         this.draft = { ...this.draft, paragraphPauseMs: value };
@@ -79,7 +67,7 @@ export class SmartParagraphSettingsModal extends Modal {
             lineBreakPauseMs: DEFAULT_PLUGIN_SETTINGS.smartParagraphLineBreakPauseMs,
             paragraphPauseMs: DEFAULT_PLUGIN_SETTINGS.smartParagraphParagraphPauseMs,
           };
-          this.updateInputValues();
+          this.render();
         });
       })
       .addButton((button) => {
@@ -99,7 +87,6 @@ export class SmartParagraphSettingsModal extends Modal {
 
   private addSecondsSetting(options: {
     desc: string;
-    input: (inputEl: HTMLInputElement) => void;
     name: string;
     onChange: (value: number) => void;
     value: number;
@@ -113,7 +100,6 @@ export class SmartParagraphSettingsModal extends Modal {
         text.inputEl.max = String(MAX_PAUSE_SECONDS);
         text.inputEl.step = '0.1';
         text.setValue(formatSeconds(options.value));
-        options.input(text.inputEl);
         text.onChange((value) => {
           const pauseMs = parseSecondsToMs(value);
           if (pauseMs === null) return;
@@ -122,25 +108,14 @@ export class SmartParagraphSettingsModal extends Modal {
       });
   }
 
-  private updateInputValues(): void {
-    if (this.lineBreakInputEl !== null) {
-      this.lineBreakInputEl.value = formatSeconds(this.draft.lineBreakPauseMs);
-    }
-    if (this.paragraphInputEl !== null) {
-      this.paragraphInputEl.value = formatSeconds(this.draft.paragraphPauseMs);
-    }
-  }
-
   private async handleSave(): Promise<void> {
-    const normalizedSettings = resolvePluginSettings({
-      ...this.deps.getSettings(),
-      smartParagraphLineBreakPauseMs: this.draft.lineBreakPauseMs,
-      smartParagraphParagraphPauseMs: this.draft.paragraphPauseMs,
-    });
+    const normalized = normalizeSmartParagraphPauseSettings(this.draft);
 
-    await this.deps.saveSettings(normalizedSettings);
-    this.draft = draftFromSettings(normalizedSettings);
-    this.updateInputValues();
+    await this.deps.saveSettings({
+      ...this.deps.getSettings(),
+      smartParagraphLineBreakPauseMs: normalized.lineBreakPauseMs,
+      smartParagraphParagraphPauseMs: normalized.paragraphPauseMs,
+    });
     this.deps.onSave?.();
     this.close();
   }
@@ -168,5 +143,5 @@ function parseSecondsToMs(value: string): number | null {
 }
 
 function formatSeconds(milliseconds: number): string {
-  return Number((milliseconds / 1000).toFixed(3)).toString();
+  return (milliseconds / 1000).toString();
 }

--- a/src/transcript/renderer.ts
+++ b/src/transcript/renderer.ts
@@ -1,13 +1,20 @@
 import type { TranscriptSegment, TranscriptSpan, UtteranceId } from '../session/session-journal';
 import type {
+  SmartParagraphPauseSettings,
   TimestampClock,
   TimestampDensity,
   TranscriptFormattingMode,
 } from '../settings/plugin-settings';
+import {
+  DEFAULT_SMART_PARAGRAPH_PAUSE_MS,
+  normalizeSmartParagraphPauseSettings,
+} from '../settings/plugin-settings';
 
-export const SMART_PARAGRAPH_PAUSE_MS = 3000;
+export const SMART_PARAGRAPH_PAUSE_MS = DEFAULT_SMART_PARAGRAPH_PAUSE_MS;
 
 export interface TranscriptRenderOptions {
+  readonly smartParagraphLineBreakPauseMs?: number;
+  readonly smartParagraphParagraphPauseMs?: number;
   readonly timestamps: TranscriptTimestampRenderOptions;
   readonly transcriptFormatting: TranscriptFormattingMode;
 }
@@ -57,8 +64,14 @@ export class TranscriptRenderer {
   private hasRenderedText = false;
   private lastRenderedSpeakerIndex: number | null = null;
   private lastTimestampMsInSession: number | null = null;
+  private readonly smartParagraphPauses: SmartParagraphPauseSettings;
 
-  constructor(private readonly options: TranscriptRenderOptions) {}
+  constructor(private readonly options: TranscriptRenderOptions) {
+    this.smartParagraphPauses = normalizeSmartParagraphPauseSettings({
+      lineBreakPauseMs: options.smartParagraphLineBreakPauseMs,
+      paragraphPauseMs: options.smartParagraphParagraphPauseMs,
+    });
+  }
 
   planAppend(
     input: TranscriptAppendInput,
@@ -170,7 +183,18 @@ export class TranscriptRenderer {
       return this.options.transcriptFormatting;
     }
 
-    return isMeaningfulPause(pauseMsBeforeUtterance) ? 'new_paragraph' : 'space';
+    if (
+      pauseMsBeforeUtterance === null ||
+      pauseMsBeforeUtterance < this.smartParagraphPauses.lineBreakPauseMs
+    ) {
+      return 'space';
+    }
+
+    if (pauseMsBeforeUtterance < this.smartParagraphPauses.paragraphPauseMs) {
+      return 'new_line';
+    }
+
+    return 'new_paragraph';
   }
 
   private shouldEmitTimestamp(input: TranscriptAppendInput): boolean {
@@ -206,8 +230,11 @@ export class TranscriptRenderer {
   }
 }
 
-export function isMeaningfulPause(pauseMsBeforeUtterance: number | null): boolean {
-  return pauseMsBeforeUtterance !== null && pauseMsBeforeUtterance >= SMART_PARAGRAPH_PAUSE_MS;
+export function isMeaningfulPause(
+  pauseMsBeforeUtterance: number | null,
+  paragraphPauseMs = SMART_PARAGRAPH_PAUSE_MS,
+): boolean {
+  return pauseMsBeforeUtterance !== null && pauseMsBeforeUtterance >= paragraphPauseMs;
 }
 
 export function formatLandmark(

--- a/src/transcript/renderer.ts
+++ b/src/transcript/renderer.ts
@@ -5,16 +5,15 @@ import type {
   TimestampDensity,
   TranscriptFormattingMode,
 } from '../settings/plugin-settings';
-import {
-  DEFAULT_SMART_PARAGRAPH_PAUSE_MS,
-  normalizeSmartParagraphPauseSettings,
-} from '../settings/plugin-settings';
+import { DEFAULT_SMART_PARAGRAPH_PAUSE_MS } from '../settings/plugin-settings';
 
-export const SMART_PARAGRAPH_PAUSE_MS = DEFAULT_SMART_PARAGRAPH_PAUSE_MS;
+const DEFAULT_SMART_PARAGRAPH_PAUSES: SmartParagraphPauseSettings = {
+  lineBreakPauseMs: DEFAULT_SMART_PARAGRAPH_PAUSE_MS,
+  paragraphPauseMs: DEFAULT_SMART_PARAGRAPH_PAUSE_MS,
+};
 
 export interface TranscriptRenderOptions {
-  readonly smartParagraphLineBreakPauseMs?: number;
-  readonly smartParagraphParagraphPauseMs?: number;
+  readonly smartParagraphPauses?: SmartParagraphPauseSettings;
   readonly timestamps: TranscriptTimestampRenderOptions;
   readonly transcriptFormatting: TranscriptFormattingMode;
 }
@@ -67,10 +66,7 @@ export class TranscriptRenderer {
   private readonly smartParagraphPauses: SmartParagraphPauseSettings;
 
   constructor(private readonly options: TranscriptRenderOptions) {
-    this.smartParagraphPauses = normalizeSmartParagraphPauseSettings({
-      lineBreakPauseMs: options.smartParagraphLineBreakPauseMs,
-      paragraphPauseMs: options.smartParagraphParagraphPauseMs,
-    });
+    this.smartParagraphPauses = options.smartParagraphPauses ?? DEFAULT_SMART_PARAGRAPH_PAUSES;
   }
 
   planAppend(
@@ -228,13 +224,6 @@ export class TranscriptRenderer {
   private shouldEmitSpeakerLabel(speakerIndex: number | null): speakerIndex is number {
     return speakerIndex !== null && speakerIndex !== this.lastRenderedSpeakerIndex;
   }
-}
-
-export function isMeaningfulPause(
-  pauseMsBeforeUtterance: number | null,
-  paragraphPauseMs = SMART_PARAGRAPH_PAUSE_MS,
-): boolean {
-  return pauseMsBeforeUtterance !== null && pauseMsBeforeUtterance >= paragraphPauseMs;
 }
 
 export function formatLandmark(

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -163,6 +163,33 @@ describe('DictationSessionController', () => {
     expect(controller.getState()).toBe('listening');
   });
 
+  it('passes smart paragraph thresholds to renderer options', async () => {
+    let rendererOptions: TranscriptRenderOptions | null = null;
+    const controller = createController({
+      createSession: (_session, options) => {
+        rendererOptions = options.rendererOptions;
+      },
+      getSettings: () =>
+        createSettings({
+          selectedModel: createExternalModelSelection(),
+          smartParagraphLineBreakPauseMs: 1200,
+          smartParagraphParagraphPauseMs: 4500,
+          transcriptFormatting: 'smart',
+        }),
+    });
+
+    await controller.startDictation();
+
+    if (rendererOptions === null) {
+      throw new Error('expected renderer options');
+    }
+    expect(rendererOptions).toMatchObject({
+      smartParagraphLineBreakPauseMs: 1200,
+      smartParagraphParagraphPauseMs: 4500,
+      transcriptFormatting: 'smart',
+    });
+  });
+
   it('includes system audio without skipping microphone capture', async () => {
     const captureStream = new FakeCaptureStream();
     const sidecarConnection = new FakeSidecarConnection();
@@ -1309,7 +1336,7 @@ function createController({
   audioLevelMeter?: FakeAudioLevelMeter;
   captureStream?: FakeCaptureStream;
   countAudioInputDevices?: () => Promise<number | null>;
-  createSession?: (session: FakeSession) => void;
+  createSession?: (session: FakeSession, options: CreateSessionOptions) => void;
   getSettings?: () => PluginSettings;
   llmRouter?: LlmRouter;
   logger?: FakeLogger;
@@ -1322,17 +1349,9 @@ function createController({
     captureStream,
     audioLevelMeter,
     ...(countAudioInputDevices !== undefined ? { countAudioInputDevices } : {}),
-    createSession: (_options: {
-      callbacks: {
-        onLockedNoteClosed: () => void;
-        onLockedNoteDeleted: () => void;
-      };
-      placement: NotePlacementOptions;
-      rendererOptions: TranscriptRenderOptions;
-      sessionId: string;
-    }) => {
+    createSession: (_options: CreateSessionOptions) => {
       const session = new FakeSession();
-      createSession?.(session);
+      createSession?.(session, _options);
       return session;
     },
     createLlmRouter: () => llmRouter,
@@ -1347,6 +1366,16 @@ function createController({
     setRibbonState: vi.fn((_state: DictationControllerState) => {}),
     sidecarConnection,
   });
+}
+
+interface CreateSessionOptions {
+  callbacks: {
+    onLockedNoteClosed: () => void;
+    onLockedNoteDeleted: () => void;
+  };
+  placement: NotePlacementOptions;
+  rendererOptions: TranscriptRenderOptions;
+  sessionId: string;
 }
 
 function createSettings(overrides: Partial<PluginSettings> = {}): PluginSettings {

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -184,8 +184,7 @@ describe('DictationSessionController', () => {
       throw new Error('expected renderer options');
     }
     expect(rendererOptions).toMatchObject({
-      smartParagraphLineBreakPauseMs: 1200,
-      smartParagraphParagraphPauseMs: 4500,
+      smartParagraphPauses: { lineBreakPauseMs: 1200, paragraphPauseMs: 4500 },
       transcriptFormatting: 'smart',
     });
   });

--- a/test/helpers/render-options.ts
+++ b/test/helpers/render-options.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_SMART_PARAGRAPH_PAUSE_MS } from '../../src/settings/plugin-settings';
 import type {
   TranscriptRenderOptions,
   TranscriptTimestampRenderOptions,
@@ -28,6 +29,8 @@ export function renderOptions(
   overrides: Partial<TranscriptRenderOptions> = {},
 ): TranscriptRenderOptions {
   return {
+    smartParagraphLineBreakPauseMs: DEFAULT_SMART_PARAGRAPH_PAUSE_MS,
+    smartParagraphParagraphPauseMs: DEFAULT_SMART_PARAGRAPH_PAUSE_MS,
     timestamps: timestamps(),
     transcriptFormatting: 'space',
     ...overrides,

--- a/test/helpers/render-options.ts
+++ b/test/helpers/render-options.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_SMART_PARAGRAPH_PAUSE_MS } from '../../src/settings/plugin-settings';
 import type {
   TranscriptRenderOptions,
   TranscriptTimestampRenderOptions,
@@ -29,8 +28,6 @@ export function renderOptions(
   overrides: Partial<TranscriptRenderOptions> = {},
 ): TranscriptRenderOptions {
   return {
-    smartParagraphLineBreakPauseMs: DEFAULT_SMART_PARAGRAPH_PAUSE_MS,
-    smartParagraphParagraphPauseMs: DEFAULT_SMART_PARAGRAPH_PAUSE_MS,
     timestamps: timestamps(),
     transcriptFormatting: 'space',
     ...overrides,

--- a/test/plugin-settings.test.ts
+++ b/test/plugin-settings.test.ts
@@ -7,9 +7,12 @@ import {
 } from '../src/llm/presets';
 import {
   DEFAULT_PLUGIN_SETTINGS,
+  DEFAULT_SMART_PARAGRAPH_PAUSE_MS,
   LLM_USER_PRESET_MAX_COUNT,
   LLM_USER_PRESET_MAX_DESCRIPTION_CHARS,
   LLM_USER_PRESET_MAX_LABEL_CHARS,
+  MAX_SMART_PARAGRAPH_PAUSE_MS,
+  MIN_SMART_PARAGRAPH_PAUSE_MS,
   resetLlmPostprocessDefaults,
   resolvePluginSettings,
   shouldRefreshLlmSidebar,
@@ -91,6 +94,8 @@ describe('resolvePluginSettings', () => {
         sidecarPathOverride: ' /tmp/sidecar ',
         sidecarRequestTimeoutSeconds: 12,
         sidecarStartupTimeoutSeconds: 6,
+        smartParagraphLineBreakPauseMs: 1500,
+        smartParagraphParagraphPauseMs: 4500,
         speakingStyle: 'patient',
         timestampClock: 'wallclock',
         timestampDensity: 'every_utterance',
@@ -135,6 +140,8 @@ describe('resolvePluginSettings', () => {
       sidecarPathOverride: '/tmp/sidecar',
       sidecarRequestTimeoutSeconds: 12,
       sidecarStartupTimeoutSeconds: 6,
+      smartParagraphLineBreakPauseMs: 1500,
+      smartParagraphParagraphPauseMs: 4500,
       speakingStyle: 'patient',
       timestampClock: 'wallclock',
       timestampDensity: 'every_utterance',
@@ -182,6 +189,8 @@ describe('resolvePluginSettings', () => {
         sidecarPathOverride: 12,
         sidecarRequestTimeoutSeconds: -1,
         sidecarStartupTimeoutSeconds: 'fast',
+        smartParagraphLineBreakPauseMs: 'soon',
+        smartParagraphParagraphPauseMs: 'later',
         timestampClock: 'date',
         timestampDensity: 'always',
         timestampsEnabled: 'yes',
@@ -240,6 +249,43 @@ describe('resolvePluginSettings', () => {
     expect(
       resolvePluginSettings({ timestampSparseIntervalMs: 999_999 }).timestampSparseIntervalMs,
     ).toBe(600_000);
+  });
+
+  it('defaults smart paragraph thresholds to the legacy meaningful pause threshold', () => {
+    expect(DEFAULT_PLUGIN_SETTINGS.smartParagraphLineBreakPauseMs).toBe(
+      DEFAULT_SMART_PARAGRAPH_PAUSE_MS,
+    );
+    expect(DEFAULT_PLUGIN_SETTINGS.smartParagraphParagraphPauseMs).toBe(
+      DEFAULT_SMART_PARAGRAPH_PAUSE_MS,
+    );
+    expect(resolvePluginSettings({})).toMatchObject({
+      smartParagraphLineBreakPauseMs: DEFAULT_SMART_PARAGRAPH_PAUSE_MS,
+      smartParagraphParagraphPauseMs: DEFAULT_SMART_PARAGRAPH_PAUSE_MS,
+    });
+  });
+
+  it('clamps smart paragraph thresholds at the settings boundary', () => {
+    expect(
+      resolvePluginSettings({
+        smartParagraphLineBreakPauseMs: 1,
+        smartParagraphParagraphPauseMs: 999_999,
+      }),
+    ).toMatchObject({
+      smartParagraphLineBreakPauseMs: MIN_SMART_PARAGRAPH_PAUSE_MS,
+      smartParagraphParagraphPauseMs: MAX_SMART_PARAGRAPH_PAUSE_MS,
+    });
+  });
+
+  it('normalizes smart paragraph line breaks to not exceed paragraph breaks', () => {
+    expect(
+      resolvePluginSettings({
+        smartParagraphLineBreakPauseMs: 5000,
+        smartParagraphParagraphPauseMs: 2000,
+      }),
+    ).toMatchObject({
+      smartParagraphLineBreakPauseMs: 2000,
+      smartParagraphParagraphPauseMs: 2000,
+    });
   });
 
   it('defaults useLlmNoteContext to false', () => {

--- a/test/transcript-renderer.test.ts
+++ b/test/transcript-renderer.test.ts
@@ -136,6 +136,43 @@ describe('TranscriptRenderer', () => {
     ).toBe('\n\nlong');
   });
 
+  it('uses custom smart paragraph line and paragraph thresholds', () => {
+    const renderer = new TranscriptRenderer({
+      smartParagraphLineBreakPauseMs: 1000,
+      smartParagraphParagraphPauseMs: 3000,
+      timestamps: timestamps(),
+      transcriptFormatting: 'smart',
+    });
+
+    expect(planAndCommit(renderer, { text: 'first' }).projectedText).toBe('first');
+    expect(
+      planAndCommit(
+        renderer,
+        {
+          pauseMsBeforeUtterance: 999,
+          text: 'short',
+        },
+        't',
+      ).projectedText,
+    ).toBe(' short');
+    expect(
+      planAndCommit(
+        renderer,
+        {
+          pauseMsBeforeUtterance: 1000,
+          text: 'line',
+        },
+        't',
+      ).projectedText,
+    ).toBe('\nline');
+    expect(
+      planAndCommit(renderer, {
+        pauseMsBeforeUtterance: 3000,
+        text: 'paragraph',
+      }).projectedText,
+    ).toBe('\n\nparagraph');
+  });
+
   it('treats null pause as continuation while still allowing interval timestamps', () => {
     const renderer = new TranscriptRenderer({
       timestamps: timestamps({ enabled: true, header: false }),

--- a/test/transcript-renderer.test.ts
+++ b/test/transcript-renderer.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  buildSpeakerSpans,
-  formatLandmark,
-  SMART_PARAGRAPH_PAUSE_MS,
-  TranscriptRenderer,
-} from '../src/transcript/renderer';
+import { DEFAULT_SMART_PARAGRAPH_PAUSE_MS } from '../src/settings/plugin-settings';
+import { buildSpeakerSpans, formatLandmark, TranscriptRenderer } from '../src/transcript/renderer';
 import {
   DEFAULT_SESSION_START_MS,
   DEFAULT_SPARSE_INTERVAL_MS,
@@ -79,7 +75,7 @@ describe('TranscriptRenderer', () => {
 
     planAndCommit(renderer, { text: 'first', utteranceStartMsInSession: 0 });
     const second = planAndCommit(renderer, {
-      pauseMsBeforeUtterance: SMART_PARAGRAPH_PAUSE_MS,
+      pauseMsBeforeUtterance: DEFAULT_SMART_PARAGRAPH_PAUSE_MS,
       text: 'later',
       utteranceStartMsInSession: DEFAULT_SPARSE_INTERVAL_MS,
     });
@@ -122,7 +118,7 @@ describe('TranscriptRenderer', () => {
       planAndCommit(
         renderer,
         {
-          pauseMsBeforeUtterance: SMART_PARAGRAPH_PAUSE_MS - 1,
+          pauseMsBeforeUtterance: DEFAULT_SMART_PARAGRAPH_PAUSE_MS - 1,
           text: 'short',
         },
         't',
@@ -130,7 +126,7 @@ describe('TranscriptRenderer', () => {
     ).toBe(' short');
     expect(
       planAndCommit(renderer, {
-        pauseMsBeforeUtterance: SMART_PARAGRAPH_PAUSE_MS,
+        pauseMsBeforeUtterance: DEFAULT_SMART_PARAGRAPH_PAUSE_MS,
         text: 'long',
       }).projectedText,
     ).toBe('\n\nlong');
@@ -138,8 +134,7 @@ describe('TranscriptRenderer', () => {
 
   it('uses custom smart paragraph line and paragraph thresholds', () => {
     const renderer = new TranscriptRenderer({
-      smartParagraphLineBreakPauseMs: 1000,
-      smartParagraphParagraphPauseMs: 3000,
+      smartParagraphPauses: { lineBreakPauseMs: 1000, paragraphPauseMs: 3000 },
       timestamps: timestamps(),
       transcriptFormatting: 'smart',
     });


### PR DESCRIPTION
## Summary
- Add smart paragraph line-break and paragraph pause thresholds with default 3000ms values to preserve existing behavior
- Add a compact row-level settings button and modal for editing the thresholds in seconds
- Pass thresholds into transcript rendering and normalize invalid persisted values at settings load

Closes #190.

## Tests
- `npm run typecheck`
- `npx biome check src/settings/plugin-settings.ts src/settings/settings-tab.ts src/settings/smart-paragraph-settings-modal.ts src/transcript/renderer.ts src/dictation/dictation-session-controller.ts test/helpers/render-options.ts test/plugin-settings.test.ts test/transcript-renderer.test.ts test/dictation-session-controller.test.ts`
- `npx vitest run test/plugin-settings.test.ts test/transcript-renderer.test.ts test/dictation-session-controller.test.ts`