### PR TITLE
Skip provider refresh on sidebar open when LLM transform is off

### DIFF
--- a/src/ui/local-dictation-view.ts
+++ b/src/ui/local-dictation-view.ts
@@ -79,13 +79,7 @@ export class LocalDictationView extends ItemView {
     this.focusRefreshController = new FocusRefreshController({
       now: () => window.performance.now(),
       refreshPresets: () => this.dependencies.synchronizePresets(),
-      refreshProviders: () => {
-        const settings = this.dependencies.getSettings();
-        if (!settings.llmFeaturesEnabled || settings.llmPostprocessMode === 'off') {
-          return Promise.resolve();
-        }
-        return this.routingControls.refreshActiveProviders({ forceLocal: true });
-      },
+      refreshProviders: () => this.refreshActiveProvidersIfEnabled({ forceLocal: true }),
     });
     this.routingControls.setInputTracker((element) => {
       this.trackInputFocus(element);
@@ -111,10 +105,20 @@ export class LocalDictationView extends ItemView {
       this.dependencies.subscribeLlmCleanupFailure?.(() => {
         this.refresh();
       }) ?? null;
-    void this.routingControls.refreshActiveProviders();
+    void this.refreshActiveProvidersIfEnabled();
     this.registerDomEvent(this.contentEl.win, 'focus', () => {
       this.focusRefreshController.request();
     });
+  }
+
+  // Skip the network probe entirely when LLM transform is off, so opening the
+  // sidebar doesn't wake Ollama or hit OpenRouter for a feature the user disabled.
+  private refreshActiveProvidersIfEnabled(options?: { forceLocal?: boolean }): Promise<void> {
+    const settings = this.dependencies.getSettings();
+    if (!settings.llmFeaturesEnabled || settings.llmPostprocessMode === 'off') {
+      return Promise.resolve();
+    }
+    return this.routingControls.refreshActiveProviders(options);
   }
 
   override async onClose(): Promise<void> {


### PR DESCRIPTION
## Summary

`LocalDictationView.onOpen()` called `refreshActiveProviders()` unconditionally, so simply opening the sidebar wakes Ollama (a local process) and/or hits the OpenRouter API even when the user has LLM transform disabled entirely. The window-focus refresh path already gated this correctly (`if (!settings.llmFeaturesEnabled || settings.llmPostprocessMode === 'off') return;`), so the two call sites had drifted.

## Fix

Extracted the gate into a single private helper, `refreshActiveProvidersIfEnabled()`, used by both `onOpen()` and the focus-refresh callback, so they can no longer diverge. Behavior is otherwise unchanged: the focus path still passes `{ forceLocal: true }`, `onOpen()` still omits it (matching prior semantics).

## Impact

- No more spurious Ollama wake-ups / OpenRouter requests when a user has transform off and just opens the sidebar (e.g. to check dictation status) — saves battery/network and avoids surprising a local Ollama instance into loading a model.

Addresses **item 6 of #195** (avoid provider refreshes when LLM transform is off).

## Test plan

- [x] `npm run typecheck`
- [x] `npm test -- --run` (582 tests passed)
- [x] `npm run lint` (biome check — clean, pre-existing schema-version info notice only)
- [x] `npm run lint:obsidian` (eslint — clean, pre-existing unrelated warning only)
- [ ] No existing test file covers `LocalDictationView.onOpen()`/focus behavior (no `local-dictation-view.test.ts`); the gated logic in `LlmRoutingControls.refreshActiveProviders` itself is already covered by `test/llm-routing-controls.test.ts`. Did not stand up new test infrastructure for the view per scope — flagging here for visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
