### PR TITLE
Guard sidecar process cleanup against stale exits

### DIFF
--- a/src/sidecar/sidecar-process.ts
+++ b/src/sidecar/sidecar-process.ts
@@ -30,7 +30,13 @@ export class SidecarProcess {
   ) {}
 
   isRunning(): boolean {
-    return this.child !== null && this.child.exitCode === null && !this.child.killed;
+    // A child that has been sent a kill signal but has not yet emitted 'exit'
+    // still owns the slot: Node sets `child.killed` synchronously inside
+    // kill(), well before the OS reaps the process. Treating it as "not
+    // running" here would let start() spawn a replacement while the old
+    // process is still alive. `exitCode` (and `signalCode` for
+    // signal-terminated processes) only flip once 'exit' has actually fired.
+    return this.child !== null && this.child.exitCode === null && this.child.signalCode === null;
   }
 
   async start(): Promise<void> {
@@ -80,6 +86,15 @@ export class SidecarProcess {
     this.stderrReader.on('line', this.handlers.onStderrLine);
 
     child.once('exit', (code, signal) => {
+      // Guard against a stale exit: if `this.child` has already moved on to a
+      // newer generation (only reachable if a future change weakens the
+      // invariants above), this exit belongs to a process we no longer own —
+      // clearing shared state or firing onExit here would clobber the
+      // replacement.
+      if (this.child !== child) {
+        return;
+      }
+
       this.disposeReaders();
       child.stdout.removeAllListeners('data');
       this.child = null;
@@ -150,10 +165,15 @@ async function waitForSpawn(child: ChildProcessWithoutNullStreams): Promise<void
 }
 
 async function waitForExit(child: ChildProcessWithoutNullStreams): Promise<void> {
+  // stop()'s contract is "the process is gone" -- resolving as soon as we
+  // *ask* it to die (rather than waiting for the real 'exit' event) is what
+  // let a slow-to-die child outlive stop() and later clobber a replacement
+  // spawned in the meantime. Give the process a grace period to exit on its
+  // own, then escalate to SIGKILL, but always wait for the actual 'exit'
+  // event -- a SIGKILLed process is guaranteed to exit on Linux/macOS.
   await new Promise<void>((resolve) => {
     const timeoutHandle = window.setTimeout(() => {
-      child.kill();
-      resolve();
+      child.kill('SIGKILL');
     }, 2_000);
 
     child.once('exit', () => {

--- a/test/sidecar-process.test.ts
+++ b/test/sidecar-process.test.ts
@@ -1,0 +1,156 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+const { spawn } = await import('node:child_process');
+const { SidecarProcess } = await import('../src/sidecar/sidecar-process');
+
+const mockedSpawn = spawn as unknown as ReturnType<typeof vi.fn>;
+
+// A minimal stand-in for ChildProcessWithoutNullStreams: real pipe streams so
+// readline's createInterface(child.stderr) and the stdout/stdin wiring in
+// SidecarProcess work unmodified, plus the process-lifecycle bits
+// (exitCode/signalCode/killed/kill/'spawn'/'exit') that the fix under test
+// depends on.
+class FakeChild extends EventEmitter {
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  killed = false;
+  kill = vi.fn((_signal?: NodeJS.Signals | number): boolean => {
+    this.killed = true;
+    return true;
+  });
+
+  /** Simulates the OS actually reaping the process. */
+  reallyExit(code: number | null, signal: NodeJS.Signals | null): void {
+    this.exitCode = code;
+    this.signalCode = signal;
+    this.emit('exit', code, signal);
+  }
+}
+
+function queueChild(): FakeChild {
+  const child = new FakeChild();
+  // doStart() awaits resolveLaunchSpec() before calling spawn(), so the test
+  // can't emit 'spawn' right after calling start() -- the listener isn't
+  // attached yet at that point. Queueing the emit as a microtask from inside
+  // spawn() itself guarantees it runs after waitForSpawn() has synchronously
+  // registered its listeners (which happens in the same synchronous stretch
+  // as this spawn() call, right before doStart suspends on that promise).
+  mockedSpawn.mockImplementationOnce(() => {
+    queueMicrotask(() => child.emit('spawn'));
+    return child;
+  });
+  return child;
+}
+
+function createHandlers() {
+  return {
+    onExit: vi.fn(),
+    onStderrLine: vi.fn(),
+    onStdoutChunk: vi.fn(),
+  };
+}
+
+async function startChild(process: InstanceType<typeof SidecarProcess>): Promise<FakeChild> {
+  const child = queueChild();
+  await process.start();
+  return child;
+}
+
+beforeEach(() => {
+  mockedSpawn.mockReset();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('SidecarProcess stale-exit race (issue #194)', () => {
+  it('stop() does not resolve until the killed child actually exits', async () => {
+    const handlers = createHandlers();
+    const process = new SidecarProcess(async () => ({ command: '/tmp/fake-sidecar' }), handlers);
+    const child = await startChild(process);
+
+    const stopPromise = process.stop();
+
+    // The graceful window elapses; stop() must escalate to SIGKILL rather
+    // than resolving on the timeout alone.
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+
+    let stopResolved = false;
+    void stopPromise.then(() => {
+      stopResolved = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(stopResolved).toBe(false);
+    expect(handlers.onExit).not.toHaveBeenCalled();
+
+    // Only once the OS actually reaps the process does stop() resolve.
+    child.reallyExit(null, 'SIGKILL');
+    await stopPromise;
+    expect(stopResolved).toBe(true);
+    expect(handlers.onExit).toHaveBeenCalledExactlyOnceWith(null, 'SIGKILL');
+  });
+
+  it('does not let a replacement spawn while the killed child is still alive', async () => {
+    const handlers = createHandlers();
+    const process = new SidecarProcess(async () => ({ command: '/tmp/fake-sidecar' }), handlers);
+    await startChild(process);
+
+    const stopPromise = process.stop();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    // A kill signal was sent but the child has not exited: isRunning() must
+    // still report true so a concurrent start() doesn't spawn a second child
+    // onto the same slot.
+    expect(process.isRunning()).toBe(true);
+    await process.start();
+    expect(mockedSpawn).toHaveBeenCalledTimes(1);
+
+    void stopPromise;
+  });
+
+  it('leaves a fully intact replacement process after a delayed old-child exit (restart regression)', async () => {
+    const handlers = createHandlers();
+    const process = new SidecarProcess(async () => ({ command: '/tmp/fake-sidecar' }), handlers);
+    const child1 = await startChild(process);
+
+    // Mirrors SidecarConnection#restart(): stop() the current child, then
+    // start() a replacement. The old child ignores the graceful shutdown
+    // path (no self-initiated exit) and only dies once SIGKILL lands.
+    const stopPromise = process.stop();
+    await vi.advanceTimersByTimeAsync(2_000);
+    child1.reallyExit(null, 'SIGKILL');
+    await stopPromise;
+
+    const child2 = await startChild(process);
+
+    expect(process.isRunning()).toBe(true);
+    expect(handlers.onExit).toHaveBeenCalledExactlyOnceWith(null, 'SIGKILL');
+
+    // The new stderr reader is alive and wired to the new child, not a stale
+    // reader left over from the old one.
+    child2.stderr.write('hello from child2\n');
+    await vi.waitFor(() => {
+      expect(handlers.onStderrLine).toHaveBeenCalledWith('hello from child2');
+    });
+
+    // A stray, late 'exit' on the old child object (e.g. a duplicate signal
+    // delivery) must never clear state or refire onExit for the wrong
+    // generation.
+    child1.emit('exit', 1, null);
+    expect(process.isRunning()).toBe(true);
+    expect(handlers.onExit).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Race scenario (issue #194, finding 5)

`SidecarConnection#restart()` calls `shutdown()` (which awaits `SidecarProcess#stop()`) then `ensureStarted()`. Two bugs combined to let a stale, slow-to-die child clobber its replacement:

- `waitForExit()` resolved as soon as its 2s grace-period timer fired and it called `child.kill()` — it never actually waited for the child's `'exit'` event. So `stop()` could return while the old child was still alive.
- `isRunning()` treated a child as "not running" once `child.killed` was true. Node sets `killed` synchronously inside `kill()`, well before the OS reaps the process, so a killed-but-alive child looked free for a new `start()` to spawn over.

Net effect: if the old child ignored graceful shutdown and only died after the kill escalation, `restart()` could spawn a new child while the old one was still exiting. The old child's `'exit'` handler in `doStart()` had no identity check, so when it eventually fired it would unconditionally null `this.child`, dispose the *new* child's stderr reader, and fire `onExit` for the wrong process generation.

## Fix (two legs)

1. **Ownership window** — `waitForExit()` now always waits for the real `'exit'` event; on timeout it escalates to `SIGKILL` instead of resolving immediately (`SIGKILL` is guaranteed to produce an exit on Linux/macOS). `isRunning()` now checks only `exitCode`/`signalCode`, not `killed`, so a killed-but-not-yet-reaped child still occupies its slot and can't be raced by a concurrent `start()`.
2. **Identity guard** — the `'exit'` handler installed in `doStart()` now checks `this.child === child` before clearing shared state or firing `onExit`, as defense in depth against any future change that reopens the ownership window.

## Tests

Added `test/sidecar-process.test.ts` with a fake, event-driven child process (real `PassThrough` streams so `readline`/stdout wiring runs unmodified) covering:
- `stop()` does not resolve on the kill-timeout alone; only once the child actually exits.
- A killed-but-alive child keeps `isRunning()` true, so a concurrent `start()` doesn't spawn a second child.
- The full restart regression: stop a child that ignores graceful shutdown, let the kill timeout fire, delay the real exit, then restart — the replacement's state (child reference, stderr reader, `onExit` call count) stays intact even when the old child's `'exit'` fires late.

Addresses **finding 5 of #194** (forced sidecar kill has a stale-exit race that can clobber a replacement process).

## Verification
- `npm run typecheck` — clean
- `npm test -- --run` — 585/585 passing (47 files)
- `npm run lint` — clean (pre-existing biome schema-version notice unrelated)
- `npm run lint:obsidian` — clean (pre-existing unrelated warning in settings-tab.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
