### PR TITLE
Route Auto LLM decision on transcript length, not full prompt length

### DIFF
--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -732,7 +732,7 @@ export class DictationSessionController {
       this.buildProviderCleanupContextSources(entry),
       rawText,
     );
-    const providerId = entry.snapshot.llmRouter.selectProviderId(userMessage.length);
+    const providerId = entry.snapshot.llmRouter.selectProviderId(rawText.length);
     const startedAt = Date.now();
     const abortController = new AbortController();
     entry.cleanupAbortControllers.add(abortController);
@@ -938,7 +938,7 @@ export class DictationSessionController {
         ? (entry.session.readNoteText(entry.snapshot.llmPostprocessNoteContextChars)?.text ?? null)
         : null;
     const userMessage = renderBatchProviderUserMessage(noteContext, transcriptText);
-    const providerId = entry.snapshot.llmRouter.selectProviderId(userMessage.length);
+    const providerId = entry.snapshot.llmRouter.selectProviderId(transcriptText.length);
 
     // The flashing processing range is now the "working" indicator, so the
     // cursor steps aside for the batch rewrite.

--- a/src/llm/provider.ts
+++ b/src/llm/provider.ts
@@ -131,11 +131,15 @@ export function withProviderModel(
 }
 
 // Pure size-based routing: 'local' always picks Ollama, 'remote' always picks
-// OpenRouter, and 'auto' escalates to OpenRouter once the user message exceeds
-// the configured character threshold (local models choke on large contexts).
+// OpenRouter, and 'auto' escalates to OpenRouter once the *transcript*
+// exceeds the configured character threshold (local models choke on large
+// contexts). This deliberately ignores the full prompt/user-message size,
+// which also carries note/prior-utterance context: the UI promises that Auto
+// only sends large transcripts to OpenRouter, and a short dictation must not
+// escalate just because it happens to have a large note attached.
 export function selectRouteProviderId(
   routing: LlmRouting,
-  userMessageChars: number,
+  transcriptChars: number,
   thresholdChars: number,
 ): LlmProviderId {
   switch (routing) {
@@ -144,7 +148,7 @@ export function selectRouteProviderId(
     case 'remote':
       return 'openrouter';
     case 'auto':
-      return userMessageChars <= thresholdChars ? 'ollama' : 'openrouter';
+      return transcriptChars <= thresholdChars ? 'ollama' : 'openrouter';
   }
 }
 

--- a/src/llm/router.ts
+++ b/src/llm/router.ts
@@ -14,9 +14,11 @@ export interface LlmRouterCleanupOptions {
   abortSignal?: AbortSignal;
   prompt: string;
   temperature: number;
-  // Length of the dictated text being transformed. The output cap scales with
-  // this, not with `userMessage`, which also carries note/prior context that
-  // the output should never approach in size.
+  // Length of the dictated text being transformed, as opposed to
+  // `userMessage`, which also carries note/prior context. This drives both
+  // the output-token cap and the Auto routing decision below — routing on
+  // `userMessage` would leak note context to OpenRouter for short
+  // dictations that merely have a large note attached (#194).
   transcriptChars: number;
   userMessage: string;
 }
@@ -29,7 +31,7 @@ export interface LlmRouterCleanupResult {
 
 export interface LlmRouter {
   cleanup(options: LlmRouterCleanupOptions): Promise<LlmRouterCleanupResult>;
-  selectProviderId(userMessageChars: number): LlmProviderId;
+  selectProviderId(transcriptChars: number): LlmProviderId;
 }
 
 // Routes each cleanup call to a provider by message size (see
@@ -48,10 +50,10 @@ export function createLlmRouter(
   // routing mode, auto threshold, model strings — deliberately stays frozen from
   // the session-start snapshot so a running session behaves predictably;
   // mid-session settings edits apply from the next session.
-  const selectProviderId = (userMessageChars: number): LlmProviderId =>
+  const selectProviderId = (transcriptChars: number): LlmProviderId =>
     selectRouteProviderId(
       isRemoteFeaturesEnabled() ? settings.llmRouting : 'local',
-      userMessageChars,
+      transcriptChars,
       settings.llmRemoteThresholdChars,
     );
 
@@ -70,7 +72,7 @@ export function createLlmRouter(
 
   return {
     async cleanup(options) {
-      const providerId = selectProviderId(options.userMessage.length);
+      const providerId = selectProviderId(options.transcriptChars);
       const model = getProviderModel(settings, providerId);
       if (model.length === 0) {
         const error = new ProviderError(

--- a/test/llm/router.test.ts
+++ b/test/llm/router.test.ts
@@ -141,6 +141,39 @@ describe('createLlmRouter', () => {
     expect(result.providerId).toBe(expected);
   });
 
+  it('routes auto on transcript length, not the full prompt (note context must not escalate a short utterance)', async () => {
+    const { router } = routerWithSpy(
+      settings({ llmRemoteThresholdChars: 100, llmRouting: 'auto' }),
+    );
+
+    // The dictated transcript is short, but the rendered userMessage embeds a
+    // large note-context block that alone would cross the threshold. Routing
+    // must stay local — #194: Auto must only escalate large *transcripts*.
+    const result = await router.cleanup({
+      prompt: 'Clean it.',
+      temperature: 0.2,
+      transcriptChars: 20,
+      userMessage: `<note_context>${'x'.repeat(1_000)}</note_context>short transcript`,
+    });
+
+    expect(result.providerId).toBe('ollama');
+  });
+
+  it('routes auto to remote when the transcript itself crosses the threshold, even with a small prompt', async () => {
+    const { router } = routerWithSpy(
+      settings({ llmRemoteThresholdChars: 100, llmRouting: 'auto' }),
+    );
+
+    const result = await router.cleanup({
+      prompt: 'Clean it.',
+      temperature: 0.2,
+      transcriptChars: 200,
+      userMessage: 'x'.repeat(200),
+    });
+
+    expect(result.providerId).toBe('openrouter');
+  });
+
   it('throws model_not_configured when the routed provider has no configured model', async () => {
     const { router } = routerWithSpy(
       settings({ llmProviderModels: { ollama: '', openrouter: '' }, llmRouting: 'local' }),


### PR DESCRIPTION
## Summary

`Auto` LLM routing (`src/llm/router.ts`) picked the provider by comparing `userMessage.length` against `llmRemoteThresholdChars`. `userMessage` is the *fully rendered* prompt built by `renderProviderUserMessage`/`renderBatchProviderUserMessage`, which embeds note context and prior utterances — not just the dictated text. That meant a short utterance with a large attached note could cross the threshold and get routed to OpenRouter, contradicting the settings UI's promise (`src/ui/llm-routing-controls.ts:283,587`) that Auto only sends *large transcripts* remotely. Net effect: private note context could leave the device unexpectedly.

A `transcriptChars` field already existed on `LlmRouterCleanupOptions` (set to `rawText.length` / `transcriptText.length` at both call sites in `src/dictation/dictation-session-controller.ts`) but was only used for the output-token budget, never for routing.

## Fix

- `selectRouteProviderId` (`src/llm/provider.ts`) and `LlmRouter.selectProviderId`/`cleanup()` (`src/llm/router.ts`) now route on `transcriptChars`, not `userMessage.length`. The output-token-budget use of `transcriptChars` is unchanged.
- Both controller call sites (`resolveTranscriptRevision` ~line 735, `runBatchCleanup` ~line 941) now pre-compute `providerId` from the transcript length (`rawText.length` / `transcriptText.length`) instead of `userMessage.length`, so the locally-cached `providerId` used for error attribution stays consistent with what `cleanup()` actually routes to.
- No UI copy changes — the code now matches the existing promise.

## Test plan

- [x] Added regression tests in `test/llm/router.test.ts`: short transcript + large note-context prompt stays on `ollama`; large transcript (small prompt) escalates to `openrouter`.
- [x] `npm run typecheck`
- [x] `npx vitest run test/llm/router.test.ts test/dictation-session-controller.test.ts` (47 passed)
- [x] `npm test -- --run` (584 passed, 46 files)
- [x] `npm run lint` (Biome, clean) and `npm run lint:obsidian` (ESLint, pre-existing unrelated warning only)

Addresses **finding 3 of #194** (Auto LLM routing can unexpectedly send short dictation plus private note context to OpenRouter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
