### PR TITLE
Skip deep model probe on plugin startup

### DIFF
--- a/src/models/model-install-manager.ts
+++ b/src/models/model-install-manager.ts
@@ -198,8 +198,24 @@ export class ModelInstallManager {
 
     const persistedSelection = this.deps.getSettings().selectedModel;
     if (persistedSelection !== null) {
-      this.selectedModelCapabilities = { selection: persistedSelection, status: 'pending' };
-      void this.refreshSelectedCapabilities(persistedSelection);
+      const snapshot = this.deps.getSettings().selectedModelCapabilitiesSnapshot;
+      if (snapshot !== null && selectedModelEquals(snapshot.selection, persistedSelection)) {
+        // Trust the capabilities captured the last time this exact selection
+        // was probed successfully (on select() or install completion)
+        // instead of re-probing the sidecar on every plugin startup —
+        // probing forces a full model load just to populate UI badges
+        // (issue #195). A stale snapshot only affects those badges; a
+        // genuinely broken model still fails loudly the moment dictation
+        // starts.
+        this.selectedModelCapabilities = {
+          capabilities: snapshot.capabilities,
+          selection: persistedSelection,
+          status: 'ready',
+        };
+      } else {
+        this.selectedModelCapabilities = { selection: persistedSelection, status: 'pending' };
+        void this.refreshSelectedCapabilities(persistedSelection);
+      }
     }
 
     this.notify();
@@ -361,6 +377,10 @@ export class ModelInstallManager {
     });
 
     if (!probeResult.available) {
+      // The user explicitly (re-)probed this exact selection and it's
+      // confirmed broken now — drop any cached "ready" snapshot for it so a
+      // future startup doesn't trust stale, now-incorrect capabilities.
+      await this.invalidateCapabilitiesSnapshot(selection);
       throw new Error(createProbeFailureMessage(probeResult));
     }
 
@@ -373,7 +393,7 @@ export class ModelInstallManager {
       }`,
     );
     await this.updateSettings({ selectedModel: selection });
-    this.applyProbeResultToCapabilities(selection, probeResult);
+    await this.applyProbeResultToCapabilities(selection, probeResult);
     return probeResult;
   }
 
@@ -426,7 +446,7 @@ export class ModelInstallManager {
 
   async clearSelection(): Promise<void> {
     this.deps.logger?.debug('model', 'cleared selected model');
-    await this.updateSettings({ selectedModel: null });
+    await this.updateSettings({ selectedModel: null, selectedModelCapabilitiesSnapshot: null });
     this.selectedModelCapabilities = { status: 'none' };
     this.notify();
   }
@@ -457,7 +477,7 @@ export class ModelInstallManager {
         modelSelection: selection,
         ...createModelStoreOverridePayload(this.deps.getSettings().modelStorePathOverride),
       });
-      this.applyProbeResultToCapabilities(selection, probeResult);
+      await this.applyProbeResultToCapabilities(selection, probeResult);
     } catch (error) {
       this.deps.logger?.warn(
         'model',
@@ -475,10 +495,10 @@ export class ModelInstallManager {
     }
   }
 
-  private applyProbeResultToCapabilities(
+  private async applyProbeResultToCapabilities(
     selection: SelectedModel,
     probeResult: ModelProbeResultEvent,
-  ): void {
+  ): Promise<void> {
     const current = this.deps.getSettings().selectedModel;
     if (current === null || !selectedModelEquals(current, selection)) {
       return;
@@ -490,6 +510,15 @@ export class ModelInstallManager {
         selection,
         status: 'ready',
       };
+      // Cache the result so a future plugin startup can trust it instead of
+      // re-probing the sidecar, which would force a full model load just to
+      // populate UI badges (issue #195).
+      await this.updateSettings({
+        selectedModelCapabilitiesSnapshot: {
+          capabilities: probeResult.mergedCapabilities,
+          selection,
+        },
+      });
     } else if (probeResult.status === 'missing' || probeResult.status === 'invalid') {
       this.selectedModelCapabilities = {
         details: createProbeFailureMessage(probeResult),
@@ -506,6 +535,13 @@ export class ModelInstallManager {
     }
 
     this.notify();
+  }
+
+  private async invalidateCapabilitiesSnapshot(selection: SelectedModel): Promise<void> {
+    const snapshot = this.deps.getSettings().selectedModelCapabilitiesSnapshot;
+    if (snapshot !== null && selectedModelEquals(snapshot.selection, selection)) {
+      await this.updateSettings({ selectedModelCapabilitiesSnapshot: null });
+    }
   }
 
   private handleSidecarEvent(event: SidecarEvent): void {

--- a/src/models/model-management-types.ts
+++ b/src/models/model-management-types.ts
@@ -167,6 +167,14 @@ export type SelectedModelCapabilities =
       capabilities: EngineCapabilitiesRecord;
     };
 
+// A persisted record of the last successful probe for a given selection, used
+// to skip the sidecar probe (which forces a full model load) on plugin
+// startup. Invalidated whenever the selection it was captured for changes.
+export interface SelectedModelCapabilitiesSnapshot {
+  capabilities: EngineCapabilitiesRecord;
+  selection: SelectedModel;
+}
+
 export type ModelInstallState =
   | 'cancelled'
   | 'completed'
@@ -221,6 +229,76 @@ export function isSelectedModel(value: unknown): value is SelectedModel {
   }
 
   return false;
+}
+
+function isLanguageSupport(value: unknown): value is LanguageSupport {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  switch (value.kind) {
+    case 'all':
+    case 'english_only':
+    case 'unknown':
+      return true;
+    case 'list':
+      return Array.isArray(value.tags) && value.tags.every((tag) => typeof tag === 'string');
+    default:
+      return false;
+  }
+}
+
+function isModelFamilyCapabilitiesRecord(value: unknown): value is ModelFamilyCapabilitiesRecord {
+  return (
+    isRecord(value) &&
+    typeof value.supportsSegmentTimestamps === 'boolean' &&
+    typeof value.supportsWordTimestamps === 'boolean' &&
+    typeof value.supportsInitialPrompt === 'boolean' &&
+    typeof value.supportsStreaming === 'boolean' &&
+    typeof value.supportsLanguageSelection === 'boolean' &&
+    isLanguageSupport(value.supportedLanguages) &&
+    (value.maxAudioDurationSecs === null || typeof value.maxAudioDurationSecs === 'number') &&
+    typeof value.producesPunctuation === 'boolean'
+  );
+}
+
+function isAcceleratorId(value: unknown): value is AcceleratorId {
+  return value === 'cpu' || value === 'cuda' || value === 'direct_ml' || value === 'metal';
+}
+
+function isModelFormat(value: unknown): value is ModelFormat {
+  return value === 'ggml' || value === 'gguf' || value === 'onnx';
+}
+
+function isRuntimeCapabilitiesRecord(value: unknown): value is RuntimeCapabilitiesRecord {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.availableAccelerators) &&
+    value.availableAccelerators.every(isAcceleratorId) &&
+    isRecord(value.acceleratorDetails) &&
+    Array.isArray(value.supportedModelFormats) &&
+    value.supportedModelFormats.every(isModelFormat)
+  );
+}
+
+export function isEngineCapabilitiesRecord(value: unknown): value is EngineCapabilitiesRecord {
+  return (
+    isRecord(value) &&
+    isModelFamilyId(value.familyId) &&
+    isRuntimeId(value.runtimeId) &&
+    isModelFamilyCapabilitiesRecord(value.family) &&
+    isRuntimeCapabilitiesRecord(value.runtime)
+  );
+}
+
+export function isSelectedModelCapabilitiesSnapshot(
+  value: unknown,
+): value is SelectedModelCapabilitiesSnapshot {
+  return (
+    isRecord(value) &&
+    isSelectedModel(value.selection) &&
+    isEngineCapabilitiesRecord(value.capabilities)
+  );
 }
 
 export function normalizeSelectedModel(value: SelectedModel): SelectedModel {

--- a/src/settings/plugin-settings.ts
+++ b/src/settings/plugin-settings.ts
@@ -18,8 +18,10 @@ import {
 import { isLlmRouting, type LlmProviderModels, type LlmRouting } from '../llm/provider';
 import {
   isSelectedModel,
+  isSelectedModelCapabilitiesSnapshot,
   normalizeSelectedModel,
   type SelectedModel,
+  type SelectedModelCapabilitiesSnapshot,
 } from '../models/model-management-types';
 import { isRecord } from '../shared/type-guards';
 import {
@@ -128,6 +130,10 @@ export interface PluginSettings {
   modelStorePathOverride: string;
   schemaVersion: 2;
   selectedModel: SelectedModel | null;
+  // Last-known-good capabilities for `selectedModel`, captured on a successful
+  // probe. Lets startup skip re-probing the sidecar (which forces a full
+  // model load) when the cached selection still matches.
+  selectedModelCapabilitiesSnapshot: SelectedModelCapabilitiesSnapshot | null;
   setupCompletedAt: string | null;
   sidecarPathOverride: string;
   sidecarRequestTimeoutSeconds: number;
@@ -178,6 +184,7 @@ export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
   modelStorePathOverride: '',
   schemaVersion: 2,
   selectedModel: null,
+  selectedModelCapabilitiesSnapshot: null,
   setupCompletedAt: null,
   sidecarPathOverride: '',
   sidecarRequestTimeoutSeconds: 300,
@@ -299,6 +306,9 @@ export function resolvePluginSettings(data: unknown): PluginSettings {
     // Bump `schemaVersion` and add a migration step when renaming a key or changing default semantics.
     schemaVersion: 2,
     selectedModel: readSelectedModel(raw.selectedModel),
+    selectedModelCapabilitiesSnapshot: readSelectedModelCapabilitiesSnapshot(
+      raw.selectedModelCapabilitiesSnapshot,
+    ),
     setupCompletedAt: readSetupCompletedAt(raw.setupCompletedAt),
     sidecarPathOverride: readString(
       raw.sidecarPathOverride,
@@ -714,6 +724,19 @@ function readSelectedModel(selectedModel: unknown): SelectedModel | null {
   }
 
   return DEFAULT_PLUGIN_SETTINGS.selectedModel;
+}
+
+function readSelectedModelCapabilitiesSnapshot(
+  value: unknown,
+): SelectedModelCapabilitiesSnapshot | null {
+  if (!isSelectedModelCapabilitiesSnapshot(value)) {
+    return DEFAULT_PLUGIN_SETTINGS.selectedModelCapabilitiesSnapshot;
+  }
+
+  return {
+    capabilities: value.capabilities,
+    selection: normalizeSelectedModel(value.selection),
+  };
 }
 
 function readListeningMode(value: unknown): ListeningMode {

--- a/test/model-install-manager.test.ts
+++ b/test/model-install-manager.test.ts
@@ -690,6 +690,122 @@ describe('ModelInstallManager', () => {
         status: 'ready',
       });
     });
+
+    it('select() persists a capabilities snapshot alongside the selection', async () => {
+      configureSidecarForInit(harness.sidecarConnection);
+      await harness.manager.init();
+      harness.sidecarConnection.probeModelSelection.mockResolvedValueOnce(sampleReadyProbeResult());
+
+      await harness.manager.select(sampleSelection());
+
+      expect(harness.getSettings().selectedModelCapabilitiesSnapshot).toEqual({
+        capabilities: sampleMergedCapabilities(),
+        selection: sampleSelection(),
+      });
+    });
+  });
+
+  describe('startup probe skip (issue #195)', () => {
+    it('trusts a matching persisted capabilities snapshot on init and never probes the sidecar', async () => {
+      harness = createManagerHarness({
+        selectedModel: sampleSelection(),
+        selectedModelCapabilitiesSnapshot: {
+          capabilities: sampleMergedCapabilities(),
+          selection: sampleSelection(),
+        },
+      });
+      configureSidecarForInit(harness.sidecarConnection);
+
+      await harness.manager.init();
+
+      expect(harness.sidecarConnection.probeModelSelection).not.toHaveBeenCalled();
+      expect(harness.manager.getState().selectedModelCapabilities).toEqual({
+        capabilities: sampleMergedCapabilities(),
+        selection: sampleSelection(),
+        status: 'ready',
+      });
+    });
+
+    it('falls back to probing when the persisted snapshot belongs to a different selection', async () => {
+      harness = createManagerHarness({
+        selectedModel: sampleSelection(),
+        selectedModelCapabilitiesSnapshot: {
+          capabilities: sampleMergedCapabilities(),
+          selection: sampleSelection('whisper_small_en_q5_1'),
+        },
+      });
+      configureSidecarForInit(harness.sidecarConnection);
+      harness.sidecarConnection.probeModelSelection.mockResolvedValueOnce(sampleReadyProbeResult());
+
+      await harness.manager.init();
+
+      await vi.waitFor(() => {
+        expect(harness.sidecarConnection.probeModelSelection).toHaveBeenCalledTimes(1);
+        expect(harness.manager.getState().selectedModelCapabilities).toEqual({
+          capabilities: sampleMergedCapabilities(),
+          selection: sampleSelection(),
+          status: 'ready',
+        });
+      });
+    });
+
+    it('falls back to probing when no snapshot has been persisted', async () => {
+      harness = createManagerHarness({ selectedModel: sampleSelection() });
+      configureSidecarForInit(harness.sidecarConnection);
+      harness.sidecarConnection.probeModelSelection.mockResolvedValueOnce(sampleReadyProbeResult());
+
+      await harness.manager.init();
+
+      await vi.waitFor(() => {
+        expect(harness.sidecarConnection.probeModelSelection).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('re-selecting a model whose probe now fails invalidates its persisted snapshot', async () => {
+      harness = createManagerHarness({
+        selectedModel: sampleSelection(),
+        selectedModelCapabilitiesSnapshot: {
+          capabilities: sampleMergedCapabilities(),
+          selection: sampleSelection(),
+        },
+      });
+      configureSidecarForInit(harness.sidecarConnection);
+      await harness.manager.init();
+      expect(harness.sidecarConnection.probeModelSelection).not.toHaveBeenCalled();
+
+      harness.sidecarConnection.probeModelSelection.mockResolvedValueOnce({
+        ...sampleReadyProbeResult(),
+        available: false,
+        details: 'file removed',
+        installed: false,
+        mergedCapabilities: null,
+        message: 'Model is not installed.',
+        resolvedPath: null,
+        sizeBytes: null,
+        status: 'missing',
+      });
+
+      await expect(harness.manager.select(sampleSelection())).rejects.toThrow(
+        'Model is not installed. (file removed)',
+      );
+      expect(harness.getSettings().selectedModelCapabilitiesSnapshot).toBeNull();
+    });
+
+    it('clearSelection() clears the persisted capabilities snapshot', async () => {
+      harness = createManagerHarness({
+        selectedModel: sampleSelection(),
+        selectedModelCapabilitiesSnapshot: {
+          capabilities: sampleMergedCapabilities(),
+          selection: sampleSelection(),
+        },
+      });
+      configureSidecarForInit(harness.sidecarConnection);
+      await harness.manager.init();
+
+      await harness.manager.clearSelection();
+
+      expect(harness.getSettings().selectedModelCapabilitiesSnapshot).toBeNull();
+    });
   });
 });
 

--- a/test/plugin-settings.test.ts
+++ b/test/plugin-settings.test.ts
@@ -203,6 +203,83 @@ describe('resolvePluginSettings', () => {
     ).toEqual(DEFAULT_PLUGIN_SETTINGS);
   });
 
+  it('round-trips a well-formed selectedModelCapabilitiesSnapshot', () => {
+    const selection = {
+      familyId: 'whisper' as const,
+      kind: 'catalog_model' as const,
+      modelId: 'whisper_large_v3_turbo_q8_0',
+      runtimeId: 'whisper_cpp' as const,
+    };
+    const capabilities = {
+      family: {
+        maxAudioDurationSecs: null,
+        producesPunctuation: true,
+        supportedLanguages: { kind: 'all' as const },
+        supportsInitialPrompt: true,
+        supportsLanguageSelection: true,
+        supportsSegmentTimestamps: true,
+        supportsStreaming: false,
+        supportsWordTimestamps: false,
+      },
+      familyId: 'whisper' as const,
+      runtime: {
+        acceleratorDetails: { cpu: { available: true, unavailableReason: null } },
+        availableAccelerators: ['cpu' as const],
+        supportedModelFormats: ['ggml' as const],
+      },
+      runtimeId: 'whisper_cpp' as const,
+    };
+
+    expect(
+      resolvePluginSettings({ selectedModelCapabilitiesSnapshot: { capabilities, selection } })
+        .selectedModelCapabilitiesSnapshot,
+    ).toEqual({ capabilities, selection });
+  });
+
+  it.each([
+    ['not a record', 'nope'],
+    [
+      'missing capabilities',
+      {
+        selection: {
+          familyId: 'whisper',
+          kind: 'catalog_model',
+          modelId: 'm',
+          runtimeId: 'whisper_cpp',
+        },
+      },
+    ],
+    [
+      'capabilities missing required fields',
+      {
+        capabilities: { familyId: 'whisper' },
+        selection: {
+          familyId: 'whisper',
+          kind: 'catalog_model',
+          modelId: 'm',
+          runtimeId: 'whisper_cpp',
+        },
+      },
+    ],
+    [
+      'invalid selection',
+      {
+        capabilities: {},
+        selection: {
+          familyId: 'not_a_family',
+          kind: 'catalog_model',
+          modelId: 'm',
+          runtimeId: 'whisper_cpp',
+        },
+      },
+    ],
+  ])('drops a malformed selectedModelCapabilitiesSnapshot (%s)', (_label, value) => {
+    expect(
+      resolvePluginSettings({ selectedModelCapabilitiesSnapshot: value })
+        .selectedModelCapabilitiesSnapshot,
+    ).toBeNull();
+  });
+
   it('validates setupCompletedAt as the exact persisted ISO timestamp', () => {
     const timestamp = '2026-05-22T10:00:00.000Z';
 


### PR DESCRIPTION
## Cost being removed

`ModelInstallManager.init()` unconditionally called
`sidecarConnection.probeModelSelection(...)` for the persisted selection
whenever a model was selected. On the Rust side, adapter `probe_model()`
implementations build a full `WhisperContext` (whisper.rs) or real ORT
sessions (moonshine.rs, cohere_transcribe.rs) just to validate the
selection, then discard them — nothing is cached. Every Obsidian startup
with a model selected forced the sidecar to load complete model weights
purely to populate UI status badges, then threw the work away. This was
the largest single startup cost identified in #195.

## Approach

Persist the capabilities from a successful probe alongside the selection
(`PluginSettings.selectedModelCapabilitiesSnapshot`, validated on read via
`isSelectedModelCapabilitiesSnapshot`). On `init()`:

- If the persisted snapshot's selection matches the persisted
  `selectedModel`, trust it directly (`status: 'ready'`) — no sidecar call.
- Otherwise (no snapshot, or the selection changed), fall back to the
  existing pending → probe flow.

The snapshot is written whenever `applyProbeResultToCapabilities` sees a
`ready` result, and invalidated when re-selecting the same model produces a
real (non-throwing) failure — so a stale "ready" cache can't survive a
confirmed-broken reprobe.

Deep validation (the real probe / model load) still happens on:
- Explicit model selection/change (`select()`)
- Install completion (existing auto-select-after-install path)
- First dictation start, which surfaces real load errors anyway

A stale/incorrect cached snapshot only affects informational UI (the
"Streaming" badge, diarization/note-context setting visibility) — it never
gates dictation itself, so the worst case of trusting stale data is a
badge being briefly wrong until the user reselects or dictates.

**Not changed** (by design, to keep this fix scoped): `init()` still calls
`listModelCatalog` / `listInstalledModels` / `getModelStore` /
`getSystemInfo`, which still spawn the sidecar process on startup. That
cost is real but separate — much cheaper than a full model load, and
tracked as its own item under #195.

## Tests

Added to `test/model-install-manager.test.ts`:
- Matching persisted snapshot on init → no `probeModelSelection` call, state goes straight to `ready`.
- Snapshot for a different selection → falls back to probing.
- No snapshot at all → falls back to probing (matches prior behavior).
- Re-selecting a model whose probe now fails → snapshot is invalidated (nulled).
- `clearSelection()` clears the persisted snapshot.
- `select()` persists a snapshot on success.

Added to `test/plugin-settings.test.ts`: round-trip of a well-formed
snapshot, and rejection of several malformed shapes (non-record, missing
capabilities, malformed capabilities, invalid selection).

## Verification

- `npm run typecheck` — clean
- `npx vitest run test/model-install-manager.test.ts` / `test/plugin-settings.test.ts` — all pass
- `npm test -- --run` — 593/593 passed
- `npm run lint` — clean (pre-existing biome schema-version info notice only)
- `npm run lint:obsidian` — 0 errors (1 pre-existing unrelated warning in settings-tab.ts)

Addresses **item 1 of #195** (remove heavyweight selected-model probing from startup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
