### PR TITLE
System audio: native macOS backend via CoreAudio process taps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,11 +45,14 @@ This installs the built `main.js`, `manifest.json`, and `styles.css` into the va
 For Linux CUDA testing:
 
 ```sh
-npm run build:frontend
-npm run build:sidecar
-npm run build:sidecar:cuda
-npm run install:dev -- --vault ~/Documents/test-vault-stt --sidecars --enable
+npm run install:dev:cuda -- --vault ~/Documents/test-vault-stt
 ```
+
+This one-command flow builds the frontend, CPU sidecar, and CUDA sidecar,
+verifies the build output, prunes stale files from the vault's installed plugin
+directory, then installs and enables the plugin. It prints a step-by-step status
+log and an override report. Existing vault-local `data.json` is preserved by
+default; pass `--reset-data` to wipe it too.
 
 For macOS testing, `npm run build:sidecar` builds the Metal-capable sidecar automatically.
 
@@ -64,6 +67,7 @@ npm run build:sidecar:cuda            # Linux CUDA sidecar
 npm run build:sidecar:cuda:windows    # Windows CUDA sidecar
 npm run dev              # watch mode for plugin
 npm run install:dev -- --vault <vault> --sidecars --enable
+npm run install:dev:cuda -- --vault <vault> # build CPU+CUDA and force-install
 ```
 
 **Test and check:**

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Transcription runs entirely on your device. No accounts or cloud required. A fas
 - **High-quality models, run locally.** Choose from Whisper, Cohere Transcribe, or Moonshine — on CPU or GPU. Cohere Transcribe currently tops the [Open ASR Leaderboard](https://huggingface.co/spaces/hf-audio/open_asr_leaderboard).
 - **Live dictation.** Moonshine streaming models show provisional words within about a second and revise them in place until each utterance finalizes.
 - **Speaker labels.** Optional on-device diarization tags who's talking — for interviews, meetings, and calls. Nothing is stored; voiceprints live in memory for the session only.
-- **System audio.** Transcribe your computer's output — meetings, calls, videos — not just your mic. Available on Windows and Linux.
+- **System audio.** Transcribe your computer's output — meetings, calls, videos — not just your mic. Available on Windows, Linux, and macOS 14.2+.
 - **Timestamps.** Optionally stamp phrases with elapsed or wall-clock time — handy for meetings and interviews.
 - **LLM presets.** Clean up, summarize, pull out action items, or reshape a transcript with built-in or custom presets, run through a local model (Ollama) or OpenRouter.
 - **Auto routing.** Keep cleanup fully local, or have only oversized transcripts route automatically to OpenRouter for a bigger model and larger context window.

--- a/docs/guides/cuda-setup.md
+++ b/docs/guides/cuda-setup.md
@@ -51,7 +51,9 @@ Don't set `LD_LIBRARY_PATH` as a global Flatpak override — it makes Electron l
 
 ## Building from source
 
-Needs CUDA Toolkit `13.2` with `nvcc` on `PATH` (and cuDNN 9.x for Cohere):
+Needs CUDA Toolkit `13.2` with `nvcc` on `PATH` (and cuDNN 9.x for Cohere).
+CUDA 13.2 supports GCC host compilers through GCC 15; on Linux the build script
+prefers `/usr/bin/gcc-15` and `/usr/bin/g++-15` when they are installed.
 
 ```sh
 bash scripts/build-cuda.sh            # Linux        (add --release for release)
@@ -63,7 +65,10 @@ Artifacts:
 - CPU: `native/target/{debug|release}/local-dictation-sidecar[.exe]`
 - CUDA: `native/target-cuda/{debug|release}/local-dictation-sidecar[.exe]`
 
-The CUDA build also stages the ONNX Runtime provider libraries next to the binary — keep them together. A repo checkout auto-detects the CUDA debug build at `native/target-cuda/debug`, so no path override is needed when testing from source.
+The Linux CUDA build also stages the ONNX Runtime provider libraries and CUDA
+runtime libraries next to the binary — keep them together. A repo checkout
+auto-detects the CUDA debug build at `native/target-cuda/debug`, so no path
+override is needed when testing from source.
 
 ## Troubleshooting
 

--- a/docs/specs/macos-system-audio-research.md
+++ b/docs/specs/macos-system-audio-research.md
@@ -1,0 +1,455 @@
+# Research: macOS Native System-Audio Capture (issue #159)
+
+Status: research complete, no implementation decision recorded yet.
+Issue: [#159](https://github.com/brittain9/local-dictation-obsidian-plugin/issues/159).
+Scope: findings only, verified against primary sources (Apple SDK headers, Apple
+docs/sample code, Chromium/Electron source, crate source). Every load-bearing
+claim carries its source. Observations, inferences, and recommendations are
+labeled where the distinction matters.
+
+## Implications for #159 (summary)
+
+- **API choice**: CoreAudio process taps (`CATapDescription` +
+  `AudioHardwareCreateProcessTap` + tap-in-aggregate-device) are the right
+  backend. Minimum macOS is **14.2** by Apple's own availability annotations and
+  sample code, and Chromium ships exactly that gate. Older macOS keeps the
+  existing `SystemAudioError::Unsupported` / virtual-device fallback.
+- **TCC attribution works in our favor**: the sidecar is a plain child process
+  of Obsidian, so TCC attributes the "record system audio" prompt and the
+  persisted grant to **Obsidian.app** (the "responsible process"), not to the
+  unsigned sidecar. The usage string must come from Obsidian's `Info.plist`
+  (`NSAudioCaptureUsageDescription`). Electron ships that key in its default
+  `Info.plist` since v39.6.0 (Feb 2026); Obsidian's 1.12.7 installer bundles
+  Electron 39.8.3, so current installers should carry it — but **older
+  installers won't**, and the failure mode without the key is a **silent dead
+  stream (no prompt, no error)**. We must runtime-probe (Chromium's
+  get/set-`kAudioTapPropertyDescription` trick) and surface guidance instead of
+  producing zero-audio.
+- **Binding route**: hand-rolled, dependency-light — `objc2` `msg_send!` for the
+  `CATapDescription` class (runtime `AnyClass::get`, no link-time dep) plus
+  `dlsym(RTLD_DEFAULT)` for the two 14.2-only C functions, with the
+  long-standing aggregate-device C API linked normally. This is exactly the
+  pattern of the Linux backend (dlopen'd libpulse) and is what
+  seren-desktop/AFFiNE ship in production Rust. `objc2-core-audio` (small,
+  MIT/Apache) is a reasonable alternative if we accept a link-time symbol
+  dependency; `cidre` is complete but heavyweight.
+- **Don't use ScreenCaptureKit**: it works (macOS 13+) but requires the Screen
+  Recording TCC class, which macOS 15 nags about monthly. The tap API's
+  dedicated "System Audio Recording Only" permission is prompt-once.
+- **Electron renderer capture is now real** (Electron ≥ 39, CATap-backed
+  `getDisplayMedia`) and would reuse our existing renderer→sidecar PCM path, but
+  it depends on the user's *installer* Electron version, which Obsidian only
+  updates on manual reinstall — not something the plugin can rely on. Keep the
+  sidecar backend as the primary plan; note the renderer path as a possible
+  future fallback.
+
+---
+
+## 1. CoreAudio process taps (the modern path)
+
+### API surface and minimum versions
+
+From the macOS 15.5 SDK headers
+(`CoreAudio.framework/Headers/AudioHardwareTapping.h`, mirror:
+<https://github.com/alexey-lysiuk/macos-sdk/blob/master/MacOSX15.5.sdk/System/Library/Frameworks/CoreAudio.framework/Versions/A/Headers/AudioHardwareTapping.h>):
+
+```c
+extern OSStatus
+AudioHardwareCreateProcessTap(CATapDescription* inDescription,
+                              AudioObjectID*  outTapID)  API_AVAILABLE(macos(14.2)) ...;
+extern OSStatus
+AudioHardwareDestroyProcessTap(AudioObjectID inTapID)    API_AVAILABLE(macos(14.2)) ...;
+```
+
+Note the whole header is wrapped in `#ifdef __OBJC__` — the declarations are
+invisible to plain-C tooling (this matters for bindgen; see §4).
+
+Per-symbol availability cross-checked against Apple's documentation JSON
+(`developer.apple.com/tutorials/data/documentation/...`):
+
+| Symbol | macOS availability | Source |
+| --- | --- | --- |
+| `AudioHardwareCreateProcessTap` | **14.2** | [docs](https://developer.apple.com/documentation/coreaudio/audiohardwarecreateprocesstap(_:_:)) |
+| `AudioHardwareDestroyProcessTap` | **14.2** (header annotation) | header above |
+| `CATapDescription` (class) | annotated **12.0** (docs and header agree) — but unusable before 14.2 because nothing public consumes it | [docs](https://developer.apple.com/documentation/coreaudio/catapdescription), header `CATapDescription.h` |
+| `CATapDescription.muteBehavior` | annotated 12.0 (enum `CATapMuteBehavior` annotated `macos(13.0)` in header) | [docs](https://developer.apple.com/documentation/coreaudio/catapdescription/mutebehavior) |
+| `NSAudioCaptureUsageDescription` (Info.plist key) | **14.2** | [docs](https://developer.apple.com/documentation/bundleresources/information-property-list/nsaudiocaptureusagedescription) |
+| `kAudioAggregateDeviceTapListKey`, `kAudioSubTapUIDKey`, `kAudioTapProperty*`, process-object selectors | plain `#define`/enums, no annotations; absent from the 13.3 SDK's `AudioHardware.h`, present from the 14.x SDKs on (verified by diffing SDK mirrors) | SDK mirror diff (13.3 vs 14.5) |
+
+**14.2 vs 14.4**: insidegui's AudioCap README claims "With macOS 14.4, Apple
+introduced new API in CoreAudio…" and the repo description says "macOS 14.4+"
+(<https://github.com/insidegui/AudioCap>). That conflicts with Apple's own
+annotations (14.2), Apple's sample-code page ("ensure that you're using macOS
+14.2 or later",
+<https://developer.apple.com/documentation/coreaudio/capturing-system-audio-with-core-audio-taps>)
+and Chromium, which gates at 14.2
+(`IsMacCatapSystemLoopbackCaptureSupported() { return MacOSVersion() >= 14'02'00; }`,
+[media/base/media_switches.cc](https://github.com/chromium/chromium/blob/main/media/base/media_switches.cc)).
+Recommendation: gate at **14.2** and rely on the runtime permission probe (§2)
+rather than a version check for correctness; treat 14.2/14.3 as best-effort
+(Chromium additionally works around a 14.x resampling bug, below).
+
+### Setup sequence (validated by three independent implementations)
+
+Apple's sample article ["Capturing system audio with Core Audio
+taps"](https://developer.apple.com/documentation/coreaudio/capturing-system-audio-with-core-audio-taps),
+AudioCap's
+[`ProcessTap.swift`](https://github.com/insidegui/AudioCap/blob/main/AudioCap/ProcessTap/ProcessTap.swift)
+and Chromium's
+[`media/audio/mac/catap_audio_input_stream.mm`](https://github.com/chromium/chromium/blob/main/media/audio/mac/catap_audio_input_stream.mm)
+all follow the same shape:
+
+1. (Optional, per-process taps) translate PIDs to process objects with
+   `kAudioHardwarePropertyTranslatePIDToProcessObject`
+   ([docs](https://developer.apple.com/documentation/coreaudio/kaudiohardwarepropertytranslatepidtoprocessobject)).
+2. Build a `CATapDescription`. For "everything the machine plays", use the
+   global-tap initializers from `CATapDescription.h`:
+   `initStereoGlobalTapButExcludeProcesses:` /
+   `initMonoGlobalTapButExcludeProcesses:` (pass an empty array to exclude
+   nothing, or your own process objects to avoid feedback). Set `name`,
+   `privateTap = true` (Chromium: `setPrivate:YES`), read/assign the `UUID`.
+   **`initMonoGlobalTapButExcludeProcesses:` is directly interesting for us**
+   — the tap itself mixes to mono, halving what we must resample to the
+   sidecar's 16 kHz mono frames.
+3. `AudioHardwareCreateProcessTap(desc, &tapID)`. Chromium notes the call
+   returns `kAudioObjectUnknown` as the tap ID "if the specified output device
+   doesn't exist" (comment in `catap_audio_input_stream.mm`).
+4. Create a **private aggregate device** whose
+   `kAudioAggregateDeviceTapListKey` contains one dictionary:
+   `{ kAudioSubTapUIDKey: <tap UUID string>, kAudioSubTapDriftCompensationKey: YES }`.
+   Chromium's aggregate contains *only* the tap (no sub-devices) plus
+   `kAudioAggregateDeviceIsPrivateKey: YES`, `kAudioAggregateDeviceTapAutoStartKey: NO`;
+   AudioCap and cidre's example additionally list the current default output
+   device under `kAudioAggregateDeviceSubDeviceListKey` and as
+   `kAudioAggregateDeviceMainSubDeviceKey`. Both work; the tap-only aggregate
+   is simpler and is what ships in Chrome.
+5. Read the tap's format: `kAudioTapPropertyFormat` returns an
+   `AudioStreamBasicDescription` — "the format of that data that will be
+   accessible in any aggregate device that contains the tap"
+   (`AudioHardware.h`; AudioCap `readAudioTapStreamBasicDescription()`).
+6. `AudioDeviceCreateIOProcID` (or `...WithBlock`) on the aggregate device, then
+   `AudioDeviceStart`. The IOProc's input buffer list carries the tap audio.
+7. Teardown, in order (AudioCap `invalidate()`): `AudioDeviceStop` →
+   `AudioDeviceDestroyIOProcID` → `AudioHardwareDestroyAggregateDevice` →
+   `AudioHardwareDestroyProcessTap`.
+
+### Default-output-device changes mid-capture
+
+Primary source: Chromium's implementation, which distinguishes two modes
+(comments on `kMacCatapCaptureAllDevices` in `catap_audio_input_stream.mm`):
+
+- A **global tap with no `deviceUID` set** "captures all system audio,
+  irrespective of the specific output device it's played on" — nothing to
+  rebuild when the default device changes, at the cost of mixing every output
+  device.
+- Chromium's **default mode** pins the tap to the default output device by
+  setting `tap_description_.deviceUID` and **rebuilds on change**: it installs
+  an `AudioObjectAddPropertyListener` on
+  `kAudioHardwarePropertyDefaultOutputDevice` and, via
+  `OnDefaultDeviceChange() → RestartStream()`, tears down and recreates the
+  whole source ("This stream is responsible for providing a seamless stream to
+  the listener, even if there are changes to the default output device,
+  achieved by reinitializing the `CatapAudioInputStreamSource` as needed" —
+  class comment on `CatapAudioInputStream`). It also watches
+  `kAudioDevicePropertyDeviceIsAlive` on the aggregate and errors out if the
+  device dies.
+
+Aggregates that embed the default output device as a sub-device (AudioCap
+style) are pinned to that device and must likewise be rebuilt. **Inference for
+us**: a device-less global mono tap is the simplest correct choice for
+dictation (follow-the-audio semantics, no restart machinery); keep a
+default-device listener only if we later pin to a device.
+
+Sample-rate caveat: "On macOS 14, CATap does not handle sample rate mismatches,
+making internal resampling necessary. This issue is resolved in macOS 15+"
+(`kMacCatapSonomaInternalResampling` comment, `catap_audio_input_stream.mm`).
+Safest plan: accept the tap's native format from `kAudioTapPropertyFormat` and
+resample to 16 kHz mono ourselves (the repo already has
+`native/src/system_audio/resample.rs`, currently `cfg(windows, test)`).
+
+### Mute behavior
+
+`CATapMuteBehavior` (`CATapDescription.h`): `CATapUnmuted = 0` (default; audio
+captured *and* still played), `CATapMuted = 1` (captured, not played),
+`CATapMutedWhenTapped = 2` (muted only while a client reads the tap). For
+dictation we keep the default `CATapUnmuted`. Chromium maps its
+"loopbackWithMute" device to `setMuteBehavior:CATapMuted`.
+
+## 2. TCC / permission UX for process taps
+
+### Which service, which prompt
+
+- The Info.plist key is `NSAudioCaptureUsageDescription` — "A message that
+  tells people why your app is requesting access to capture system audio on
+  macOS", introduced macOS 14.2
+  ([Apple docs](https://developer.apple.com/documentation/bundleresources/information-property-list/nsaudiocaptureusagedescription)).
+- Prompt timing, per Apple's sample article: "The first time you start
+  recording from an aggregate device that contains a tap, the system prompts
+  you to grant the app system audio recording permission"
+  ([Capturing system audio with Core Audio taps](https://developer.apple.com/documentation/coreaudio/capturing-system-audio-with-core-audio-taps)).
+  Chromium's comment is more precise about the trigger point: "If this is the
+  first time we're calling `AudioDeviceCreateIOProcID()`, this will trigger the
+  macOS permission dialog. If the user doesn't respond to the dialog, this call
+  will time out in 60 seconds. When this happens all interactions with
+  CoreAudio will fail until the audio process is restarted"
+  (`catap_audio_input_stream.mm`; Chromium literally kills its audio process on
+  that timeout, feature `kMacCatapRestartAudioProcessOnTimeout`). **Design
+  consequence for the sidecar**: run tap setup so that a wedged CoreAudio
+  session can be recovered — worst case the sidecar process itself must be
+  restartable, which our plugin already handles.
+- The private TCC service name is `kTCCServiceAudioCapture`: AudioCap
+  checks/requests it via `TCCAccessPreflight` / `TCCAccessRequest` from the
+  private TCC framework
+  ([`AudioRecordingPermission.swift`](https://github.com/insidegui/AudioCap/blob/main/AudioCap/ProcessTap/AudioRecordingPermission.swift)),
+  because "There's no public API to request audio recording permission or to
+  check if the app has that permission"
+  ([AudioCap README](https://github.com/insidegui/AudioCap#permission)).
+- Settings location on macOS 15+: System Settings → Privacy & Security →
+  **"Screen & System Audio Recording"**; Apple's user guide: "You can allow
+  apps to record both your screen and audio, or just your audio" (i.e. the pane
+  hosts a separate system-audio-only list)
+  ([Apple mac-help guide, macOS 15 selector](https://support.apple.com/guide/mac-help/mchld6aa7d23/15.0/mac/15.0)).
+  `tccutil reset <service>` resets decisions per the macOS man page; the
+  documented service name for screen recording is `ScreenCapture`, and the
+  audio-capture service is `AudioCapture` (kTCCService prefix stripped) —
+  *inference from the SPI service name; not verified on hardware in this
+  research pass*.
+
+### Missing usage description ⇒ silent failure, not a crash
+
+The Electron project hit exactly this when Chromium made CATap the default:
+"desktopCapturer abruptly stops working without the new plist entry… Electron's
+`desktopCapturer` will create a **dead audio stream** if the new permission is
+absent however **no errors or warnings will occur**"
+([electron/electron#49717](https://github.com/electron/electron/pull/49717),
+merged 2026-02, backported to 39/40/41). So unlike AVFoundation microphone
+access (where a missing `NSMicrophoneUsageDescription` kills the app —
+[Apple docs](https://developer.apple.com/documentation/BundleResources/Information-Property-List/NSMicrophoneUsageDescription)),
+a missing `NSAudioCaptureUsageDescription` yields **no prompt and zero
+audio**. This is the exact "silent zero-audio" trap #159 must design against.
+
+### Who is the "responsible process" for our sidecar?
+
+Quinn (Apple DTS), "On File System Permissions"
+([developer.apple.com/forums/thread/678819](https://developer.apple.com/forums/thread/678819)):
+
+> "The MAC privilege mechanism is heavily dependent on the concept of
+> *responsible code*. For example, if an app contains a helper tool and the
+> helper tool triggers a MAC prompt, we want: the app's name and usage
+> description to appear in the alert; the user's decision to be recorded for
+> the whole app, not that specific helper tool; that decision to show up in
+> System Settings under the app's name."
+
+A directly spawned child (our sidecar is `spawn()`ed by Obsidian's renderer
+process) is attributed to the app; the chain only breaks if the child
+"daemonizes itself" or is launched via launchd (fixable with
+`AssociatedBundleIdentifiers`), or if the parent explicitly disclaims
+responsibility (`responsibility_spawnattrs_setdisclaim`, which WebKit uses for
+its helper processes — see
+[Qt's write-up "The Curious Case of the Responsible Process"](https://www.qt.io/blog/the-curious-case-of-the-responsible-process)).
+**Conclusion**: the TCC prompt and grant will carry Obsidian's name, icon and
+usage string; the sidecar being unsigned is irrelevant to attribution. The
+grant persists for Obsidian, so it survives sidecar restarts.
+
+### Does Obsidian.app carry `NSAudioCaptureUsageDescription`?
+
+Chain of evidence (no public dump of Obsidian's shipped plist was found):
+
+- Electron's default `shell/browser/resources/mac/Info.plist` includes
+  `NSMicrophoneUsageDescription` / `NSCameraUsageDescription` ("This app needs
+  access to the microphone/camera") since 2019
+  ([electron#19871](https://github.com/electron/electron/pull/19871)) and
+  gained `NSAudioCaptureUsageDescription` = "This app needs access to audio
+  capture" in
+  [electron#49717](https://github.com/electron/electron/pull/49717)
+  (main, 2026-02-10; 39-x-y backport
+  [#49740](https://github.com/electron/electron/pull/49740) merged 2026-02-11,
+  first shipped in **v39.6.0**, 2026-02-13 — release dates from the Electron
+  releases API; commit `0aba4a6ab8` is an ancestor of v39.8.3).
+- Obsidian 1.12.7 (2026-03-23): "The installer has been updated to use Electron
+  v39.8.3" ([Obsidian changelog](https://obsidian.md/changelog/2026-03-23-desktop-v1.12.7/)).
+- electron-builder-produced apps start from Electron's bundled plist and merge
+  app-specific keys, so the default usage-description keys survive unless the
+  vendor deletes them (observation of the packaging model; Obsidian is known to
+  ship Electron's default mic string).
+
+**Inference**: Obsidian installers ≥ 1.12.7 ship the key; anything on an older
+installer base (Obsidian updates Electron **only** via installer reinstall, see
+changelog note) does not, and will hit the silent-dead-stream path. First
+implementation task on a Mac: `plutil -p /Applications/Obsidian.app/Contents/Info.plist`
+to confirm.
+
+### Pre-flighting permission state
+
+- **Public-API probe (recommended; what Chrome ships)**: after creating the
+  tap, read `kAudioTapPropertyDescription` and write it back; "If either of
+  these operations fail, this function returns false which is an indication
+  that we don't have system audio capture permission"
+  (`CatapAudioInputStreamSource::ProbeAudioTapPermissions`,
+  `catap_audio_input_stream.mm`; feature `kMacCatapProbeTapOnCreation`,
+  enabled by default; failure maps to `OpenOutcome::kFailedSystemPermissions`).
+  Note tap *creation itself succeeds without permission* — only the audio is
+  withheld, hence the probe.
+- **TCC SPI** (`TCCAccessPreflight`/`TCCAccessRequest` on
+  `kTCCServiceAudioCapture` via dlopen of the private TCC framework): gives a
+  true tri-state without instantiating a tap (AudioCap, link above). Private
+  API; fine for a non-MAS sidecar, but a stability/App-Review liability. Our
+  Linux backend already dlopens libpulse, so mechanically this is familiar —
+  keep it optional if used at all.
+- Map probe failure to a new `SystemAudioError` variant with guidance ("enable
+  Obsidian under System Settings → Privacy & Security → Screen & System Audio
+  Recording"), mirroring how `SystemAudioError::message()` already documents
+  the virtual-device fallback (`native/src/system_audio/mod.rs`).
+
+## 3. ScreenCaptureKit audio (the alternative)
+
+- `SCStreamConfiguration.capturesAudio` and `excludesCurrentProcessAudio` are
+  macOS **13.0+**; `captureMicrophone` and `SCRecordingOutput` are macOS
+  **15.0+**; `SCContentSharingPicker` is macOS 14.0+ (Apple docs JSON
+  availability:
+  [capturesAudio](https://developer.apple.com/documentation/screencapturekit/scstreamconfiguration/capturesaudio),
+  [captureMicrophone](https://developer.apple.com/documentation/screencapturekit/scstreamconfiguration/capturemicrophone),
+  [SCRecordingOutput](https://developer.apple.com/documentation/screencapturekit/screcordingoutput),
+  [SCContentSharingPicker](https://developer.apple.com/documentation/screencapturekit/sccontentsharingpicker)).
+- **Audio-only capture is possible** — Chromium's SCK loopback adds only an
+  `SCStreamOutputTypeAudio` output and notes: "All settings related to video
+  capture must remain at their default values, otherwise a video sample stream
+  output must also be added"
+  ([media/audio/mac/audio_loopback_input_mac_impl.mm](https://github.com/chromium/chromium/blob/main/media/audio/mac/audio_loopback_input_mac_impl.mm)).
+  No video frames are delivered, but a display `SCContentFilter` (from
+  `SCShareableContent`) is still required.
+- **Permission**: the framework overview instructs "Request screen recording
+  permission from the person before capturing content" via
+  `NSScreenCaptureUsageDescription`
+  ([ScreenCaptureKit overview](https://developer.apple.com/documentation/screencapturekit));
+  Chromium treats `SCShareableContent` retrieval failure as
+  `kFailedSystemPermissions` (same file). There is **no SCK system-audio-only
+  mode that avoids the Screen Recording TCC class** — audio-only SCK still
+  rides the screen-recording grant; Apple's system-audio-only permission is
+  the Core Audio tap service from §2. (macOS 15's picker,
+  `SCContentSharingPicker`, avoids the TCC prompt but requires interactive
+  content selection per session — unusable for a background dictation source.)
+- **macOS 15 re-approval nags**: Sequoia betas prompted weekly to re-confirm
+  screen-recording apps, changed to monthly by beta 6 and further relaxed in
+  15.1 ("Applications using our deprecated content capture technologies now
+  have enhanced user awareness policies" — Apple 15.1 beta release note quoted
+  by press;
+  [MacRumors](https://www.macrumors.com/2024/08/15/macos-sequoia-screen-recording-app-permissions/),
+  [9to5Mac](https://9to5mac.com/2024/10/07/macos-sequoia-screen-recording-popups/);
+  prompt text: "…requesting to bypass the system private window picker and
+  directly access your screen and audio…"). Apple added the
+  [`com.apple.developer.persistent-content-capture`](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.developer.persistent-content-capture)
+  entitlement (macOS 15.0+) for VNC-class apps to opt out — not attainable for
+  an unsigned sidecar. SCK capture also lights the screen-sharing menu-bar
+  indicator. **This recurring-nag UX is disqualifying for a dictation feature
+  when the tap API exists**; Chromium itself now prefers CATap and keeps SCK
+  loopback only for macOS < 15
+  (`IsMacSckSystemLoopbackCaptureSupported() { return MacOSVersion() < 15'00'00 || …; }`,
+  media_switches.cc).
+
+## 4. Rust bindings landscape
+
+- **`coreaudio-sys` (0.2.18)**: bindgen runs at build time in **C mode** over
+  the umbrella `CoreAudio/CoreAudio.h`
+  ([build.rs](https://github.com/RustAudio/coreaudio-sys/blob/master/build.rs)).
+  Because `AudioHardwareTapping.h`/`CATapDescription.h` are `#ifdef __OBJC__`,
+  **`AudioHardwareCreateProcessTap` and `CATapDescription` are not generated**;
+  the plain-C aggregate/tap constants (`kAudioAggregateDeviceTapListKey`,
+  `kAudioSubTapUIDKey`, `kAudioTapPropertyFormat`, `AudioHardwareCreateAggregateDevice`,
+  `AudioDeviceCreateIOProcID*`, …) *are* available **iff the build machine's
+  SDK is ≥ 14.x** (bindings are SDK-dependent at compile time). AFFiNE builds
+  on exactly this split: constants from `coreaudio::sys`, tap functions via
+  hand-rolled `unsafe extern "C"`, `CATapDescription` via `objc2::msg_send!`
+  ([tap_audio.rs](https://github.com/toeverything/AFFiNE/blob/canary/packages/frontend/native/media_capture/src/macos/tap_audio.rs),
+  [ca_tap_description.rs](https://github.com/toeverything/AFFiNE/blob/canary/packages/frontend/native/media_capture/src/macos/ca_tap_description.rs)).
+- **`objc2-core-audio` (0.3.2, MIT/Apache-2.0/Zlib, auto-generated by the
+  objc2 project)**: exposes the full set —
+  [`AudioHardwareCreateProcessTap`](https://docs.rs/objc2-core-audio/latest/objc2_core_audio/fn.AudioHardwareCreateProcessTap.html)
+  / `AudioHardwareDestroyProcessTap` (as `unsafe extern "C-unwind"` fns, feature
+  `AudioHardware` + `objc2`), `CATapDescription`, `kAudioTapPropertyFormat`,
+  `AudioHardwareCreateAggregateDevice`, `AudioDeviceCreateIOProcID`. Caveat:
+  the tap functions are ordinary link-time imports with no weak-linking
+  support, so a sidecar binary that *calls through the crate's extern* carries
+  a hard symbol dependency — fine only if the symbol exists on our minimum
+  supported macOS, which it does **not** (sidecar must still run for mic
+  dictation on macOS < 14.2). Usable if we route those two calls through
+  `dlsym` ourselves and use the crate for constants/class glue.
+- **`cidre` (0.16.0, MIT, active, `rust-version = 1.88`, edition 2024)**: the
+  most complete bindings — `TapDesc` with all six initializers
+  ([tap_description.rs](https://github.com/yury/cidre/blob/main/cidre/src/core_audio/tap_description.rs)),
+  `Tap`/`TapGuard` RAII incl. `asbd()` for `kAudioTapPropertyFormat`
+  ([hardware_tapping.rs](https://github.com/yury/cidre/blob/main/cidre/src/core_audio/hardware_tapping.rs)),
+  and a complete ~100-line system-audio recorder example
+  ([examples/core-audio-record](https://github.com/yury/cidre/blob/main/cidre/examples/core-audio-record/main.rs)).
+  Great as *reference code*; as a dependency it drags in a very large
+  multi-framework crate, against this repo's dependency posture.
+- **`screencapturekit` crate (8.0.0)** exists and is maintained, but only
+  matters if we chose SCK (§3 says don't).
+- **Recommended route (matches repo style)**: hand-rolled backend file like
+  `windows.rs`/`linux.rs`:
+  - `objc2` + `objc2-foundation` for `CATapDescription` via
+    `AnyClass::get(c"CATapDescription")` + `msg_send!` — runtime lookup returns
+    `None` on old macOS instead of a load failure (AFFiNE pattern), or
+    `extern_class!` as seren-desktop does;
+  - the two 14.2-only functions resolved with
+    `dlsym(RTLD_DEFAULT, "AudioHardwareCreateProcessTap")` at first use,
+    returning `SystemAudioError::Unsupported` when absent — precedent:
+    [seren-desktop `src-tauri/src/audio/capture/macos.rs`](https://github.com/serenorg/seren-desktop/blob/main/src-tauri/src/audio/capture/macos.rs)
+    ("Resolve them lazily via `dlsym` instead and report `Unsupported` when
+    absent");
+  - long-standing C API (`AudioHardwareCreateAggregateDevice`,
+    `AudioDeviceCreateIOProcID`, `AudioObjectGetPropertyData`, `AudioDeviceStart/Stop`)
+    via a small `extern "C"` block (or `objc2-core-audio` for its constants).
+  MSRV/edition: repo is edition 2024 / rust 1.94.1 (`native/Cargo.toml`);
+  `objc2` 0.6.x and `objc2-core-audio` 0.3.x are comfortably below that.
+
+## 5. Electron/Chromium loopback (completeness check)
+
+- **Chromium**: system-audio loopback on macOS is implemented twice — SCK-based
+  (`media/audio/mac/audio_loopback_input_mac_impl.mm`, macOS 13+) and
+  CATap-based (`media/audio/mac/catap_audio_input_stream.{h,mm}`, macOS 14.2+).
+  Current main: `kMacCatapLoopbackAudioForScreenShare` is
+  `FEATURE_ENABLED_BY_DEFAULT` and SCK is only "supported" below macOS 15
+  ([media_switches.cc](https://github.com/chromium/chromium/blob/main/media/base/media_switches.cc)).
+  So `getDisplayMedia({audio:…})`-driven system audio on modern macOS goes
+  through the same tap API + `NSAudioCaptureUsageDescription` + audio-capture
+  TCC service described in §§1–2.
+- **Electron**: the [desktopCapturer docs](https://www.electronjs.org/docs/latest/api/desktop-capturer)
+  state that "As of Electron v39.0.0-beta.4, Chromium made Apple's CoreAudio
+  Tap API the default for desktop audio capture", that
+  `NSAudioCaptureUsageDescription` is required, and that the absence of the key
+  produces a dead stream with no errors
+  ([PR #49717](https://github.com/electron/electron/pull/49717)); apps can
+  revert via `disable-features=MacCatapLoopbackAudioForScreenShare`. (The
+  [session.md](https://github.com/electron/electron/blob/main/docs/api/session.md)
+  note that the `audio: 'loopback'` *string shortcut* is Windows-only is about
+  that specific handler API, not about macOS loopback overall.)
+- **Obsidian**: ships Electron 39.8.3 in the 1.12.7 installer
+  ([changelog](https://obsidian.md/changelog/2026-03-23-desktop-v1.12.7/)), so
+  a renderer-side `getDisplayMedia` system-audio capture is *technically
+  plausible today* and would flow into our existing renderer→sidecar PCM
+  protocol unchanged. But: (a) it depends on the **installer** Electron, which
+  users update only by reinstalling; (b) the plugin cannot install the
+  display-media request handler (that's app code; Obsidian would have to wire
+  it — plugins only get `navigator.mediaDevices`, and `getDisplayMedia` without
+  a handler fails in Electron); (c) picker/permission behavior is outside our
+  control. **Recommendation**: not viable as the primary mechanism; revisit
+  only if Obsidian exposes a display-media handler.
+
+## 6. Prior art to crib from
+
+| Project | Language / shape | What to take |
+| --- | --- | --- |
+| [insidegui/AudioCap](https://github.com/insidegui/AudioCap) — [`ProcessTap.swift`](https://github.com/insidegui/AudioCap/blob/main/AudioCap/ProcessTap/ProcessTap.swift), [`AudioRecordingPermission.swift`](https://github.com/insidegui/AudioCap/blob/main/AudioCap/ProcessTap/AudioRecordingPermission.swift) | Swift app | Canonical minimal tap+aggregate lifecycle; TCC SPI preflight; teardown ordering (`invalidate()`) |
+| Chromium [`media/audio/mac/catap_audio_input_stream.mm`](https://github.com/chromium/chromium/blob/main/media/audio/mac/catap_audio_input_stream.mm) (+`catap_api.h` seam for testing) | C++/ObjC++, production | Permission probe (`ProbeAudioTapPermissions`), default-device-change restart, 60 s prompt-timeout hazard, mono/stereo + resampling strategy per macOS version, tap-only aggregate dict |
+| [yury/cidre `examples/core-audio-record`](https://github.com/yury/cidre/blob/main/cidre/examples/core-audio-record/main.rs) + [`core_audio/hardware_tapping.rs`](https://github.com/yury/cidre/blob/main/cidre/src/core_audio/hardware_tapping.rs) | Rust | Complete end-to-end Rust recorder; RAII guards over tap/aggregate |
+| [AFFiNE `media_capture/src/macos/tap_audio.rs`](https://github.com/toeverything/AFFiNE/blob/canary/packages/frontend/native/media_capture/src/macos/tap_audio.rs), [`ca_tap_description.rs`](https://github.com/toeverything/AFFiNE/blob/canary/packages/frontend/native/media_capture/src/macos/ca_tap_description.rs) | Rust NAPI module inside an **Electron** app | Closest overall architecture to ours: coreaudio-sys constants + hand-rolled extern + `objc2 msg_send!` class glue; device/property-listener handling |
+| [serenorg/seren-desktop `src-tauri/src/audio/capture/macos.rs`](https://github.com/serenorg/seren-desktop/blob/main/src-tauri/src/audio/capture/macos.rs) | Rust (Tauri) | The `dlsym(RTLD_DEFAULT)` lazy-resolution pattern for the 14.2-only symbols — the exact portability trick our single-binary sidecar needs |
+| Chromium [`media/audio/mac/audio_loopback_input_mac_impl.mm`](https://github.com/chromium/chromium/blob/main/media/audio/mac/audio_loopback_input_mac_impl.mm) | C++/ObjC++ | Only if SCK ever becomes relevant: audio-only SCK stream configuration |
+
+Other Rust codebases found using `AudioHardwareCreateProcessTap` (GitHub code
+search, 2026-07): snolab/CapsLockX, pathorsAI/parley, majorsimon/midium,
+rankun203/meeting-notes, zouwei/moraya, fluxerapp/fluxer, khawkins98/Hush,
+kenotron-ms/side-huddle, djgould/audio-tap-tauri-example — all follow either
+the AFFiNE (extern + msg_send) or cidre route; none surfaced problems beyond
+the permission/attribution issues documented above.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -63,9 +63,10 @@ it into fixed 640-byte frames at 50 fps.
   linear-interpolation resampling from the browser's native rate (44.1/48 kHz)
   down to 16 kHz.
 - **System audio** (this computer's output) is captured natively by the sidecar
-  on Windows (WASAPI loopback) and Linux (the default PulseAudio/PipeWire
-  monitor). It is optional and graceful — if the platform's audio stack is
-  unavailable (as on macOS) the source is simply hidden.
+  on Windows (WASAPI loopback), Linux (the default PulseAudio/PipeWire monitor),
+  and macOS 14.2+ (CoreAudio process taps attached to a private aggregate
+  device). It is optional and graceful — if the platform's audio stack is
+  unavailable the source is simply hidden.
 
 **PCM format** (shared constants, identical in TS and Rust):
 

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -92,6 +92,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +320,16 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -838,8 +857,11 @@ dependencies = [
  "futures-util",
  "half",
  "hound",
+ "libc",
  "libloading 0.9.0",
  "ndarray",
+ "objc2",
+ "objc2-foundation",
  "ort",
  "realfft",
  "reqwest",
@@ -954,6 +976,45 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -72,3 +72,8 @@ wasapi = "0.23.0"
 # only Linux capture dependency — no libpulse-dev / pkg-config at build time.
 [target."cfg(target_os = \"linux\")".dependencies]
 libloading = "0.9"
+
+[target."cfg(target_os = \"macos\")".dependencies]
+libc = "0.2"
+objc2 = "0.6.4"
+objc2-foundation = "0.3.2"

--- a/native/src/app.rs
+++ b/native/src/app.rs
@@ -293,6 +293,7 @@ impl AppState {
 
                 (ControlFlow::Continue, events)
             }
+            Command::ProbeSystemAudio => (ControlFlow::Continue, events),
             Command::ContextResponse {
                 correlation_id,
                 context,
@@ -2166,6 +2167,32 @@ mod tests {
             !app.active_sessions.contains_key("session-1"),
             "failed system-audio start must tear down the partially-created session"
         );
+    }
+
+    #[test]
+    fn system_audio_permission_denied_reports_permission_code() {
+        let model_file_path = create_model_file();
+        let system_audio = FakeSystemAudioState::default();
+        system_audio.fail_start(SystemAudioError::PermissionDenied);
+        let mut app = test_app_with_system_audio(system_audio.clone());
+
+        let (_, events) = app.handle_command(start_session_command_with_system_audio(
+            "session-1",
+            &model_file_path,
+            true,
+        ));
+
+        assert_eq!(
+            events,
+            vec![Event::Error {
+                code: "system_audio_permission_denied".to_string(),
+                details: None,
+                message: "System-audio recording permission is off for Obsidian. Open System Settings → Privacy & Security → Screen & System Audio Recording, enable Obsidian, and try again.".to_string(),
+                session_id: Some("session-1".to_string()),
+            }]
+        );
+        assert_eq!(system_audio.starts(), vec!["session-1"]);
+        assert_eq!(system_audio.stops(), vec!["session-1"]);
     }
 
     #[test]

--- a/native/src/main.rs
+++ b/native/src/main.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use local_dictation_sidecar::app::{AppState, ControlFlow};
 use local_dictation_sidecar::catalog::ModelCatalog;
 use local_dictation_sidecar::protocol::{
-    AudioFrame, Event, IncomingFrame, read_frame, write_event_frame,
+    AudioFrame, Command, Event, IncomingFrame, read_frame, write_event_frame,
 };
 use whisper_rs::install_logging_hooks;
 
@@ -17,6 +17,7 @@ enum InputMessage {
     Frame(IncomingFrame),
     ProtocolError(String),
     SystemAudio(AudioFrame),
+    SystemAudioProbeResult(Event),
 }
 
 fn main() -> Result<()> {
@@ -37,7 +38,7 @@ fn run_stdio(catalog: ModelCatalog, sidecar_version: String) -> Result<()> {
     // into the same channel the stdin reader feeds, so they flow through the
     // identical command/audio dispatch path. `Sender` is `!Sync`, so a `Mutex`
     // makes the sink satisfy the `Send + Sync` bound.
-    let sink_tx = Mutex::new(input_tx);
+    let sink_tx = Mutex::new(input_tx.clone());
     app_state.set_system_audio_sink(Arc::new(move |frame| {
         if let Ok(tx) = sink_tx.lock() {
             let _ = tx.send(InputMessage::SystemAudio(frame));
@@ -54,6 +55,10 @@ fn run_stdio(catalog: ModelCatalog, sidecar_version: String) -> Result<()> {
                         ControlFlow::Continue,
                         app_state.handle_audio_frame(audio_frame),
                     ),
+                    IncomingFrame::Command(Command::ProbeSystemAudio) => {
+                        spawn_system_audio_probe(input_tx.clone());
+                        (ControlFlow::Continue, Vec::new())
+                    }
                     IncomingFrame::Command(command) => app_state.handle_command(command),
                 };
 
@@ -68,6 +73,9 @@ fn run_stdio(catalog: ModelCatalog, sidecar_version: String) -> Result<()> {
                     &mut writer,
                     app_state.handle_system_audio_frame(audio_frame),
                 )?;
+            }
+            Ok(InputMessage::SystemAudioProbeResult(event)) => {
+                write_events(&mut writer, vec![event])?;
             }
             Ok(InputMessage::ProtocolError(details)) => {
                 write_events(
@@ -115,6 +123,25 @@ fn spawn_input_reader(tx: Sender<InputMessage>) {
                 }
             }
         }
+    });
+}
+
+fn spawn_system_audio_probe(tx: Sender<InputMessage>) {
+    thread::spawn(move || {
+        let event = match local_dictation_sidecar::system_audio::probe_system_audio() {
+            Ok(()) => Event::SystemAudioProbeResult {
+                ok: true,
+                code: None,
+                message: None,
+            },
+            Err(error) => Event::SystemAudioProbeResult {
+                ok: false,
+                code: Some(error.code().to_string()),
+                message: Some(error.message()),
+            },
+        };
+
+        let _ = tx.send(InputMessage::SystemAudioProbeResult(event));
     });
 }
 

--- a/native/src/protocol.rs
+++ b/native/src/protocol.rs
@@ -266,6 +266,7 @@ struct CommandEnvelope {
 )]
 pub enum Command {
     Health,
+    ProbeSystemAudio,
     StartSession {
         #[serde(default)]
         acceleration_preference: AccelerationPreference,
@@ -398,6 +399,13 @@ pub enum Event {
         compiled_runtimes: Vec<CompiledRuntimeInfo>,
         compiled_adapters: Vec<CompiledAdapterInfo>,
         system_info: String,
+    },
+    SystemAudioProbeResult {
+        ok: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        code: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
     },
     SessionStarted {
         mode: ListeningMode,
@@ -703,6 +711,22 @@ mod tests {
     }
 
     #[test]
+    fn probe_system_audio_command_round_trips() {
+        let payload = serde_json::to_vec(&serde_json::json!({
+            "type": "probe_system_audio"
+        }))
+        .expect("payload should serialize");
+        let mut framed = Vec::new();
+        write_frame(&mut framed, JSON_FRAME_KIND, &payload).expect("frame should write");
+
+        let parsed = read_frame(&mut framed.as_slice())
+            .expect("frame should parse")
+            .expect("frame should exist");
+
+        assert_eq!(parsed, IncomingFrame::Command(Command::ProbeSystemAudio));
+    }
+
+    #[test]
     fn audio_level_event_serializes_for_ribbon_metering() {
         let event = Event::AudioLevel {
             bands: [0.0, 0.1, 0.2, 0.3, 0.4, 1.0],
@@ -714,6 +738,28 @@ mod tests {
         let parsed: EventEnvelope = serde_json::from_slice(payload).expect("event should parse");
 
         assert_eq!(parsed.event, event);
+    }
+
+    #[test]
+    fn system_audio_probe_result_omits_success_error_fields() {
+        let event = Event::SystemAudioProbeResult {
+            ok: true,
+            code: None,
+            message: None,
+        };
+        let mut framed = Vec::new();
+        write_event_frame(&mut framed, &event).expect("event should write");
+        let payload = &framed[FRAME_HEADER_LENGTH..];
+        let parsed: serde_json::Value =
+            serde_json::from_slice(payload).expect("event should parse");
+
+        assert_eq!(
+            parsed,
+            serde_json::json!({
+                "type": "system_audio_probe_result",
+                "ok": true
+            })
+        );
     }
 
     #[test]

--- a/native/src/system_audio/macos.rs
+++ b/native/src/system_audio/macos.rs
@@ -3,46 +3,22 @@
 //! The tap entry points arrived in macOS 14.2, so they are resolved with
 //! `dlsym` instead of linked. The older aggregate-device and IOProc APIs are
 //! linked normally through CoreAudio.
-
-#[cfg(target_os = "macos")]
-use std::sync::Arc;
-#[cfg(target_os = "macos")]
-use std::sync::atomic::{AtomicBool, Ordering};
-#[cfg(target_os = "macos")]
-use std::sync::mpsc;
-#[cfg(target_os = "macos")]
-use std::thread;
-#[cfg(target_os = "macos")]
-use std::time::Duration;
+//!
+//! Everything that touches CoreAudio lives in the `platform` module, gated on
+//! macOS as one unit. The items above it are pure format/description helpers
+//! that also compile under `cfg(test)` so the host test suite covers them.
 
 use super::SystemAudioError;
-#[cfg(target_os = "macos")]
-use super::{AudioFrameSink, CaptureHandle};
-
-#[cfg(target_os = "macos")]
-const INIT_TIMEOUT: Duration = Duration::from_secs(10);
-
-#[cfg(target_os = "macos")]
-const MACOS_UNSUPPORTED_MESSAGE: &str = "System-audio capture needs macOS 14.2 or later. Route \
-    output through a virtual audio device (BlackHole) and pick it as your microphone instead.";
 
 type OSStatus = i32;
-#[cfg(target_os = "macos")]
-type AudioObjectID = u32;
 type AudioObjectPropertySelector = u32;
 type AudioObjectPropertyScope = u32;
 type AudioObjectPropertyElement = u32;
 type AudioFormatID = u32;
 type AudioFormatFlags = u32;
 
-#[cfg(target_os = "macos")]
-const K_AUDIO_HARDWARE_NO_ERROR: OSStatus = 0;
-#[cfg(target_os = "macos")]
-const K_AUDIO_OBJECT_UNKNOWN: AudioObjectID = 0;
 const K_AUDIO_OBJECT_PROPERTY_SCOPE_GLOBAL: AudioObjectPropertyScope = 0x676c_6f62;
 const K_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN: AudioObjectPropertyElement = 0;
-#[cfg(target_os = "macos")]
-const K_AUDIO_TAP_PROPERTY_DESCRIPTION: AudioObjectPropertySelector = 0x7464_7363;
 const K_AUDIO_TAP_PROPERTY_FORMAT: AudioObjectPropertySelector = 0x7466_6d74;
 const K_AUDIO_FORMAT_LINEAR_PCM: AudioFormatID = 0x6c70_636d;
 const K_AUDIO_FORMAT_FLAG_IS_FLOAT: AudioFormatFlags = 1 << 0;
@@ -55,23 +31,6 @@ struct AudioObjectPropertyAddress {
     m_selector: AudioObjectPropertySelector,
     m_scope: AudioObjectPropertyScope,
     m_element: AudioObjectPropertyElement,
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg(target_os = "macos")]
-struct AudioBuffer {
-    m_number_channels: u32,
-    m_data_byte_size: u32,
-    m_data: *mut std::ffi::c_void,
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg(target_os = "macos")]
-struct AudioBufferList {
-    m_number_buffers: u32,
-    m_buffers: [AudioBuffer; 1],
 }
 
 #[repr(C)]
@@ -101,53 +60,6 @@ struct AggregateDeviceDescription {
     tap_auto_start: bool,
     tap_uid: String,
     drift_compensation: bool,
-}
-
-#[cfg(target_os = "macos")]
-pub(crate) fn spawn_capture(
-    session_id: String,
-    sink: AudioFrameSink,
-) -> Result<CaptureHandle, SystemAudioError> {
-    spawn_capture_with_timeout(session_id, sink, INIT_TIMEOUT)
-}
-
-#[cfg(target_os = "macos")]
-pub(super) fn spawn_capture_with_timeout(
-    session_id: String,
-    sink: AudioFrameSink,
-    init_timeout: Duration,
-) -> Result<CaptureHandle, SystemAudioError> {
-    let stop = Arc::new(AtomicBool::new(false));
-    let thread_stop = Arc::clone(&stop);
-    let (init_tx, init_rx) = mpsc::channel::<Result<(), SystemAudioError>>();
-
-    let join = thread::spawn(move || capture_thread(session_id, sink, thread_stop, init_tx));
-
-    match init_rx.recv_timeout(init_timeout) {
-        Ok(Ok(())) => Ok(CaptureHandle::new(stop, join)),
-        Ok(Err(error)) => {
-            let _ = join.join();
-            Err(error)
-        }
-        Err(_) => {
-            stop.store(true, Ordering::Relaxed);
-            Err(SystemAudioError::Capture(
-                "timed out opening the macOS system-audio tap".into(),
-            ))
-        }
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn capture_thread(
-    session_id: String,
-    sink: AudioFrameSink,
-    stop: Arc<AtomicBool>,
-    init_tx: mpsc::Sender<Result<(), SystemAudioError>>,
-) {
-    if let Err(error) = platform::run_capture(session_id, sink, stop, init_tx) {
-        eprintln!("system-audio capture: {error}");
-    }
 }
 
 fn parse_tap_format(
@@ -215,18 +127,6 @@ fn tap_property_address(selector: AudioObjectPropertySelector) -> AudioObjectPro
     }
 }
 
-#[cfg(target_os = "macos")]
-fn os_status_result(status: OSStatus, action: &str) -> Result<(), SystemAudioError> {
-    if status == K_AUDIO_HARDWARE_NO_ERROR {
-        Ok(())
-    } else {
-        Err(SystemAudioError::Capture(format!(
-            "{action} failed with CoreAudio status {}",
-            format_os_status(status)
-        )))
-    }
-}
-
 fn format_os_status(status: OSStatus) -> String {
     let bytes = (status as u32).to_be_bytes();
     if bytes
@@ -240,13 +140,17 @@ fn format_os_status(status: OSStatus) -> String {
 }
 
 #[cfg(target_os = "macos")]
+pub(crate) use platform::{spawn_capture, spawn_capture_with_timeout};
+
+#[cfg(target_os = "macos")]
 mod platform {
-    use std::ffi::c_void;
+    use std::ffi::{CStr, c_void};
     use std::mem;
     use std::ptr;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc::{self, SyncSender};
+    use std::thread;
     use std::time::Duration;
 
     use objc2::msg_send;
@@ -255,23 +159,48 @@ mod platform {
     use objc2_foundation::{NSArray, NSDictionary, NSNumber, NSString, NSUUID};
 
     use super::{
-        AudioBufferList, AudioFrameSink, AudioObjectID, AudioObjectPropertyAddress,
-        AudioStreamBasicDescription, K_AUDIO_OBJECT_UNKNOWN, K_AUDIO_TAP_PROPERTY_DESCRIPTION,
-        K_AUDIO_TAP_PROPERTY_FORMAT, MACOS_UNSUPPORTED_MESSAGE, MacLoopbackFormat, OSStatus,
-        SystemAudioError, aggregate_device_description, os_status_result, parse_tap_format,
-        tap_property_address,
+        AudioObjectPropertyAddress, AudioStreamBasicDescription, K_AUDIO_TAP_PROPERTY_FORMAT,
+        MacLoopbackFormat, OSStatus, SystemAudioError, aggregate_device_description,
+        format_os_status, parse_tap_format, tap_property_address,
     };
     use crate::protocol::AudioFrame;
     use crate::system_audio::resample::LoopbackFrameResampler;
+    use crate::system_audio::{AudioFrameSink, CaptureHandle};
 
+    type AudioObjectID = u32;
+
+    const INIT_TIMEOUT: Duration = Duration::from_secs(10);
     const SAMPLE_CHANNEL_CAPACITY: usize = 8;
     const DRAIN_INTERVAL: Duration = Duration::from_millis(10);
+
+    const MACOS_UNSUPPORTED_MESSAGE: &str = "System-audio capture needs macOS 14.2 or later. \
+        Route output through a virtual audio device (BlackHole) and pick it as your microphone \
+        instead.";
+
+    const K_AUDIO_HARDWARE_NO_ERROR: OSStatus = 0;
+    const K_AUDIO_OBJECT_UNKNOWN: AudioObjectID = 0;
+    const K_AUDIO_TAP_PROPERTY_DESCRIPTION: super::AudioObjectPropertySelector = 0x7464_7363;
 
     const K_AUDIO_AGGREGATE_DEVICE_IS_PRIVATE_KEY: &str = "private";
     const K_AUDIO_AGGREGATE_DEVICE_TAP_LIST_KEY: &str = "taps";
     const K_AUDIO_AGGREGATE_DEVICE_TAP_AUTO_START_KEY: &str = "tapautostart";
     const K_AUDIO_SUB_TAP_UID_KEY: &str = "uid";
     const K_AUDIO_SUB_TAP_DRIFT_COMPENSATION_KEY: &str = "drift";
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    struct AudioBuffer {
+        m_number_channels: u32,
+        m_data_byte_size: u32,
+        m_data: *mut c_void,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    struct AudioBufferList {
+        m_number_buffers: u32,
+        m_buffers: [AudioBuffer; 1],
+    }
 
     type CreateProcessTap = unsafe extern "C" fn(
         in_description: *mut AnyObject,
@@ -400,7 +329,62 @@ mod platform {
         tx: SyncSender<Vec<f32>>,
     }
 
-    pub(super) fn run_capture(
+    pub(crate) fn spawn_capture(
+        session_id: String,
+        sink: AudioFrameSink,
+    ) -> Result<CaptureHandle, SystemAudioError> {
+        spawn_capture_with_timeout(session_id, sink, INIT_TIMEOUT)
+    }
+
+    pub(crate) fn spawn_capture_with_timeout(
+        session_id: String,
+        sink: AudioFrameSink,
+        init_timeout: Duration,
+    ) -> Result<CaptureHandle, SystemAudioError> {
+        let stop = Arc::new(AtomicBool::new(false));
+        let thread_stop = Arc::clone(&stop);
+        let (init_tx, init_rx) = mpsc::channel::<Result<(), SystemAudioError>>();
+
+        let join = thread::spawn(move || capture_thread(session_id, sink, thread_stop, init_tx));
+
+        match init_rx.recv_timeout(init_timeout) {
+            Ok(Ok(())) => Ok(CaptureHandle::new(stop, join)),
+            Ok(Err(error)) => {
+                let _ = join.join();
+                Err(error)
+            }
+            Err(_) => {
+                stop.store(true, Ordering::Relaxed);
+                Err(SystemAudioError::Capture(
+                    "timed out opening the macOS system-audio tap".into(),
+                ))
+            }
+        }
+    }
+
+    fn capture_thread(
+        session_id: String,
+        sink: AudioFrameSink,
+        stop: Arc<AtomicBool>,
+        init_tx: mpsc::Sender<Result<(), SystemAudioError>>,
+    ) {
+        if let Err(error) = run_capture(session_id, sink, stop, init_tx) {
+            eprintln!("system-audio capture: {error}");
+        }
+    }
+
+    fn os_status_result(status: OSStatus, action: &str) -> Result<(), SystemAudioError> {
+        if status == K_AUDIO_HARDWARE_NO_ERROR {
+            Ok(())
+        } else {
+            Err(SystemAudioError::Capture(format!(
+                "{action} failed with CoreAudio status {}",
+                format_os_status(status)
+            )))
+        }
+    }
+
+    fn run_capture(
         session_id: String,
         sink: AudioFrameSink,
         stop: Arc<AtomicBool>,
@@ -545,8 +529,12 @@ mod platform {
                 return Err(macos_unsupported());
             }
 
-            let create_process_tap = load_create_process_tap().ok_or_else(macos_unsupported)?;
-            let destroy_process_tap = load_destroy_process_tap().ok_or_else(macos_unsupported)?;
+            let create_process_tap =
+                load_symbol::<CreateProcessTap>(c"AudioHardwareCreateProcessTap")
+                    .ok_or_else(macos_unsupported)?;
+            let destroy_process_tap =
+                load_symbol::<DestroyProcessTap>(c"AudioHardwareDestroyProcessTap")
+                    .ok_or_else(macos_unsupported)?;
             Ok(Self {
                 create_process_tap,
                 destroy_process_tap,
@@ -581,7 +569,7 @@ mod platform {
     }
 
     fn probe_tap_permission(tap_id: AudioObjectID) -> Result<(), SystemAudioError> {
-        let address = super::tap_property_address(K_AUDIO_TAP_PROPERTY_DESCRIPTION);
+        let address = tap_property_address(K_AUDIO_TAP_PROPERTY_DESCRIPTION);
         let mut description: *mut c_void = ptr::null_mut();
         let mut data_size = mem::size_of::<*mut c_void>() as u32;
         let status = unsafe {
@@ -705,7 +693,7 @@ mod platform {
         // Read through raw pointers: the list's trailing buffer array is
         // variable-length, so a `&AudioBufferList` reference (declared with one
         // buffer) must not be used to reach later entries.
-        let buffers = unsafe { (&raw const (*input_data).m_buffers).cast::<super::AudioBuffer>() };
+        let buffers = unsafe { (&raw const (*input_data).m_buffers).cast::<AudioBuffer>() };
         let buffer_count = unsafe { (*input_data).m_number_buffers } as usize;
 
         if format.non_interleaved {
@@ -716,7 +704,7 @@ mod platform {
     }
 
     unsafe fn collect_interleaved_mono(
-        buffers: *const super::AudioBuffer,
+        buffers: *const AudioBuffer,
         buffer_count: usize,
         channels: usize,
     ) -> Vec<f32> {
@@ -734,6 +722,9 @@ mod platform {
             let sample_count = buffer.m_data_byte_size as usize / mem::size_of::<f32>();
             let samples =
                 unsafe { std::slice::from_raw_parts(buffer.m_data.cast::<f32>(), sample_count) };
+            // Reserve up front: this runs on the real-time IOProc thread, where
+            // geometric Vec growth means repeated reallocations per callback.
+            mono.reserve(sample_count / channels);
             for frame in samples.chunks_exact(channels) {
                 mono.push(frame.iter().sum::<f32>() / channels as f32);
             }
@@ -742,10 +733,10 @@ mod platform {
     }
 
     unsafe fn collect_non_interleaved_mono(
-        buffers: *const super::AudioBuffer,
+        buffers: *const AudioBuffer,
         buffer_count: usize,
     ) -> Vec<f32> {
-        let mut channel_slices: Vec<&[f32]> = Vec::new();
+        let mut channel_slices: Vec<&[f32]> = Vec::with_capacity(buffer_count);
         for buffer_index in 0..buffer_count {
             let buffer = unsafe { &*buffers.add(buffer_index) };
             if buffer.m_data.is_null() {
@@ -775,32 +766,13 @@ mod platform {
         mono
     }
 
-    fn load_create_process_tap() -> Option<CreateProcessTap> {
-        let symbol = unsafe {
-            libc::dlsym(
-                libc::RTLD_DEFAULT,
-                c"AudioHardwareCreateProcessTap".as_ptr(),
-            )
-        };
-        if symbol.is_null() {
-            None
-        } else {
-            Some(unsafe { mem::transmute::<*mut c_void, CreateProcessTap>(symbol) })
-        }
-    }
-
-    fn load_destroy_process_tap() -> Option<DestroyProcessTap> {
-        let symbol = unsafe {
-            libc::dlsym(
-                libc::RTLD_DEFAULT,
-                c"AudioHardwareDestroyProcessTap".as_ptr(),
-            )
-        };
-        if symbol.is_null() {
-            None
-        } else {
-            Some(unsafe { mem::transmute::<*mut c_void, DestroyProcessTap>(symbol) })
-        }
+    /// Resolve one dynamically-loaded CoreAudio entry point. Returns `None`
+    /// when the symbol is absent (macOS < 14.2).
+    ///
+    /// `T` must be the matching `unsafe extern "C" fn` pointer type.
+    fn load_symbol<T: Copy>(name: &CStr) -> Option<T> {
+        let symbol = unsafe { libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr()) };
+        (!symbol.is_null()).then(|| unsafe { mem::transmute_copy::<*mut c_void, T>(&symbol) })
     }
 
     fn macos_unsupported() -> SystemAudioError {

--- a/native/src/system_audio/macos.rs
+++ b/native/src/system_audio/macos.rs
@@ -1,0 +1,898 @@
+//! macOS system-audio capture via CoreAudio process taps.
+//!
+//! The tap entry points arrived in macOS 14.2, so they are resolved with
+//! `dlsym` instead of linked. The older aggregate-device and IOProc APIs are
+//! linked normally through CoreAudio.
+
+#[cfg(target_os = "macos")]
+use std::sync::Arc;
+#[cfg(target_os = "macos")]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(target_os = "macos")]
+use std::sync::mpsc;
+#[cfg(target_os = "macos")]
+use std::thread;
+#[cfg(target_os = "macos")]
+use std::time::Duration;
+
+use super::SystemAudioError;
+#[cfg(target_os = "macos")]
+use super::{AudioFrameSink, CaptureHandle};
+
+#[cfg(target_os = "macos")]
+const INIT_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[cfg(target_os = "macos")]
+const MACOS_UNSUPPORTED_MESSAGE: &str = "System-audio capture needs macOS 14.2 or later. Route \
+    output through a virtual audio device (BlackHole) and pick it as your microphone instead.";
+
+type OSStatus = i32;
+#[cfg(target_os = "macos")]
+type AudioObjectID = u32;
+type AudioObjectPropertySelector = u32;
+type AudioObjectPropertyScope = u32;
+type AudioObjectPropertyElement = u32;
+type AudioFormatID = u32;
+type AudioFormatFlags = u32;
+
+#[cfg(target_os = "macos")]
+const K_AUDIO_HARDWARE_NO_ERROR: OSStatus = 0;
+#[cfg(target_os = "macos")]
+const K_AUDIO_OBJECT_UNKNOWN: AudioObjectID = 0;
+const K_AUDIO_OBJECT_PROPERTY_SCOPE_GLOBAL: AudioObjectPropertyScope = 0x676c_6f62;
+const K_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN: AudioObjectPropertyElement = 0;
+#[cfg(target_os = "macos")]
+const K_AUDIO_TAP_PROPERTY_DESCRIPTION: AudioObjectPropertySelector = 0x7464_7363;
+const K_AUDIO_TAP_PROPERTY_FORMAT: AudioObjectPropertySelector = 0x7466_6d74;
+const K_AUDIO_FORMAT_LINEAR_PCM: AudioFormatID = 0x6c70_636d;
+const K_AUDIO_FORMAT_FLAG_IS_FLOAT: AudioFormatFlags = 1 << 0;
+const K_AUDIO_FORMAT_FLAG_IS_PACKED: AudioFormatFlags = 1 << 3;
+const K_AUDIO_FORMAT_FLAG_IS_NON_INTERLEAVED: AudioFormatFlags = 1 << 5;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct AudioObjectPropertyAddress {
+    m_selector: AudioObjectPropertySelector,
+    m_scope: AudioObjectPropertyScope,
+    m_element: AudioObjectPropertyElement,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg(target_os = "macos")]
+struct AudioBuffer {
+    m_number_channels: u32,
+    m_data_byte_size: u32,
+    m_data: *mut std::ffi::c_void,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg(target_os = "macos")]
+struct AudioBufferList {
+    m_number_buffers: u32,
+    m_buffers: [AudioBuffer; 1],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct AudioStreamBasicDescription {
+    m_sample_rate: f64,
+    m_format_id: AudioFormatID,
+    m_format_flags: AudioFormatFlags,
+    m_bytes_per_packet: u32,
+    m_frames_per_packet: u32,
+    m_bytes_per_frame: u32,
+    m_channels_per_frame: u32,
+    m_bits_per_channel: u32,
+    m_reserved: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct MacLoopbackFormat {
+    sample_rate: u32,
+    channels: usize,
+    non_interleaved: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AggregateDeviceDescription {
+    is_private: bool,
+    tap_auto_start: bool,
+    tap_uid: String,
+    drift_compensation: bool,
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn spawn_capture(
+    session_id: String,
+    sink: AudioFrameSink,
+) -> Result<CaptureHandle, SystemAudioError> {
+    spawn_capture_with_timeout(session_id, sink, INIT_TIMEOUT)
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn spawn_capture_with_timeout(
+    session_id: String,
+    sink: AudioFrameSink,
+    init_timeout: Duration,
+) -> Result<CaptureHandle, SystemAudioError> {
+    let stop = Arc::new(AtomicBool::new(false));
+    let thread_stop = Arc::clone(&stop);
+    let (init_tx, init_rx) = mpsc::channel::<Result<(), SystemAudioError>>();
+
+    let join = thread::spawn(move || capture_thread(session_id, sink, thread_stop, init_tx));
+
+    match init_rx.recv_timeout(init_timeout) {
+        Ok(Ok(())) => Ok(CaptureHandle::new(stop, join)),
+        Ok(Err(error)) => {
+            let _ = join.join();
+            Err(error)
+        }
+        Err(_) => {
+            stop.store(true, Ordering::Relaxed);
+            Err(SystemAudioError::Capture(
+                "timed out opening the macOS system-audio tap".into(),
+            ))
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn capture_thread(
+    session_id: String,
+    sink: AudioFrameSink,
+    stop: Arc<AtomicBool>,
+    init_tx: mpsc::Sender<Result<(), SystemAudioError>>,
+) {
+    if let Err(error) = platform::run_capture(session_id, sink, stop, init_tx) {
+        eprintln!("system-audio capture: {error}");
+    }
+}
+
+fn parse_tap_format(
+    asbd: &AudioStreamBasicDescription,
+) -> Result<MacLoopbackFormat, SystemAudioError> {
+    if asbd.m_sample_rate <= 0.0 || !asbd.m_sample_rate.is_finite() {
+        return Err(SystemAudioError::Capture(
+            "tap reported an invalid sample rate".into(),
+        ));
+    }
+
+    if asbd.m_format_id != K_AUDIO_FORMAT_LINEAR_PCM
+        || asbd.m_bits_per_channel != 32
+        || asbd.m_bytes_per_frame == 0
+        || asbd.m_channels_per_frame == 0
+        || (asbd.m_format_flags & K_AUDIO_FORMAT_FLAG_IS_FLOAT) == 0
+        || (asbd.m_format_flags & K_AUDIO_FORMAT_FLAG_IS_PACKED) == 0
+    {
+        return Err(SystemAudioError::Capture(format!(
+            "unsupported tap format: {}",
+            describe_tap_format(asbd)
+        )));
+    }
+
+    let sample_rate = asbd.m_sample_rate.round();
+    if sample_rate < 1.0 || sample_rate > u32::MAX as f64 {
+        return Err(SystemAudioError::Capture(
+            "tap reported an out-of-range sample rate".into(),
+        ));
+    }
+
+    Ok(MacLoopbackFormat {
+        sample_rate: sample_rate as u32,
+        channels: asbd.m_channels_per_frame as usize,
+        non_interleaved: (asbd.m_format_flags & K_AUDIO_FORMAT_FLAG_IS_NON_INTERLEAVED) != 0,
+    })
+}
+
+fn aggregate_device_description(tap_uid: String) -> AggregateDeviceDescription {
+    AggregateDeviceDescription {
+        is_private: true,
+        tap_auto_start: false,
+        tap_uid,
+        drift_compensation: true,
+    }
+}
+
+fn describe_tap_format(asbd: &AudioStreamBasicDescription) -> String {
+    format!(
+        "format=0x{:08x} flags=0x{:08x} rate={} bits={} channels={} bytes_per_frame={}",
+        asbd.m_format_id,
+        asbd.m_format_flags,
+        asbd.m_sample_rate,
+        asbd.m_bits_per_channel,
+        asbd.m_channels_per_frame,
+        asbd.m_bytes_per_frame
+    )
+}
+
+fn tap_property_address(selector: AudioObjectPropertySelector) -> AudioObjectPropertyAddress {
+    AudioObjectPropertyAddress {
+        m_selector: selector,
+        m_scope: K_AUDIO_OBJECT_PROPERTY_SCOPE_GLOBAL,
+        m_element: K_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN,
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn os_status_result(status: OSStatus, action: &str) -> Result<(), SystemAudioError> {
+    if status == K_AUDIO_HARDWARE_NO_ERROR {
+        Ok(())
+    } else {
+        Err(SystemAudioError::Capture(format!(
+            "{action} failed with CoreAudio status {}",
+            format_os_status(status)
+        )))
+    }
+}
+
+fn format_os_status(status: OSStatus) -> String {
+    let bytes = (status as u32).to_be_bytes();
+    if bytes
+        .iter()
+        .all(|byte| byte.is_ascii_graphic() || *byte == b' ')
+    {
+        format!("'{}' ({status})", String::from_utf8_lossy(&bytes))
+    } else {
+        status.to_string()
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use std::ffi::c_void;
+    use std::mem;
+    use std::ptr;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc::{self, SyncSender};
+    use std::time::Duration;
+
+    use objc2::msg_send;
+    use objc2::rc::Retained;
+    use objc2::runtime::{AnyClass, AnyObject};
+    use objc2_foundation::{NSArray, NSDictionary, NSNumber, NSString, NSUUID};
+
+    use super::{
+        AudioBufferList, AudioFrameSink, AudioObjectID, AudioObjectPropertyAddress,
+        AudioStreamBasicDescription, K_AUDIO_OBJECT_UNKNOWN, K_AUDIO_TAP_PROPERTY_DESCRIPTION,
+        K_AUDIO_TAP_PROPERTY_FORMAT, MACOS_UNSUPPORTED_MESSAGE, MacLoopbackFormat, OSStatus,
+        SystemAudioError, aggregate_device_description, os_status_result, parse_tap_format,
+        tap_property_address,
+    };
+    use crate::protocol::AudioFrame;
+    use crate::system_audio::resample::LoopbackFrameResampler;
+
+    const SAMPLE_CHANNEL_CAPACITY: usize = 8;
+    const DRAIN_INTERVAL: Duration = Duration::from_millis(10);
+
+    const K_AUDIO_AGGREGATE_DEVICE_IS_PRIVATE_KEY: &str = "private";
+    const K_AUDIO_AGGREGATE_DEVICE_TAP_LIST_KEY: &str = "taps";
+    const K_AUDIO_AGGREGATE_DEVICE_TAP_AUTO_START_KEY: &str = "tapautostart";
+    const K_AUDIO_SUB_TAP_UID_KEY: &str = "uid";
+    const K_AUDIO_SUB_TAP_DRIFT_COMPENSATION_KEY: &str = "drift";
+
+    type CreateProcessTap = unsafe extern "C" fn(
+        in_description: *mut AnyObject,
+        out_tap_id: *mut AudioObjectID,
+    ) -> OSStatus;
+    type DestroyProcessTap = unsafe extern "C" fn(in_tap_id: AudioObjectID) -> OSStatus;
+
+    type AudioDeviceIOProc = unsafe extern "C" fn(
+        AudioObjectID,
+        *const c_void,
+        *const AudioBufferList,
+        *const c_void,
+        *mut AudioBufferList,
+        *const c_void,
+        *mut c_void,
+    ) -> OSStatus;
+    type AudioDeviceIOProcID = Option<AudioDeviceIOProc>;
+
+    #[link(name = "CoreAudio", kind = "framework")]
+    unsafe extern "C" {
+        fn AudioHardwareCreateAggregateDevice(
+            in_description: *const c_void,
+            out_device_id: *mut AudioObjectID,
+        ) -> OSStatus;
+        fn AudioHardwareDestroyAggregateDevice(in_device_id: AudioObjectID) -> OSStatus;
+        fn AudioObjectGetPropertyData(
+            in_object_id: AudioObjectID,
+            in_address: *const AudioObjectPropertyAddress,
+            in_qualifier_data_size: u32,
+            in_qualifier_data: *const c_void,
+            io_data_size: *mut u32,
+            out_data: *mut c_void,
+        ) -> OSStatus;
+        fn AudioObjectSetPropertyData(
+            in_object_id: AudioObjectID,
+            in_address: *const AudioObjectPropertyAddress,
+            in_qualifier_data_size: u32,
+            in_qualifier_data: *const c_void,
+            in_data_size: u32,
+            in_data: *const c_void,
+        ) -> OSStatus;
+        fn AudioDeviceCreateIOProcID(
+            in_device: AudioObjectID,
+            in_proc: AudioDeviceIOProcID,
+            in_client_data: *mut c_void,
+            out_io_proc_id: *mut AudioDeviceIOProcID,
+        ) -> OSStatus;
+        fn AudioDeviceDestroyIOProcID(
+            in_device: AudioObjectID,
+            in_io_proc_id: AudioDeviceIOProcID,
+        ) -> OSStatus;
+        fn AudioDeviceStart(in_device: AudioObjectID, in_proc_id: AudioDeviceIOProcID) -> OSStatus;
+        fn AudioDeviceStop(in_device: AudioObjectID, in_proc_id: AudioDeviceIOProcID) -> OSStatus;
+    }
+
+    #[derive(Clone, Copy)]
+    struct TapApi {
+        create_process_tap: CreateProcessTap,
+        destroy_process_tap: DestroyProcessTap,
+    }
+
+    struct CaptureResources {
+        api: TapApi,
+        aggregate_device: Option<AudioObjectID>,
+        io_proc_id: Option<AudioDeviceIOProcID>,
+        started: bool,
+        tap_id: Option<AudioObjectID>,
+    }
+
+    impl CaptureResources {
+        fn new(api: TapApi) -> Self {
+            Self {
+                api,
+                aggregate_device: None,
+                io_proc_id: None,
+                started: false,
+                tap_id: None,
+            }
+        }
+    }
+
+    impl Drop for CaptureResources {
+        fn drop(&mut self) {
+            if self.started
+                && let (Some(device), Some(io_proc_id)) = (self.aggregate_device, self.io_proc_id)
+            {
+                let status = unsafe { AudioDeviceStop(device, io_proc_id) };
+                if status != 0 {
+                    eprintln!(
+                        "system-audio capture: AudioDeviceStop failed with CoreAudio status {status}"
+                    );
+                }
+            }
+
+            if let (Some(device), Some(io_proc_id)) = (self.aggregate_device, self.io_proc_id) {
+                let status = unsafe { AudioDeviceDestroyIOProcID(device, io_proc_id) };
+                if status != 0 {
+                    eprintln!(
+                        "system-audio capture: AudioDeviceDestroyIOProcID failed with CoreAudio status {status}"
+                    );
+                }
+            }
+
+            if let Some(device) = self.aggregate_device {
+                let status = unsafe { AudioHardwareDestroyAggregateDevice(device) };
+                if status != 0 {
+                    eprintln!(
+                        "system-audio capture: AudioHardwareDestroyAggregateDevice failed with CoreAudio status {status}"
+                    );
+                }
+            }
+
+            if let Some(tap_id) = self.tap_id {
+                let status = unsafe { (self.api.destroy_process_tap)(tap_id) };
+                if status != 0 {
+                    eprintln!(
+                        "system-audio capture: AudioHardwareDestroyProcessTap failed with CoreAudio status {status}"
+                    );
+                }
+            }
+        }
+    }
+
+    struct IoProcContext {
+        format: MacLoopbackFormat,
+        tx: SyncSender<Vec<f32>>,
+    }
+
+    pub(super) fn run_capture(
+        session_id: String,
+        sink: AudioFrameSink,
+        stop: Arc<AtomicBool>,
+        init_tx: mpsc::Sender<Result<(), SystemAudioError>>,
+    ) -> Result<(), SystemAudioError> {
+        let api = match TapApi::resolve() {
+            Ok(api) => api,
+            Err(error) => {
+                let _ = init_tx.send(Err(error));
+                return Ok(());
+            }
+        };
+
+        let mut resources = CaptureResources::new(api);
+
+        let (tap_description, tap_uid) = match create_tap_description() {
+            Ok(description) => description,
+            Err(error) => {
+                let _ = init_tx.send(Err(error));
+                return Ok(());
+            }
+        };
+
+        let mut tap_id = K_AUDIO_OBJECT_UNKNOWN;
+        let status = unsafe {
+            (api.create_process_tap)(Retained::as_ptr(&tap_description).cast_mut(), &mut tap_id)
+        };
+        if status != 0 || tap_id == K_AUDIO_OBJECT_UNKNOWN {
+            let error = if status == 0 {
+                SystemAudioError::Capture("CoreAudio returned an unknown process-tap id".into())
+            } else {
+                SystemAudioError::Capture(format!(
+                    "AudioHardwareCreateProcessTap failed with CoreAudio status {status}"
+                ))
+            };
+            let _ = init_tx.send(Err(error));
+            return Ok(());
+        }
+        resources.tap_id = Some(tap_id);
+
+        if let Err(error) = probe_tap_permission(tap_id) {
+            let _ = init_tx.send(Err(error));
+            return Ok(());
+        }
+
+        let aggregate_description = create_aggregate_description(tap_uid);
+        let mut aggregate_device = K_AUDIO_OBJECT_UNKNOWN;
+        let status = unsafe {
+            AudioHardwareCreateAggregateDevice(
+                Retained::as_ptr(&aggregate_description).cast::<c_void>(),
+                &mut aggregate_device,
+            )
+        };
+        if status != 0 || aggregate_device == K_AUDIO_OBJECT_UNKNOWN {
+            let error = if status == 0 {
+                SystemAudioError::Capture(
+                    "CoreAudio returned an unknown aggregate-device id".into(),
+                )
+            } else {
+                SystemAudioError::Capture(format!(
+                    "AudioHardwareCreateAggregateDevice failed with CoreAudio status {status}"
+                ))
+            };
+            let _ = init_tx.send(Err(error));
+            return Ok(());
+        }
+        resources.aggregate_device = Some(aggregate_device);
+
+        let format = match read_tap_format(tap_id) {
+            Ok(format) => format,
+            Err(error) => {
+                let _ = init_tx.send(Err(error));
+                return Ok(());
+            }
+        };
+
+        let (sample_tx, sample_rx) = mpsc::sync_channel::<Vec<f32>>(SAMPLE_CHANNEL_CAPACITY);
+        let mut io_context = Box::new(IoProcContext {
+            format,
+            tx: sample_tx,
+        });
+        let mut io_proc_id: AudioDeviceIOProcID = None;
+        let status = unsafe {
+            AudioDeviceCreateIOProcID(
+                aggregate_device,
+                Some(io_proc),
+                (&mut *io_context as *mut IoProcContext).cast::<c_void>(),
+                &mut io_proc_id,
+            )
+        };
+        if status != 0 {
+            let _ = init_tx.send(Err(SystemAudioError::Capture(format!(
+                "AudioDeviceCreateIOProcID failed with CoreAudio status {status}"
+            ))));
+            return Ok(());
+        }
+        resources.io_proc_id = Some(io_proc_id);
+
+        let status = unsafe { AudioDeviceStart(aggregate_device, io_proc_id) };
+        if status != 0 {
+            let _ = init_tx.send(Err(SystemAudioError::Capture(format!(
+                "AudioDeviceStart failed with CoreAudio status {status}"
+            ))));
+            return Ok(());
+        }
+        resources.started = true;
+
+        if init_tx.send(Ok(())).is_err() {
+            // Stop the device (via `resources`) before `io_context` is freed;
+            // the IOProc holds a raw pointer to it.
+            drop(resources);
+            return Ok(());
+        }
+
+        let mut resampler = LoopbackFrameResampler::new(format.sample_rate);
+        while !stop.load(Ordering::Relaxed) {
+            match sample_rx.recv_timeout(DRAIN_INTERVAL) {
+                Ok(samples) => {
+                    let session_id = &session_id;
+                    resampler.push(&samples, |frame_bytes| {
+                        (sink)(AudioFrame {
+                            frame_bytes,
+                            session_id: session_id.clone(),
+                        });
+                    });
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+
+        // Stop the device before `io_context` is freed; the IOProc holds a raw
+        // pointer to it and can fire until AudioDeviceStop returns.
+        drop(resources);
+        drop(io_context);
+        Ok(())
+    }
+
+    impl TapApi {
+        fn resolve() -> Result<Self, SystemAudioError> {
+            if AnyClass::get(c"CATapDescription").is_none() {
+                return Err(macos_unsupported());
+            }
+
+            let create_process_tap = load_create_process_tap().ok_or_else(macos_unsupported)?;
+            let destroy_process_tap = load_destroy_process_tap().ok_or_else(macos_unsupported)?;
+            Ok(Self {
+                create_process_tap,
+                destroy_process_tap,
+            })
+        }
+    }
+
+    fn create_tap_description() -> Result<(Retained<AnyObject>, String), SystemAudioError> {
+        let tap_class = AnyClass::get(c"CATapDescription").ok_or_else(macos_unsupported)?;
+        let excluded_processes = NSArray::<AnyObject>::from_slice(&[]);
+        let allocated: *mut AnyObject = unsafe { msg_send![tap_class, alloc] };
+        let initialized: *mut AnyObject = unsafe {
+            msg_send![
+                allocated,
+                initMonoGlobalTapButExcludeProcesses: &*excluded_processes
+            ]
+        };
+        let tap_description = unsafe { Retained::from_raw(initialized) }.ok_or_else(|| {
+            SystemAudioError::Capture("CATapDescription initialization returned null".into())
+        })?;
+
+        let name = NSString::from_str("Local Dictation System Audio");
+        unsafe {
+            let _: () = msg_send![&*tap_description, setName: &*name];
+            let _: () = msg_send![&*tap_description, setPrivate: true];
+        }
+
+        let uuid: Retained<NSUUID> = unsafe { msg_send![&*tap_description, UUID] };
+        let uuid_string: Retained<NSString> = unsafe { msg_send![&*uuid, UUIDString] };
+
+        Ok((tap_description, uuid_string.to_string()))
+    }
+
+    fn probe_tap_permission(tap_id: AudioObjectID) -> Result<(), SystemAudioError> {
+        let address = super::tap_property_address(K_AUDIO_TAP_PROPERTY_DESCRIPTION);
+        let mut description: *mut c_void = ptr::null_mut();
+        let mut data_size = mem::size_of::<*mut c_void>() as u32;
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                tap_id,
+                &address,
+                0,
+                ptr::null(),
+                &mut data_size,
+                (&mut description as *mut *mut c_void).cast::<c_void>(),
+            )
+        };
+        if status != 0 || description.is_null() {
+            return Err(SystemAudioError::PermissionDenied);
+        }
+        // The get is a Copy-rule +1 reference; hand it to `Retained` so it is
+        // released when the probe returns.
+        let _description = unsafe { Retained::from_raw(description.cast::<AnyObject>()) };
+
+        let status = unsafe {
+            AudioObjectSetPropertyData(
+                tap_id,
+                &address,
+                0,
+                ptr::null(),
+                data_size,
+                (&description as *const *mut c_void).cast::<c_void>(),
+            )
+        };
+        if status != 0 {
+            return Err(SystemAudioError::PermissionDenied);
+        }
+
+        Ok(())
+    }
+
+    fn create_aggregate_description(
+        tap_uid: String,
+    ) -> Retained<NSDictionary<NSString, AnyObject>> {
+        let description = aggregate_device_description(tap_uid);
+        let tap_uid = NSString::from_str(&description.tap_uid);
+        let drift_compensation = NSNumber::new_bool(description.drift_compensation);
+        let tap_entry = NSDictionary::<NSString, AnyObject>::from_slices(
+            &[
+                &*NSString::from_str(K_AUDIO_SUB_TAP_UID_KEY),
+                &*NSString::from_str(K_AUDIO_SUB_TAP_DRIFT_COMPENSATION_KEY),
+            ],
+            &[&*tap_uid, &*drift_compensation],
+        );
+        let tap_list = NSArray::<NSDictionary<NSString, AnyObject>>::from_slice(&[&*tap_entry]);
+        let is_private = NSNumber::new_bool(description.is_private);
+        let tap_auto_start = NSNumber::new_bool(description.tap_auto_start);
+
+        NSDictionary::<NSString, AnyObject>::from_slices(
+            &[
+                &*NSString::from_str(K_AUDIO_AGGREGATE_DEVICE_IS_PRIVATE_KEY),
+                &*NSString::from_str(K_AUDIO_AGGREGATE_DEVICE_TAP_LIST_KEY),
+                &*NSString::from_str(K_AUDIO_AGGREGATE_DEVICE_TAP_AUTO_START_KEY),
+            ],
+            &[&*is_private, &*tap_list, &*tap_auto_start],
+        )
+    }
+
+    fn read_tap_format(tap_id: AudioObjectID) -> Result<MacLoopbackFormat, SystemAudioError> {
+        let address = tap_property_address(K_AUDIO_TAP_PROPERTY_FORMAT);
+        let mut asbd = AudioStreamBasicDescription {
+            m_sample_rate: 0.0,
+            m_format_id: 0,
+            m_format_flags: 0,
+            m_bytes_per_packet: 0,
+            m_frames_per_packet: 0,
+            m_bytes_per_frame: 0,
+            m_channels_per_frame: 0,
+            m_bits_per_channel: 0,
+            m_reserved: 0,
+        };
+        let mut data_size = mem::size_of::<AudioStreamBasicDescription>() as u32;
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                tap_id,
+                &address,
+                0,
+                ptr::null(),
+                &mut data_size,
+                (&mut asbd as *mut AudioStreamBasicDescription).cast::<c_void>(),
+            )
+        };
+        os_status_result(
+            status,
+            "AudioObjectGetPropertyData(kAudioTapPropertyFormat)",
+        )?;
+        parse_tap_format(&asbd)
+    }
+
+    unsafe extern "C" fn io_proc(
+        _device: AudioObjectID,
+        _now: *const c_void,
+        input_data: *const AudioBufferList,
+        _input_time: *const c_void,
+        _output_data: *mut AudioBufferList,
+        _output_time: *const c_void,
+        client_data: *mut c_void,
+    ) -> OSStatus {
+        if client_data.is_null() || input_data.is_null() {
+            return 0;
+        }
+
+        let context = unsafe { &*(client_data.cast::<IoProcContext>()) };
+        let samples = unsafe { collect_mono_samples(input_data, context.format) };
+        if !samples.is_empty() {
+            let _ = context.tx.try_send(samples);
+        }
+
+        0
+    }
+
+    unsafe fn collect_mono_samples(
+        input_data: *const AudioBufferList,
+        format: MacLoopbackFormat,
+    ) -> Vec<f32> {
+        // Read through raw pointers: the list's trailing buffer array is
+        // variable-length, so a `&AudioBufferList` reference (declared with one
+        // buffer) must not be used to reach later entries.
+        let buffers = unsafe { (&raw const (*input_data).m_buffers).cast::<super::AudioBuffer>() };
+        let buffer_count = unsafe { (*input_data).m_number_buffers } as usize;
+
+        if format.non_interleaved {
+            unsafe { collect_non_interleaved_mono(buffers, buffer_count) }
+        } else {
+            unsafe { collect_interleaved_mono(buffers, buffer_count, format.channels) }
+        }
+    }
+
+    unsafe fn collect_interleaved_mono(
+        buffers: *const super::AudioBuffer,
+        buffer_count: usize,
+        channels: usize,
+    ) -> Vec<f32> {
+        if channels == 0 {
+            return Vec::new();
+        }
+
+        let mut mono = Vec::new();
+        for buffer_index in 0..buffer_count {
+            let buffer = unsafe { &*buffers.add(buffer_index) };
+            if buffer.m_data.is_null() {
+                continue;
+            }
+
+            let sample_count = buffer.m_data_byte_size as usize / mem::size_of::<f32>();
+            let samples =
+                unsafe { std::slice::from_raw_parts(buffer.m_data.cast::<f32>(), sample_count) };
+            for frame in samples.chunks_exact(channels) {
+                mono.push(frame.iter().sum::<f32>() / channels as f32);
+            }
+        }
+        mono
+    }
+
+    unsafe fn collect_non_interleaved_mono(
+        buffers: *const super::AudioBuffer,
+        buffer_count: usize,
+    ) -> Vec<f32> {
+        let mut channel_slices: Vec<&[f32]> = Vec::new();
+        for buffer_index in 0..buffer_count {
+            let buffer = unsafe { &*buffers.add(buffer_index) };
+            if buffer.m_data.is_null() {
+                continue;
+            }
+            let sample_count = buffer.m_data_byte_size as usize / mem::size_of::<f32>();
+            channel_slices.push(unsafe {
+                std::slice::from_raw_parts(buffer.m_data.cast::<f32>(), sample_count)
+            });
+        }
+
+        let Some(frame_count) = channel_slices.iter().map(|samples| samples.len()).min() else {
+            return Vec::new();
+        };
+        if frame_count == 0 {
+            return Vec::new();
+        }
+
+        let mut mono = Vec::with_capacity(frame_count);
+        for frame_index in 0..frame_count {
+            let sum = channel_slices
+                .iter()
+                .map(|samples| samples[frame_index])
+                .sum::<f32>();
+            mono.push(sum / channel_slices.len() as f32);
+        }
+        mono
+    }
+
+    fn load_create_process_tap() -> Option<CreateProcessTap> {
+        let symbol = unsafe {
+            libc::dlsym(
+                libc::RTLD_DEFAULT,
+                c"AudioHardwareCreateProcessTap".as_ptr(),
+            )
+        };
+        if symbol.is_null() {
+            None
+        } else {
+            Some(unsafe { mem::transmute::<*mut c_void, CreateProcessTap>(symbol) })
+        }
+    }
+
+    fn load_destroy_process_tap() -> Option<DestroyProcessTap> {
+        let symbol = unsafe {
+            libc::dlsym(
+                libc::RTLD_DEFAULT,
+                c"AudioHardwareDestroyProcessTap".as_ptr(),
+            )
+        };
+        if symbol.is_null() {
+            None
+        } else {
+            Some(unsafe { mem::transmute::<*mut c_void, DestroyProcessTap>(symbol) })
+        }
+    }
+
+    fn macos_unsupported() -> SystemAudioError {
+        SystemAudioError::Capture(MACOS_UNSUPPORTED_MESSAGE.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn float_asbd(
+        rate: f64,
+        channels: u32,
+        flags: AudioFormatFlags,
+    ) -> AudioStreamBasicDescription {
+        AudioStreamBasicDescription {
+            m_sample_rate: rate,
+            m_format_id: K_AUDIO_FORMAT_LINEAR_PCM,
+            m_format_flags: K_AUDIO_FORMAT_FLAG_IS_FLOAT | K_AUDIO_FORMAT_FLAG_IS_PACKED | flags,
+            m_bytes_per_packet: channels * 4,
+            m_frames_per_packet: 1,
+            m_bytes_per_frame: channels * 4,
+            m_channels_per_frame: channels,
+            m_bits_per_channel: 32,
+            m_reserved: 0,
+        }
+    }
+
+    #[test]
+    fn parse_tap_format_accepts_packed_float_pcm() {
+        let format = parse_tap_format(&float_asbd(48_000.0, 1, 0)).expect("format should parse");
+
+        assert_eq!(
+            format,
+            MacLoopbackFormat {
+                sample_rate: 48_000,
+                channels: 1,
+                non_interleaved: false,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_tap_format_preserves_non_interleaved_layout() {
+        let format = parse_tap_format(&float_asbd(
+            44_100.0,
+            2,
+            K_AUDIO_FORMAT_FLAG_IS_NON_INTERLEAVED,
+        ))
+        .expect("format should parse");
+
+        assert_eq!(format.sample_rate, 44_100);
+        assert_eq!(format.channels, 2);
+        assert!(format.non_interleaved);
+    }
+
+    #[test]
+    fn parse_tap_format_rejects_zero_channels() {
+        let error =
+            parse_tap_format(&float_asbd(48_000.0, 0, 0)).expect_err("zero channels should fail");
+
+        assert!(error.message().contains("unsupported tap format"));
+    }
+
+    #[test]
+    fn aggregate_description_is_private_tap_only_and_does_not_auto_start() {
+        let description = aggregate_device_description("tap-uid".to_string());
+
+        assert_eq!(
+            description,
+            AggregateDeviceDescription {
+                is_private: true,
+                tap_auto_start: false,
+                tap_uid: "tap-uid".to_string(),
+                drift_compensation: true,
+            }
+        );
+    }
+
+    #[test]
+    fn tap_property_address_uses_global_main_scope() {
+        let address = tap_property_address(K_AUDIO_TAP_PROPERTY_FORMAT);
+
+        assert_eq!(address.m_selector, K_AUDIO_TAP_PROPERTY_FORMAT);
+        assert_eq!(address.m_scope, K_AUDIO_OBJECT_PROPERTY_SCOPE_GLOBAL);
+        assert_eq!(address.m_element, K_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN);
+    }
+
+    #[test]
+    fn os_status_formatter_decodes_four_character_codes() {
+        assert_eq!(format_os_status(0x7768_6174), "'what' (2003329396)");
+        assert_eq!(format_os_status(-1), "-1");
+    }
+}

--- a/native/src/system_audio/mod.rs
+++ b/native/src/system_audio/mod.rs
@@ -8,18 +8,17 @@
 //!
 //! Capture is inherently per-OS. Windows uses WASAPI loopback of the default
 //! render endpoint; Linux records the monitor of the default PulseAudio/PipeWire
-//! sink (`@DEFAULT_MONITOR@`). Both are zero user setup. macOS and other
-//! platforms have no native backend yet: [`SystemAudioController`] is a stub
-//! whose [`start`](SystemAudioController::start) returns
+//! sink (`@DEFAULT_MONITOR@`); macOS 14.2+ uses CoreAudio process taps attached
+//! to a private aggregate device. Older macOS and other platforms return
 //! [`SystemAudioError::Unsupported`], and users route output through a virtual
 //! audio device and pick it in the normal microphone list instead.
 //!
-//! The real controller and [`CaptureHandle`] therefore compile on Windows and
-//! Linux; elsewhere only the stub and the shared error type compile. (The
-//! resampler is Windows-only — the Linux backend asks PulseAudio for 16 kHz
-//! mono directly, so no client-side resampling is needed.)
+//! The real controller and [`CaptureHandle`] therefore compile on Windows,
+//! Linux, and macOS. Elsewhere only the stub and the shared error type compile.
+//! The resampler is shared by Windows and macOS; Linux asks PulseAudio for
+//! 16 kHz mono directly, so no client-side resampling is needed.
 
-#[cfg(any(windows, test))]
+#[cfg(any(windows, target_os = "macos", test))]
 mod resample;
 
 #[cfg(windows)]
@@ -28,8 +27,13 @@ mod windows;
 #[cfg(target_os = "linux")]
 mod linux;
 
+#[cfg(any(target_os = "macos", test))]
+mod macos;
+
 #[cfg(target_os = "linux")]
 use self::linux as backend;
+#[cfg(target_os = "macos")]
+use self::macos as backend;
 #[cfg(windows)]
 use self::windows as backend;
 
@@ -53,6 +57,8 @@ pub trait SystemAudioCapture: Send {
 pub enum SystemAudioError {
     /// This platform has no native loopback backend yet.
     Unsupported,
+    /// macOS has not granted the host app system-audio recording permission.
+    PermissionDenied,
     /// The OS audio backend failed to open or initialize the loopback stream.
     Capture(String),
 }
@@ -62,6 +68,7 @@ impl SystemAudioError {
     pub fn code(&self) -> &'static str {
         match self {
             Self::Unsupported => "system_audio_unsupported",
+            Self::PermissionDenied => "system_audio_permission_denied",
             Self::Capture(_) => "system_audio_capture_failed",
         }
     }
@@ -72,6 +79,10 @@ impl SystemAudioError {
             Self::Unsupported => "System-audio capture isn't available on this platform yet. \
                 Route this computer's output through a virtual audio device and pick it as your \
                 microphone — see the System audio guide."
+                .to_string(),
+            Self::PermissionDenied => "System-audio recording permission is off for Obsidian. \
+                Open System Settings → Privacy & Security → Screen & System Audio Recording, \
+                enable Obsidian, and try again."
                 .to_string(),
             Self::Capture(details) => format!("Could not start system-audio capture: {details}"),
         }
@@ -88,13 +99,13 @@ impl std::error::Error for SystemAudioError {}
 
 /// A running capture thread for one session. Dropping or stopping signals the
 /// thread to exit and joins it.
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 pub(crate) struct CaptureHandle {
     stop: Arc<std::sync::atomic::AtomicBool>,
     join: Option<std::thread::JoinHandle<()>>,
 }
 
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 impl CaptureHandle {
     /// Build a handle from a shared stop flag and the thread it controls. Used
     /// by platform backends after they spawn their capture loop.
@@ -119,13 +130,13 @@ impl CaptureHandle {
 /// Owns the active system-audio capture threads, keyed by session id, and the
 /// sink frames are delivered to. Captures stop when their session ends and when
 /// the controller is dropped (sidecar shutdown).
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 pub struct SystemAudioController {
     sink: AudioFrameSink,
     captures: std::collections::HashMap<String, CaptureHandle>,
 }
 
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 impl SystemAudioController {
     /// A controller with a no-op sink. The host installs the real sink with
     /// [`set_sink`](Self::set_sink) once its ingestion channel exists.
@@ -161,7 +172,7 @@ impl SystemAudioController {
     }
 }
 
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 impl Drop for SystemAudioController {
     fn drop(&mut self) {
         for (_session_id, handle) in self.captures.drain() {
@@ -174,10 +185,10 @@ impl Drop for SystemAudioController {
 /// matches the native controller so the host wires it identically; `start`
 /// reports the feature unavailable so callers fall back to the documented
 /// virtual-device method.
-#[cfg(not(any(windows, target_os = "linux")))]
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
 pub struct SystemAudioController;
 
-#[cfg(not(any(windows, target_os = "linux")))]
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
 impl SystemAudioController {
     pub fn new() -> Self {
         Self
@@ -212,7 +223,23 @@ impl Default for SystemAudioController {
     }
 }
 
-#[cfg(all(test, not(any(windows, target_os = "linux"))))]
+#[cfg(target_os = "macos")]
+pub fn probe_system_audio() -> Result<(), SystemAudioError> {
+    let handle = backend::spawn_capture_with_timeout(
+        uuid::Uuid::new_v4().to_string(),
+        Arc::new(|_frame| {}),
+        std::time::Duration::from_secs(75),
+    )?;
+    handle.stop_and_join();
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn probe_system_audio() -> Result<(), SystemAudioError> {
+    Err(SystemAudioError::Unsupported)
+}
+
+#[cfg(all(test, not(any(windows, target_os = "linux", target_os = "macos"))))]
 mod tests {
     use super::{SystemAudioController, SystemAudioError};
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "vitest run",
     "test:system-audio": "cargo test --manifest-path native/Cargo.toml --test system_audio_smoke -- --ignored --nocapture",
     "install:dev": "node scripts/install-dev-plugin.mjs",
+    "install:dev:cuda": "node scripts/install-dev-cuda.mjs",
     "verify:build-output": "node scripts/verify-build-output.mjs",
     "verify:build-output:release": "node scripts/verify-build-output.mjs --release",
     "check:frontend": "npm run typecheck && npm run lint && npm run lint:obsidian && npm run test && npm run build:frontend",

--- a/scripts/build-cuda.sh
+++ b/scripts/build-cuda.sh
@@ -17,8 +17,8 @@ Options:
   --help      Show this help text.
 
 Environment overrides:
-  CC             Host C compiler       (default: /usr/bin/gcc)
-  CXX            Host C++ compiler     (default: /usr/bin/g++)
+  CC             Host C compiler       (default: newest supported /usr/bin/gcc-*)
+  CXX            Host C++ compiler     (default: newest supported /usr/bin/g++-*)
   CUDAHOSTCXX    nvcc host compiler    (default: $CXX)
   CUDACXX        CUDA compiler         (default: /usr/local/cuda/bin/nvcc)
   CUDA_LIB_PATH  Library dir for RPATH (auto-detected from CUDACXX)
@@ -44,6 +44,42 @@ require_glob_match() {
   compgen -G "$pattern" >/dev/null || die "required runtime artifact missing after build: $pattern"
 }
 
+compiler_major() {
+  local compiler=$1
+  "$compiler" -dumpfullversion -dumpversion | awk -F. '{ print $1 }'
+}
+
+pick_supported_compiler() {
+  local fallback=$1
+  shift
+
+  local candidate
+  for candidate in "$@"; do
+    [[ -x "$candidate" ]] || continue
+    local major
+    major=$(compiler_major "$candidate")
+    [[ "$major" =~ ^[0-9]+$ ]] || continue
+    if (( major <= 15 )); then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+
+  printf '%s\n' "$fallback"
+}
+
+require_cuda_supported_compiler() {
+  local label=$1
+  local compiler=$2
+  local major
+  major=$(compiler_major "$compiler")
+  [[ "$major" =~ ^[0-9]+$ ]] || die "failed to detect $label version from $compiler"
+
+  if (( major > 15 )); then
+    die "CUDA 13.2 does not support $label $compiler (GCC $major). Install gcc-15/g++-15 or set CC/CXX/CUDAHOSTCXX to a GCC <= 15 toolchain."
+  fi
+}
+
 stage_runtime_artifact() {
   local artifact_path=$1
   local resolved_path
@@ -54,6 +90,15 @@ stage_runtime_artifact() {
     rm -f "$artifact_path"
     cp "$resolved_path" "$artifact_path"
   fi
+}
+
+copy_resolved_artifact() {
+  local source_path=$1
+  local destination_path=$2
+  local resolved_path
+  resolved_path=$(readlink -f "$source_path")
+  [[ -f "$resolved_path" ]] || die "runtime artifact does not resolve to a file: $source_path"
+  cp "$resolved_path" "$destination_path"
 }
 
 # ---------------------------------------------------------------------------
@@ -87,8 +132,10 @@ done
 # ---------------------------------------------------------------------------
 
 export PATH="/usr/local/cuda/bin:$HOME/.cargo/bin:$PATH"
-export CC=${CC:-/usr/bin/gcc}
-export CXX=${CXX:-/usr/bin/g++}
+default_cc=$(pick_supported_compiler /usr/bin/gcc /usr/bin/gcc-15 /usr/bin/gcc-14 /usr/bin/gcc-13 /usr/bin/gcc-12 /usr/bin/gcc)
+default_cxx=$(pick_supported_compiler /usr/bin/g++ /usr/bin/g++-15 /usr/bin/g++-14 /usr/bin/g++-13 /usr/bin/g++-12 /usr/bin/g++)
+export CC=${CC:-$default_cc}
+export CXX=${CXX:-$default_cxx}
 export CUDAHOSTCXX=${CUDAHOSTCXX:-$CXX}
 export CUDACXX=${CUDACXX:-/usr/local/cuda/bin/nvcc}
 export WHISPER_DONT_GENERATE_BINDINGS=1
@@ -106,6 +153,9 @@ require_cmd "$CC"
 require_cmd "$CXX"
 require_cmd "$CUDAHOSTCXX"
 require_cmd "$CUDACXX"
+require_cuda_supported_compiler "CC" "$CC"
+require_cuda_supported_compiler "CXX" "$CXX"
+require_cuda_supported_compiler "CUDAHOSTCXX" "$CUDAHOSTCXX"
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -183,4 +233,8 @@ while IFS= read -r provider; do
   require_glob_match "$target_dir/$profile/${provider}*"
   stage_runtime_artifact "$target_dir/$profile/$provider"
 done < <(node "$REPO_ROOT/scripts/list-cuda-artifacts.mjs" providers linux)
+
+while IFS= read -r runtime; do
+  copy_resolved_artifact "$cuda_lib/$runtime" "$target_dir/$profile/$runtime"
+done < <(node "$REPO_ROOT/scripts/list-cuda-artifacts.mjs" runtime linux)
 printf 'Done: %s\n' "$binary"

--- a/scripts/install-dev-cuda.d.mts
+++ b/scripts/install-dev-cuda.d.mts
@@ -1,0 +1,58 @@
+export interface DevCudaInstallOptions {
+  cleanCuda: boolean;
+  cuda: boolean;
+  enable: boolean;
+  help: boolean;
+  jobs: number | null;
+  release: boolean;
+  resetData: boolean;
+  vault: string | null;
+}
+
+export interface DevCudaInstallStep {
+  args: string[];
+  command: string;
+  env?: Record<string, string>;
+  label: string;
+  retry?: {
+    args: string[];
+    command: string;
+    env?: Record<string, string>;
+    reason: string;
+  };
+}
+
+export interface FileSnapshotEntry {
+  kind: 'file';
+  sha256: string;
+  size: number;
+}
+
+export interface SymlinkSnapshotEntry {
+  kind: 'symlink';
+  linkTarget: string;
+  size: number;
+}
+
+export type SnapshotEntry = FileSnapshotEntry | SymlinkSnapshotEntry;
+export type InstallSnapshot = Map<string, SnapshotEntry>;
+
+export interface InstallChangeSummary {
+  created: string[];
+  overwrittenChanged: string[];
+  overwrittenUnchanged: string[];
+  preserved: string[];
+  removed: string[];
+}
+
+export function parseArgs(argv: string[]): DevCudaInstallOptions;
+export function createBuildSteps(
+  options: DevCudaInstallOptions,
+  platform?: NodeJS.Platform | string,
+): DevCudaInstallStep[];
+export function createInstallStep(options: DevCudaInstallOptions): DevCudaInstallStep;
+export function summarizeInstallChanges(
+  before: InstallSnapshot,
+  after: InstallSnapshot,
+  preservedFiles?: readonly string[],
+): InstallChangeSummary;

--- a/scripts/install-dev-cuda.mjs
+++ b/scripts/install-dev-cuda.mjs
@@ -1,0 +1,516 @@
+#!/usr/bin/env node
+// One-command local dev deployment:
+//   build frontend + CPU sidecar + CUDA sidecar, verify the output, then install
+//   a fresh copy into a target Obsidian vault. The wrapper prunes stale files
+//   from the installed plugin directory immediately before reinstalling, while
+//   preserving vault-local plugin settings by default.
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { lstat, mkdir, readdir, readFile, readlink, rm } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import process from 'node:process';
+
+const PLUGIN_ID = 'local-dictation';
+const PRESERVED_PLUGIN_FILES = Object.freeze(['data.json']);
+
+const HELP_TEXT = `Usage: npm run install:dev:cuda -- --vault <vault-path> [OPTIONS]
+
+Builds frontend, CPU sidecar, CUDA sidecar, verifies outputs, then force-installs
+the dev plugin into <vault-path>/.obsidian/plugins/${PLUGIN_ID}.
+
+Options:
+  --vault <path>   Obsidian vault path. A single positional path is also accepted.
+  --release        Build and install release-profile sidecars.
+  --jobs N         CUDA build job count.
+  --clean-cuda     Clean native/target-cuda before rebuilding CUDA.
+  --skip-cuda      Build/install CPU sidecar only.
+  --no-enable      Do not enable the plugin in the target vault.
+  --reset-data     Also delete existing plugin data.json before reinstalling.
+  --help, -h       Show this help text.
+`;
+
+export function parseArgs(argv) {
+  const options = {
+    cleanCuda: false,
+    cuda: true,
+    enable: true,
+    help: false,
+    jobs: null,
+    release: false,
+    resetData: false,
+    vault: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else if (arg === '--release') {
+      options.release = true;
+    } else if (arg === '--clean-cuda') {
+      options.cleanCuda = true;
+    } else if (arg === '--skip-cuda' || arg === '--no-cuda') {
+      options.cuda = false;
+    } else if (arg === '--no-enable') {
+      options.enable = false;
+    } else if (arg === '--reset-data') {
+      options.resetData = true;
+    } else if (arg === '--vault') {
+      const value = argv[index + 1];
+      if (value === undefined || value.startsWith('--')) {
+        throw new Error('--vault requires a path.');
+      }
+      options.vault = value;
+      index += 1;
+    } else if (arg.startsWith('--vault=')) {
+      const value = arg.slice('--vault='.length);
+      if (value.length === 0) {
+        throw new Error('--vault requires a path.');
+      }
+      options.vault = value;
+    } else if (arg === '--jobs') {
+      const value = argv[index + 1];
+      if (value === undefined || value.startsWith('--')) {
+        throw new Error('--jobs requires a value.');
+      }
+      options.jobs = parsePositiveInteger(value, '--jobs');
+      index += 1;
+    } else if (arg.startsWith('--jobs=')) {
+      options.jobs = parsePositiveInteger(arg.slice('--jobs='.length), '--jobs');
+    } else if (arg.startsWith('--')) {
+      throw new Error(`Unknown argument: ${arg}`);
+    } else if (options.vault === null) {
+      options.vault = arg;
+    } else {
+      throw new Error(`Unexpected positional argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+export function createBuildSteps(options, platform = process.platform) {
+  const profileArgs = options.release ? ['--release'] : [];
+  const steps = [
+    {
+      args: ['run', 'build:frontend'],
+      command: npmCommand(platform),
+      label: 'Build frontend bundle',
+    },
+    {
+      args: ['scripts/build-sidecar.mjs', ...profileArgs],
+      command: nodeCommand(),
+      label: 'Build CPU sidecar',
+    },
+  ];
+
+  if (options.cuda) {
+    steps.push(createCudaBuildStep(options, platform));
+  }
+
+  steps.push({
+    args: ['scripts/verify-build-output.mjs', ...profileArgs],
+    command: nodeCommand(),
+    label: 'Verify build output',
+  });
+
+  return steps;
+}
+
+export function createInstallStep(options) {
+  const args = [
+    'scripts/install-dev-plugin.mjs',
+    '--vault',
+    options.vault,
+    '--sidecars',
+    ...(options.release ? ['--release'] : []),
+    ...(options.enable ? ['--enable'] : []),
+  ];
+
+  return {
+    args,
+    command: nodeCommand(),
+    label: 'Install into vault',
+  };
+}
+
+export function summarizeInstallChanges(before, after, preservedFiles = PRESERVED_PLUGIN_FILES) {
+  const preserved = [];
+  const overwrittenChanged = [];
+  const overwrittenUnchanged = [];
+  const created = [];
+  const removed = [];
+  const preservedSet = new Set(preservedFiles);
+  const paths = new Set([...before.keys(), ...after.keys()]);
+
+  for (const path of [...paths].sort()) {
+    const beforeEntry = before.get(path);
+    const afterEntry = after.get(path);
+
+    if (preservedSet.has(path) && beforeEntry !== undefined && afterEntry !== undefined) {
+      preserved.push(path);
+      continue;
+    }
+
+    if (beforeEntry !== undefined && afterEntry !== undefined) {
+      if (entryFingerprint(beforeEntry) === entryFingerprint(afterEntry)) {
+        overwrittenUnchanged.push(path);
+      } else {
+        overwrittenChanged.push(path);
+      }
+    } else if (beforeEntry === undefined && afterEntry !== undefined) {
+      created.push(path);
+    } else if (beforeEntry !== undefined && afterEntry === undefined) {
+      removed.push(path);
+    }
+  }
+
+  return { created, overwrittenChanged, overwrittenUnchanged, preserved, removed };
+}
+
+async function main(rawArgs) {
+  const options = parseArgs(rawArgs);
+  if (options.help) {
+    console.log(HELP_TEXT);
+    return;
+  }
+
+  if (options.vault === null) {
+    console.log(HELP_TEXT);
+    throw new Error('Missing required --vault path.');
+  }
+
+  options.vault = resolve(options.vault);
+  await requireVaultDirectory(options.vault);
+
+  const pluginDirectory = join(options.vault, '.obsidian', 'plugins', PLUGIN_ID);
+  const buildSteps = createBuildSteps(options);
+  const installStep = createInstallStep(options);
+
+  printHeader(options, pluginDirectory);
+
+  let stepIndex = 1;
+  const totalSteps = buildSteps.length + 3;
+  await runDependencyStep(stepIndex, totalSteps);
+  stepIndex += 1;
+
+  for (const step of buildSteps) {
+    runStep(stepIndex, totalSteps, step);
+    stepIndex += 1;
+  }
+
+  const before = await snapshotPluginDirectory(pluginDirectory);
+  await runPrepareStep(stepIndex, totalSteps, pluginDirectory, options);
+  stepIndex += 1;
+
+  runStep(stepIndex, totalSteps, installStep);
+
+  const after = await snapshotPluginDirectory(pluginDirectory);
+  printChangeReport(summarizeInstallChanges(before, after), pluginDirectory);
+}
+
+async function requireVaultDirectory(vaultPath) {
+  let info;
+  try {
+    info = await lstat(vaultPath);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      throw new Error(`Vault path does not exist: ${vaultPath}`);
+    }
+    throw error;
+  }
+
+  if (!info.isDirectory()) {
+    throw new Error(`Vault path is not a directory: ${vaultPath}`);
+  }
+}
+
+async function runDependencyStep(stepIndex, totalSteps) {
+  console.log(`\n[${stepIndex}/${totalSteps}] Check npm dependencies`);
+  if (await fileExists(join('node_modules', 'esbuild', 'package.json'))) {
+    console.log('  ok: node_modules is present');
+    return;
+  }
+
+  const step = {
+    args: ['install'],
+    command: npmCommand(),
+    label: 'Install npm dependencies',
+  };
+  console.log(`  running: ${formatCommand(step.command, step.args)}`);
+  runCommand(step.command, step.args);
+}
+
+function runStep(stepIndex, totalSteps, step) {
+  console.log(`\n[${stepIndex}/${totalSteps}] ${step.label}`);
+  console.log(`  running: ${formatCommand(step.command, step.args)}`);
+  try {
+    runCommand(step.command, step.args, step.env);
+  } catch (error) {
+    if (step.retry === undefined) throw error;
+    console.warn(`  ${step.retry.reason}`);
+    console.warn(`  retrying: ${formatCommand(step.retry.command, step.retry.args)}`);
+    runCommand(step.retry.command, step.retry.args, step.retry.env);
+  }
+}
+
+async function runPrepareStep(stepIndex, totalSteps, pluginDirectory, options) {
+  console.log(`\n[${stepIndex}/${totalSteps}] Prepare target plugin directory`);
+  const preserved = await prunePluginDirectory(pluginDirectory, {
+    preserveData: !options.resetData,
+  });
+
+  if (preserved.length === 0) {
+    console.log('  pruned existing plugin directory; no plugin data was preserved');
+    return;
+  }
+
+  console.log(`  pruned existing plugin directory; preserved ${preserved.join(', ')}`);
+}
+
+async function prunePluginDirectory(pluginDirectory, options) {
+  const preserved = [];
+  let info;
+
+  try {
+    info = await lstat(pluginDirectory);
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error;
+    await mkdir(pluginDirectory, { recursive: true });
+    return preserved;
+  }
+
+  if (!info.isDirectory() || info.isSymbolicLink()) {
+    await rm(pluginDirectory, { force: true, recursive: true });
+    await mkdir(pluginDirectory, { recursive: true });
+    return preserved;
+  }
+
+  const entries = await readdir(pluginDirectory, { withFileTypes: true });
+  for (const entry of entries) {
+    if (options.preserveData && PRESERVED_PLUGIN_FILES.includes(entry.name)) {
+      preserved.push(entry.name);
+      continue;
+    }
+    await rm(join(pluginDirectory, entry.name), { force: true, recursive: true });
+  }
+
+  return preserved;
+}
+
+async function snapshotPluginDirectory(pluginDirectory) {
+  const entries = new Map();
+  let info;
+
+  try {
+    info = await lstat(pluginDirectory);
+  } catch (error) {
+    if (error.code === 'ENOENT') return entries;
+    throw error;
+  }
+
+  if (info.isSymbolicLink()) {
+    entries.set('.', {
+      kind: 'symlink',
+      linkTarget: await readlink(pluginDirectory),
+      size: 0,
+    });
+    return entries;
+  }
+
+  if (!info.isDirectory()) {
+    entries.set('.', await fileSnapshot(pluginDirectory, info));
+    return entries;
+  }
+
+  await walkDirectory(pluginDirectory, '', entries);
+  return entries;
+}
+
+async function walkDirectory(directory, prefix, entries) {
+  const directoryEntries = await readdir(directory, { withFileTypes: true });
+  for (const entry of directoryEntries) {
+    const path = join(directory, entry.name);
+    const relativePath = prefix.length === 0 ? entry.name : `${prefix}/${entry.name}`;
+    const info = await lstat(path);
+
+    if (info.isSymbolicLink()) {
+      entries.set(relativePath, {
+        kind: 'symlink',
+        linkTarget: await readlink(path),
+        size: 0,
+      });
+    } else if (info.isDirectory()) {
+      await walkDirectory(path, relativePath, entries);
+    } else if (info.isFile()) {
+      entries.set(relativePath, await fileSnapshot(path, info));
+    }
+  }
+}
+
+async function fileSnapshot(path, info) {
+  const data = await readFile(path);
+  return {
+    kind: 'file',
+    sha256: createHash('sha256').update(data).digest('hex'),
+    size: info.size,
+  };
+}
+
+function printHeader(options, pluginDirectory) {
+  console.log('Local Dictation dev CUDA install');
+  console.log(`  vault:    ${options.vault}`);
+  console.log(`  plugin:   ${pluginDirectory}`);
+  console.log(`  profile:  ${options.release ? 'release' : 'debug'}`);
+  console.log(`  cuda:     ${options.cuda ? 'enabled' : 'skipped'}`);
+  console.log(`  enable:   ${options.enable ? 'yes' : 'no'}`);
+  console.log(
+    `  preserve: ${options.resetData ? 'nothing (--reset-data)' : PRESERVED_PLUGIN_FILES.join(', ')}`,
+  );
+}
+
+function printChangeReport(summary, pluginDirectory) {
+  console.log('\nOverride report');
+  console.log(`  target: ${pluginDirectory}`);
+  printList('  overwritten (changed)', summary.overwrittenChanged);
+  printList('  overwritten (same content)', summary.overwrittenUnchanged);
+  printList('  created', summary.created);
+  printList('  removed stale', summary.removed);
+  printList('  preserved', summary.preserved);
+  console.log('\nDone.');
+}
+
+function printList(label, values) {
+  const max = 40;
+  if (values.length === 0) {
+    console.log(`${label}: none`);
+    return;
+  }
+
+  console.log(`${label}:`);
+  for (const value of values.slice(0, max)) {
+    console.log(`    ${value}`);
+  }
+  if (values.length > max) {
+    console.log(`    ... ${values.length - max} more`);
+  }
+}
+
+function createCudaBuildStep(options, platform) {
+  if (platform === 'linux') {
+    const args = [
+      'scripts/build-cuda.sh',
+      ...(options.release ? ['--release'] : []),
+      ...(options.cleanCuda ? ['--clean'] : []),
+      ...(options.jobs === null ? [] : ['--jobs', String(options.jobs)]),
+    ];
+    const retryArgs = [
+      'scripts/build-cuda.sh',
+      ...(options.release ? ['--release'] : []),
+      '--clean',
+      ...(options.jobs === null ? [] : ['--jobs', String(options.jobs)]),
+    ];
+
+    return {
+      args,
+      command: 'bash',
+      label: 'Build CUDA sidecar',
+      retry: options.cleanCuda
+        ? undefined
+        : {
+            args: retryArgs,
+            command: 'bash',
+            reason:
+              'CUDA build failed; retrying once with --clean to clear stale native build state.',
+          },
+    };
+  }
+
+  if (platform === 'win32') {
+    if (options.cleanCuda) {
+      throw new Error('--clean-cuda is only supported by scripts/build-cuda.sh on Linux.');
+    }
+
+    return {
+      args: [
+        '-ExecutionPolicy',
+        'Bypass',
+        '-File',
+        'scripts/build-cuda.ps1',
+        ...(options.release ? ['-Release'] : []),
+      ],
+      command: 'powershell',
+      env: options.jobs === null ? undefined : { BUILD_JOBS: String(options.jobs) },
+      label: 'Build CUDA sidecar',
+    };
+  }
+
+  throw new Error(`CUDA sidecar builds are not supported on ${platform}. Use --skip-cuda.`);
+}
+
+function runCommand(command, args, extraEnv) {
+  const result = spawnSync(command, args, {
+    env: extraEnv === undefined ? process.env : { ...process.env, ...extraEnv },
+    stdio: 'inherit',
+  });
+
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`${formatCommand(command, args)} failed with exit code ${result.status}.`);
+  }
+}
+
+async function fileExists(path) {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if (error.code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+function parsePositiveInteger(value, label) {
+  if (!/^[1-9][0-9]*$/.test(value)) {
+    throw new Error(`${label} must be a positive integer.`);
+  }
+  return Number(value);
+}
+
+function entryFingerprint(entry) {
+  if (entry.kind === 'file') return `${entry.kind}:${entry.size}:${entry.sha256}`;
+  return `${entry.kind}:${entry.linkTarget}`;
+}
+
+function npmCommand(platform = process.platform) {
+  return platform === 'win32' ? 'npm.cmd' : 'npm';
+}
+
+function nodeCommand() {
+  return process.execPath;
+}
+
+function formatCommand(command, args) {
+  return [command, ...args].map(shellQuote).join(' ');
+}
+
+function shellQuote(value) {
+  if (/^[A-Za-z0-9_./:=@+-]+$/.test(value)) return value;
+  return `'${value.replaceAll("'", "'\"'\"'")}'`;
+}
+
+const invokedDirectly =
+  import.meta.url === `file://${process.argv[1]}` ||
+  import.meta.url.endsWith(process.argv[1] ?? '');
+
+if (invokedDirectly) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(`\nerror: ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/src/audio/system-audio-permission-message.ts
+++ b/src/audio/system-audio-permission-message.ts
@@ -1,0 +1,92 @@
+import type { SystemAudioProbeResultEvent } from '../sidecar/protocol';
+
+const SYSTEM_AUDIO_PERMISSION_DENIED_CODE = 'system_audio_permission_denied';
+const ELECTRON_SYSTEM_AUDIO_PERMISSION_MINIMUM_VERSION = '39.6.0';
+const OBSIDIAN_INSTALLER_MESSAGE =
+  'Your Obsidian installer predates the macOS system-audio permission. Download a fresh installer from obsidian.md and reinstall, then try again.';
+
+export function formatSystemAudioProbeResultMessage(
+  result: Pick<SystemAudioProbeResultEvent, 'code' | 'message'>,
+  electronVersion = readElectronVersion(),
+): string {
+  return formatSystemAudioErrorMessage(
+    result.message ?? 'System audio is not ready.',
+    result.code,
+    electronVersion,
+  );
+}
+
+export function formatSystemAudioErrorMessage(
+  message: string,
+  code: string | undefined,
+  electronVersion = readElectronVersion(),
+): string {
+  if (
+    code !== SYSTEM_AUDIO_PERMISSION_DENIED_CODE ||
+    !isElectronVersionOlderThan(electronVersion, ELECTRON_SYSTEM_AUDIO_PERMISSION_MINIMUM_VERSION)
+  ) {
+    return message;
+  }
+
+  return `${message} ${OBSIDIAN_INSTALLER_MESSAGE}`;
+}
+
+export function formatSystemAudioSidecarErrorMessage(
+  error: unknown,
+  electronVersion = readElectronVersion(),
+): string | null {
+  const code = (error as { code?: unknown } | null)?.code;
+
+  if (code !== SYSTEM_AUDIO_PERMISSION_DENIED_CODE) {
+    return null;
+  }
+
+  const message = error instanceof Error ? error.message : (error as { message?: unknown }).message;
+  if (typeof message !== 'string') {
+    return null;
+  }
+
+  return formatSystemAudioErrorMessage(message, code, electronVersion);
+}
+
+export function isElectronVersionOlderThan(
+  version: string | null | undefined,
+  minimumVersion: string,
+): boolean {
+  const parsedVersion = parseVersion(version);
+  const parsedMinimum = parseVersion(minimumVersion);
+
+  if (parsedVersion === null || parsedMinimum === null) {
+    return false;
+  }
+
+  for (let index = 0; index < parsedMinimum.length; index += 1) {
+    const current = parsedVersion[index] ?? 0;
+    const minimum = parsedMinimum[index] ?? 0;
+
+    if (current < minimum) {
+      return true;
+    }
+    if (current > minimum) {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+function parseVersion(version: string | null | undefined): number[] | null {
+  if (version === null || version === undefined) {
+    return null;
+  }
+
+  const parts = version.split('.').map((part) => Number.parseInt(part, 10));
+  return parts.every(Number.isInteger) ? parts : null;
+}
+
+function readElectronVersion(): string | null {
+  const maybeProcess =
+    typeof process === 'undefined' ? undefined : (process as { versions?: { electron?: string } });
+
+  return maybeProcess?.versions?.electron ?? null;
+}

--- a/src/audio/system-audio-permission-message.ts
+++ b/src/audio/system-audio-permission-message.ts
@@ -1,4 +1,5 @@
 import type { SystemAudioProbeResultEvent } from '../sidecar/protocol';
+import { compareVersions } from '../version';
 
 const SYSTEM_AUDIO_PERMISSION_DENIED_CODE = 'system_audio_permission_denied';
 const ELECTRON_SYSTEM_AUDIO_PERMISSION_MINIMUM_VERSION = '39.6.0';
@@ -35,53 +36,26 @@ export function formatSystemAudioSidecarErrorMessage(
   error: unknown,
   electronVersion = readElectronVersion(),
 ): string | null {
-  const code = (error as { code?: unknown } | null)?.code;
+  const details = error as { code?: unknown; message?: unknown } | null;
 
-  if (code !== SYSTEM_AUDIO_PERMISSION_DENIED_CODE) {
+  if (details?.code !== SYSTEM_AUDIO_PERMISSION_DENIED_CODE) {
     return null;
   }
 
-  const message = error instanceof Error ? error.message : (error as { message?: unknown }).message;
+  const { message } = details;
   if (typeof message !== 'string') {
     return null;
   }
 
-  return formatSystemAudioErrorMessage(message, code, electronVersion);
+  return formatSystemAudioErrorMessage(message, details.code, electronVersion);
 }
 
 export function isElectronVersionOlderThan(
   version: string | null | undefined,
   minimumVersion: string,
 ): boolean {
-  const parsedVersion = parseVersion(version);
-  const parsedMinimum = parseVersion(minimumVersion);
-
-  if (parsedVersion === null || parsedMinimum === null) {
-    return false;
-  }
-
-  for (let index = 0; index < parsedMinimum.length; index += 1) {
-    const current = parsedVersion[index] ?? 0;
-    const minimum = parsedMinimum[index] ?? 0;
-
-    if (current < minimum) {
-      return true;
-    }
-    if (current > minimum) {
-      return false;
-    }
-  }
-
-  return false;
-}
-
-function parseVersion(version: string | null | undefined): number[] | null {
-  if (version === null || version === undefined) {
-    return null;
-  }
-
-  const parts = version.split('.').map((part) => Number.parseInt(part, 10));
-  return parts.every(Number.isInteger) ? parts : null;
+  // Unknown or unparseable versions must not trigger the reinstall hint.
+  return compareVersions(version, minimumVersion) === -1;
 }
 
 function readElectronVersion(): string | null {

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -5,6 +5,10 @@ import { Platform } from 'obsidian';
 import type { AudioCaptureStream } from '../audio/audio-capture-stream';
 import { formatMicrophoneCaptureErrorMessage } from '../audio/microphone-permission-message';
 import type { SidecarAudioLevelMeter } from '../audio/sidecar-audio-level-meter';
+import {
+  formatSystemAudioErrorMessage,
+  formatSystemAudioSidecarErrorMessage,
+} from '../audio/system-audio-permission-message';
 import type { NotePlacementOptions } from '../editor/note-surface';
 import {
   type LlmPostprocessMode,
@@ -1085,7 +1089,8 @@ export class DictationSessionController {
       return;
     }
 
-    const detail = event.details ? `${event.message} (${event.details})` : event.message;
+    const rawDetail = event.details ? `${event.message} (${event.details})` : event.message;
+    const detail = formatSystemAudioErrorMessage(rawDetail, event.code);
 
     if (event.sessionId === undefined) {
       this.handleError('Local Dictation sidecar error', detail);
@@ -1185,6 +1190,13 @@ export class DictationSessionController {
     if (microphoneMessage !== null) {
       this.dependencies.logger?.warn('session', message, formatErrorMessage(error));
       this.dependencies.notice(microphoneMessage);
+      return;
+    }
+
+    const systemAudioMessage = formatSystemAudioSidecarErrorMessage(error);
+    if (systemAudioMessage !== null) {
+      this.dependencies.logger?.warn('session', message, formatErrorMessage(error));
+      this.dependencies.notice(systemAudioMessage);
       return;
     }
 

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -680,10 +680,12 @@ export class DictationSessionController {
     entry: ManagedSession,
     event: TranscriptReadyEvent,
   ): Promise<void> {
-    this.dependencies.logger?.debug(
-      'session',
-      `transcript received (${event.text.length} chars, ${event.processingDurationMs}ms processing)`,
-    );
+    if (event.isFinal) {
+      this.dependencies.logger?.debug(
+        'session',
+        `final transcript received (${event.text.length} chars, ${event.processingDurationMs}ms processing)`,
+      );
+    }
 
     for (const warning of event.warnings) {
       this.dependencies.logger?.debug(

--- a/src/settings/setting-helpers.ts
+++ b/src/settings/setting-helpers.ts
@@ -57,13 +57,14 @@ export function addEnumSetting<K extends keyof PluginSettings>(
 export function addToggleSetting<K extends SettingsKeyOf<boolean>>(
   parent: HTMLElement,
   access: SettingAccess,
-  spec: SettingSpec & { key: K },
+  spec: SettingSpec & { key: K; onChange?: (value: boolean) => void | Promise<void> },
 ): Setting {
   const setting = new Setting(parent).setName(spec.name).setDesc(spec.desc);
   setting.addToggle((toggle) => {
     toggle.setValue(access.getSettings()[spec.key]);
     toggle.onChange(async (value) => {
       await access.persistOne(spec.key, value);
+      await spec.onChange?.(value);
     });
   });
   appendInfoTooltip(setting, spec.tooltip);

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -179,7 +179,17 @@ export class LocalSttSettingTab extends PluginSettingTab {
     });
 
     if (systemAudioSupported) {
-      this.renderSystemAudioSetting(captureCard, settings);
+      addToggleSetting(captureCard, this.access, {
+        name: 'Include system audio',
+        desc: "Also capture this computer's default audio output for meetings, calls, and videos.",
+        key: 'includeSystemAudio',
+        onChange: async (value) => {
+          // First-ever probe is the designed moment for the macOS TCC prompt.
+          if (value && Platform.isMacOS) {
+            await this.probeSystemAudio();
+          }
+        },
+      });
     }
 
     addEnumSetting(captureCard, this.access, {
@@ -329,25 +339,6 @@ export class LocalSttSettingTab extends PluginSettingTab {
     this.disposeMissingSidecarBanner?.();
     this.disposeMissingSidecarBanner = null;
     this.missingSidecarProgressEl = null;
-  }
-
-  private renderSystemAudioSetting(parent: HTMLElement, settings: PluginSettings): void {
-    const setting = new Setting(parent)
-      .setName('Include system audio')
-      .setDesc(
-        "Also capture this computer's default audio output for meetings, calls, and videos.",
-      );
-
-    setting.addToggle((toggle) => {
-      toggle.setValue(settings.includeSystemAudio);
-      toggle.onChange(async (value) => {
-        await this.access.persistOne('includeSystemAudio', value);
-
-        if (value && Platform.isMacOS) {
-          await this.probeSystemAudio();
-        }
-      });
-    });
   }
 
   private async probeSystemAudio(): Promise<void> {

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -1,6 +1,7 @@
 import type { App, Plugin } from 'obsidian';
 import { Notice, Platform, PluginSettingTab, Setting } from 'obsidian';
 
+import { formatSystemAudioProbeResultMessage } from '../audio/system-audio-permission-message';
 import { resolveEngineCapabilities } from '../models/capability-view';
 import type { ModelInstallManager } from '../models/model-install-manager';
 import { updateInstallProgressElement } from '../models/model-install-progress';
@@ -49,6 +50,7 @@ import {
   SidecarSettingsSection,
 } from './sidecar-settings-section';
 import { SmartParagraphSettingsModal } from './smart-paragraph-settings-modal';
+import { isSystemAudioSupportedOnCurrentPlatform } from './system-audio-support';
 
 interface SettingsTabDependencies {
   getSettings: () => PluginSettings;
@@ -61,7 +63,7 @@ interface SettingsTabDependencies {
   resolvePluginDirectory: () => Promise<string>;
   restartSidecar: () => Promise<void>;
   saveSettings: (settings: PluginSettings) => Promise<void>;
-  sidecarConnection: Pick<SidecarConnection, 'shutdown'>;
+  sidecarConnection: Pick<SidecarConnection, 'probeSystemAudio' | 'shutdown'>;
   sidecarInstallManager: SidecarInstallManager;
 }
 
@@ -168,7 +170,7 @@ export class LocalSttSettingTab extends PluginSettingTab {
     // --- Capture ---
     const captureCard = createSettingGroup(containerEl, 'Capture');
 
-    const systemAudioSupported = Platform.isWin || Platform.isLinux;
+    const systemAudioSupported = isSystemAudioSupportedOnCurrentPlatform();
 
     this.disposeMicrophoneSection = renderMicrophonePicker(captureCard, {
       access: this.access,
@@ -177,11 +179,7 @@ export class LocalSttSettingTab extends PluginSettingTab {
     });
 
     if (systemAudioSupported) {
-      addToggleSetting(captureCard, this.access, {
-        name: 'Include system audio',
-        desc: "Also capture this computer's default audio output for meetings, calls, and videos.",
-        key: 'includeSystemAudio',
-      });
+      this.renderSystemAudioSetting(captureCard, settings);
     }
 
     addEnumSetting(captureCard, this.access, {
@@ -331,6 +329,39 @@ export class LocalSttSettingTab extends PluginSettingTab {
     this.disposeMissingSidecarBanner?.();
     this.disposeMissingSidecarBanner = null;
     this.missingSidecarProgressEl = null;
+  }
+
+  private renderSystemAudioSetting(parent: HTMLElement, settings: PluginSettings): void {
+    const setting = new Setting(parent)
+      .setName('Include system audio')
+      .setDesc(
+        "Also capture this computer's default audio output for meetings, calls, and videos.",
+      );
+
+    setting.addToggle((toggle) => {
+      toggle.setValue(settings.includeSystemAudio);
+      toggle.onChange(async (value) => {
+        await this.access.persistOne('includeSystemAudio', value);
+
+        if (value && Platform.isMacOS) {
+          await this.probeSystemAudio();
+        }
+      });
+    });
+  }
+
+  private async probeSystemAudio(): Promise<void> {
+    try {
+      const result = await this.dependencies.sidecarConnection.probeSystemAudio();
+      if (result.ok) {
+        new Notice('System audio is ready.');
+        return;
+      }
+
+      new Notice(formatSystemAudioProbeResultMessage(result));
+    } catch (error) {
+      new Notice(`Could not test system audio: ${formatErrorMessage(error)}`);
+    }
   }
 
   private renderTranscriptFormattingSetting(parent: HTMLElement): void {

--- a/src/settings/system-audio-support.ts
+++ b/src/settings/system-audio-support.ts
@@ -1,5 +1,7 @@
 import { Platform } from 'obsidian';
 
+import { compareVersions } from '../version';
+
 export interface SystemAudioPlatform {
   isLinux: boolean;
   isMacOS: boolean;
@@ -26,19 +28,8 @@ export function isMacOSVersionAtLeast(
   requiredMajor: number,
   requiredMinor: number,
 ): boolean {
-  if (version === null || version === undefined) {
-    return false;
-  }
-
-  const [majorText, minorText = '0'] = version.trim().split('.');
-  const major = Number.parseInt(majorText ?? '', 10);
-  const minor = Number.parseInt(minorText, 10);
-
-  if (!Number.isInteger(major) || !Number.isInteger(minor)) {
-    return false;
-  }
-
-  return major > requiredMajor || (major === requiredMajor && minor >= requiredMinor);
+  const comparison = compareVersions(version, `${requiredMajor}.${requiredMinor}`);
+  return comparison !== null && comparison >= 0;
 }
 
 function readMacOSSystemVersion(): string | null {

--- a/src/settings/system-audio-support.ts
+++ b/src/settings/system-audio-support.ts
@@ -1,0 +1,57 @@
+import { Platform } from 'obsidian';
+
+export interface SystemAudioPlatform {
+  isLinux: boolean;
+  isMacOS: boolean;
+  isWin: boolean;
+}
+
+export function isSystemAudioSupportedOnCurrentPlatform(): boolean {
+  return isSystemAudioSupported(Platform, readMacOSSystemVersion());
+}
+
+export function isSystemAudioSupported(
+  platform: SystemAudioPlatform,
+  macOSVersion: string | null | undefined,
+): boolean {
+  if (platform.isWin || platform.isLinux) {
+    return true;
+  }
+
+  return platform.isMacOS && isMacOSVersionAtLeast(macOSVersion, 14, 2);
+}
+
+export function isMacOSVersionAtLeast(
+  version: string | null | undefined,
+  requiredMajor: number,
+  requiredMinor: number,
+): boolean {
+  if (version === null || version === undefined) {
+    return false;
+  }
+
+  const [majorText, minorText = '0'] = version.trim().split('.');
+  const major = Number.parseInt(majorText ?? '', 10);
+  const minor = Number.parseInt(minorText, 10);
+
+  if (!Number.isInteger(major) || !Number.isInteger(minor)) {
+    return false;
+  }
+
+  return major > requiredMajor || (major === requiredMajor && minor >= requiredMinor);
+}
+
+function readMacOSSystemVersion(): string | null {
+  const maybeProcess =
+    typeof process === 'undefined' ? undefined : (process as { getSystemVersion?: () => string });
+
+  if (typeof maybeProcess?.getSystemVersion !== 'function') {
+    return null;
+  }
+
+  try {
+    return maybeProcess.getSystemVersion();
+  } catch {
+    return null;
+  }
+}

--- a/src/sidecar/protocol.ts
+++ b/src/sidecar/protocol.ts
@@ -106,6 +106,8 @@ interface EnvelopeBase<TType extends string> {
 
 export type HealthCommand = EnvelopeBase<'health'>;
 
+export type ProbeSystemAudioCommand = EnvelopeBase<'probe_system_audio'>;
+
 export interface StartSessionCommand extends EnvelopeBase<'start_session'> {
   accelerationPreference: AccelerationPreference;
   diarizationEnabled: boolean;
@@ -180,6 +182,7 @@ export type SidecarCommand =
   | InstallModelCommand
   | ListInstalledModelsCommand
   | ListModelCatalogCommand
+  | ProbeSystemAudioCommand
   | ProbeModelSelectionCommand
   | RemoveModelCommand
   | ShutdownCommand
@@ -196,6 +199,12 @@ export interface SystemInfoEvent extends EnvelopeBase<'system_info'> {
   compiledRuntimes: CompiledRuntimeInfo[];
   sidecarVersion: string;
   systemInfo: string;
+}
+
+export interface SystemAudioProbeResultEvent extends EnvelopeBase<'system_audio_probe_result'> {
+  code?: string;
+  message?: string;
+  ok: boolean;
 }
 
 export interface ModelStoreEvent extends EnvelopeBase<'model_store'>, ModelStoreRecord {}
@@ -296,6 +305,7 @@ export type SidecarEvent =
   | SessionStartedEvent
   | SessionStateChangedEvent
   | SessionStoppedEvent
+  | SystemAudioProbeResultEvent
   | SystemInfoEvent
   | TranscriptionQueueChangedEvent
   | TranscriptReadyEvent
@@ -303,6 +313,10 @@ export type SidecarEvent =
 
 export function createHealthCommand(): HealthCommand {
   return createEnvelope('health');
+}
+
+export function createProbeSystemAudioCommand(): ProbeSystemAudioCommand {
+  return createEnvelope('probe_system_audio');
 }
 
 export function createGetSystemInfoCommand(): GetSystemInfoCommand {
@@ -475,6 +489,7 @@ const SIDECAR_EVENT_TYPE_FLAGS = {
   session_started: 1,
   session_state_changed: 1,
   session_stopped: 1,
+  system_audio_probe_result: 1,
   system_info: 1,
   transcript_ready: 1,
   transcription_queue_changed: 1,

--- a/src/sidecar/sidecar-connection.ts
+++ b/src/sidecar/sidecar-connection.ts
@@ -466,9 +466,10 @@ function shouldLogProtocolEvent(event: SidecarEvent): boolean {
     case 'session_started':
     case 'session_state_changed':
     case 'session_stopped':
-    case 'transcript_ready':
     case 'warning':
       return true;
+    case 'transcript_ready':
+      return event.isFinal;
     case 'model_install_update':
       return false;
     default:
@@ -487,7 +488,7 @@ function summarizeProtocolEvent(event: SidecarEvent): string {
     case 'session_stopped':
       return `event: session_stopped (${event.sessionId}, ${event.reason})`;
     case 'transcript_ready':
-      return `event: transcript_ready (${event.sessionId}, ${event.text.length} chars)`;
+      return `event: transcript_ready (${event.sessionId}, final, ${event.text.length} chars)`;
     case 'warning':
       return `event: warning (${event.code})`;
     case 'error':

--- a/src/sidecar/sidecar-connection.ts
+++ b/src/sidecar/sidecar-connection.ts
@@ -13,6 +13,7 @@ import {
   createListInstalledModelsCommand,
   createListModelCatalogCommand,
   createProbeModelSelectionCommand,
+  createProbeSystemAudioCommand,
   createRemoveModelCommand,
   createStartSessionCommand,
   createStopSessionCommand,
@@ -34,6 +35,7 @@ import {
   type SidecarCommand,
   type SidecarEvent,
   type StartSessionCommand,
+  type SystemAudioProbeResultEvent,
   type SystemInfoEvent,
 } from './protocol';
 import { createSidecarStderrLogEntry } from './sidecar-logging';
@@ -201,6 +203,16 @@ export class SidecarConnection {
         selectedModelEquals(event.selection, payload.modelSelection),
       'model_probe_result',
       timeoutMs,
+    );
+  }
+
+  async probeSystemAudio(timeoutMs = 75_000): Promise<SystemAudioProbeResultEvent> {
+    return this.sendCommandAndWait(
+      createProbeSystemAudioCommand(),
+      (event): event is SystemAudioProbeResultEvent => event.type === 'system_audio_probe_result',
+      'system_audio_probe_result',
+      timeoutMs,
+      (event) => event.sessionId === undefined,
     );
   }
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,41 @@
+/**
+ * Compares two dot-separated numeric version strings ("14.2.1"). Missing
+ * segments count as 0, so "14" equals "14.0". Returns null when either side
+ * has a non-numeric segment (or `a` is absent), so callers can treat unknown
+ * versions conservatively instead of guessing a direction.
+ */
+export function compareVersions(a: string | null | undefined, b: string): -1 | 0 | 1 | null {
+  const left = parseVersion(a);
+  const right = parseVersion(b);
+
+  if (left === null || right === null) {
+    return null;
+  }
+
+  const length = Math.max(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = left[index] ?? 0;
+    const rightPart = right[index] ?? 0;
+
+    if (leftPart < rightPart) {
+      return -1;
+    }
+    if (leftPart > rightPart) {
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+function parseVersion(version: string | null | undefined): number[] | null {
+  if (version === null || version === undefined) {
+    return null;
+  }
+
+  const parts = version
+    .trim()
+    .split('.')
+    .map((part) => Number.parseInt(part, 10));
+  return parts.every(Number.isInteger) ? parts : null;
+}

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -373,6 +373,44 @@ describe('DictationSessionController', () => {
     });
   });
 
+  it('debug-logs final transcript summaries without logging partial revision summaries', async () => {
+    const logger = new FakeLogger();
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const controller = createController({
+      createSession: (session) => {
+        sessions.push(session);
+      },
+      logger,
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    logger.debug.mockClear();
+
+    sidecarConnection.emit(transcriptReady(sessionId, 'partial', { isFinal: false, revision: 1 }));
+
+    await vi.waitFor(() => {
+      expect(sessions[0]?.acceptTranscript).toHaveBeenCalledWith(
+        expect.objectContaining({ isFinal: false, text: 'partial' }),
+      );
+    });
+    expect(logger.debug).not.toHaveBeenCalledWith(
+      'session',
+      expect.stringContaining('transcript received'),
+    );
+
+    sidecarConnection.emit(transcriptReady(sessionId, 'final', { isFinal: true, revision: 2 }));
+
+    await vi.waitFor(() => {
+      expect(logger.debug).toHaveBeenCalledWith(
+        'session',
+        'final transcript received (5 chars, 12ms processing)',
+      );
+    });
+  });
+
   it('silently enforces the five-session active plus draining cap', async () => {
     const sidecarConnection = new FakeSidecarConnection();
     const controller = createController({ sidecarConnection });

--- a/test/install-dev-cuda.test.ts
+++ b/test/install-dev-cuda.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createBuildSteps,
+  createInstallStep,
+  type DevCudaInstallOptions,
+  type InstallSnapshot,
+  parseArgs,
+  summarizeInstallChanges,
+} from '../scripts/install-dev-cuda.mjs';
+
+function options(overrides: Partial<DevCudaInstallOptions> = {}): DevCudaInstallOptions {
+  return {
+    cleanCuda: false,
+    cuda: true,
+    enable: true,
+    help: false,
+    jobs: null,
+    release: false,
+    resetData: false,
+    vault: '/vault',
+    ...overrides,
+  };
+}
+
+function file(sha256: string, size = 1): { kind: 'file'; sha256: string; size: number } {
+  return { kind: 'file', sha256, size };
+}
+
+describe('parseArgs', () => {
+  it('accepts the vault as a flag and parses install options', () => {
+    expect(
+      parseArgs([
+        '--vault',
+        '/tmp/vault',
+        '--release',
+        '--jobs',
+        '8',
+        '--clean-cuda',
+        '--no-enable',
+        '--reset-data',
+      ]),
+    ).toMatchObject({
+      cleanCuda: true,
+      enable: false,
+      jobs: 8,
+      release: true,
+      resetData: true,
+      vault: '/tmp/vault',
+    });
+  });
+
+  it('accepts a positional vault path for the one-command workflow', () => {
+    expect(parseArgs(['/tmp/vault']).vault).toBe('/tmp/vault');
+  });
+
+  it('rejects invalid job counts', () => {
+    expect(() => parseArgs(['--vault', '/tmp/vault', '--jobs', '0'])).toThrow(/positive integer/);
+  });
+});
+
+describe('createBuildSteps', () => {
+  it('builds frontend, CPU sidecar, CUDA sidecar, and verification on Linux', () => {
+    const steps = createBuildSteps(options(), 'linux');
+
+    expect(steps.map((step) => step.label)).toEqual([
+      'Build frontend bundle',
+      'Build CPU sidecar',
+      'Build CUDA sidecar',
+      'Verify build output',
+    ]);
+    expect(steps[2]?.command).toBe('bash');
+    expect(steps[2]?.args).toEqual(['scripts/build-cuda.sh']);
+    expect(steps[2]?.retry?.args).toEqual(['scripts/build-cuda.sh', '--clean']);
+  });
+
+  it('passes release, clean, and job options to the relevant build steps', () => {
+    const steps = createBuildSteps(options({ cleanCuda: true, jobs: 4, release: true }), 'linux');
+
+    expect(steps[1]?.args).toContain('--release');
+    expect(steps[2]?.args).toEqual([
+      'scripts/build-cuda.sh',
+      '--release',
+      '--clean',
+      '--jobs',
+      '4',
+    ]);
+    expect(steps[2]?.retry).toBeUndefined();
+    expect(steps[3]?.args).toContain('--release');
+  });
+
+  it('can intentionally skip CUDA for CPU-only dev installs', () => {
+    const steps = createBuildSteps(options({ cuda: false }), 'linux');
+
+    expect(steps.map((step) => step.label)).toEqual([
+      'Build frontend bundle',
+      'Build CPU sidecar',
+      'Verify build output',
+    ]);
+  });
+
+  it('rejects unsupported CUDA platforms unless CUDA is skipped', () => {
+    expect(() => createBuildSteps(options(), 'darwin')).toThrow(/Use --skip-cuda/);
+  });
+});
+
+describe('createInstallStep', () => {
+  it('installs sidecars and enables the plugin by default', () => {
+    const step = createInstallStep(options());
+
+    expect(step.args).toEqual([
+      'scripts/install-dev-plugin.mjs',
+      '--vault',
+      '/vault',
+      '--sidecars',
+      '--enable',
+    ]);
+  });
+
+  it('passes release and omits enable when requested', () => {
+    const step = createInstallStep(options({ enable: false, release: true }));
+
+    expect(step.args).toEqual([
+      'scripts/install-dev-plugin.mjs',
+      '--vault',
+      '/vault',
+      '--sidecars',
+      '--release',
+    ]);
+  });
+});
+
+describe('summarizeInstallChanges', () => {
+  it('classifies overwritten, created, removed, and preserved install files', () => {
+    const before: InstallSnapshot = new Map([
+      ['bin/old-runtime.so', file('old-runtime')],
+      ['data.json', file('settings')],
+      ['main.js', file('old-main', 10)],
+      ['styles.css', file('same-style')],
+    ]);
+    const after: InstallSnapshot = new Map([
+      ['data.json', file('settings')],
+      ['main.js', file('new-main', 20)],
+      ['manifest.json', file('manifest')],
+      ['styles.css', file('same-style')],
+    ]);
+
+    expect(summarizeInstallChanges(before, after)).toEqual({
+      created: ['manifest.json'],
+      overwrittenChanged: ['main.js'],
+      overwrittenUnchanged: ['styles.css'],
+      preserved: ['data.json'],
+      removed: ['bin/old-runtime.so'],
+    });
+  });
+});

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -8,6 +8,7 @@ import {
   createCancelSessionCommand,
   createContextResponseCommand,
   createHealthCommand,
+  createProbeSystemAudioCommand,
   createStartSessionCommand,
   createStopSessionCommand,
   decodeAudioFrameEnvelope,
@@ -259,6 +260,12 @@ describe('command serialization', () => {
     });
   });
 
+  it('serializes the system-audio probe command without a session payload', () => {
+    expect(readPayload(encodeJsonFrame(createProbeSystemAudioCommand()))).toEqual({
+      type: 'probe_system_audio',
+    });
+  });
+
   it('serializes context_response carrying a context window or explicit null', () => {
     const window: ContextWindow = {
       budgetChars: 512,
@@ -276,6 +283,31 @@ describe('command serialization', () => {
       context: null,
       correlationId: 'corr-1',
       type: 'context_response',
+    });
+  });
+});
+
+// Events ---------------------------------------------------------------------
+
+describe('event parsing', () => {
+  it('accepts successful and failed system-audio probe results', () => {
+    expect(
+      parseEventFrame(JSON.stringify({ ok: true, type: 'system_audio_probe_result' })),
+    ).toEqual({ ok: true, type: 'system_audio_probe_result' });
+    expect(
+      parseEventFrame(
+        JSON.stringify({
+          code: 'system_audio_permission_denied',
+          message: 'grant permission',
+          ok: false,
+          type: 'system_audio_probe_result',
+        }),
+      ),
+    ).toEqual({
+      code: 'system_audio_permission_denied',
+      message: 'grant permission',
+      ok: false,
+      type: 'system_audio_probe_result',
     });
   });
 });

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -287,7 +287,7 @@ describe('command serialization', () => {
   });
 });
 
-// Events ---------------------------------------------------------------------
+// Event parsing --------------------------------------------------------------
 
 describe('event parsing', () => {
   it('accepts successful and failed system-audio probe results', () => {
@@ -310,11 +310,7 @@ describe('event parsing', () => {
       type: 'system_audio_probe_result',
     });
   });
-});
 
-// Event parsing --------------------------------------------------------------
-
-describe('event parsing', () => {
   it('parses audio_level events for ribbon metering', () => {
     expect(
       parseEventFrame(

--- a/test/sidecar-connection.test.ts
+++ b/test/sidecar-connection.test.ts
@@ -6,6 +6,7 @@ import {
   type HealthOkEvent,
   type ModelInstallUpdateEvent,
   type SidecarEvent,
+  type TranscriptReadyEvent,
   type WarningEvent,
 } from '../src/sidecar/protocol';
 import { SidecarConnection, type SidecarError } from '../src/sidecar/sidecar-connection';
@@ -63,7 +64,10 @@ class FakeSidecarProcess {
   }
 }
 
-function createHarness(timeoutMs = 5_000): {
+function createHarness(
+  timeoutMs = 5_000,
+  logger?: ConstructorParameters<typeof SidecarConnection>[0]['logger'],
+): {
   connection: SidecarConnection;
   process: FakeSidecarProcess;
 } {
@@ -71,10 +75,16 @@ function createHarness(timeoutMs = 5_000): {
   const resolveLaunchSpec: ResolveSidecarLaunchSpec = async () => ({
     command: '/tmp/local-dictation-sidecar-test',
   });
-  const connection = new SidecarConnection({
+  const options: ConstructorParameters<typeof SidecarConnection>[0] = {
     createProcess: (_resolve, handlers) => process.attach(handlers),
     getRequestTimeoutMs: () => timeoutMs,
     resolveLaunchSpec,
+  };
+  if (logger !== undefined) {
+    options.logger = logger;
+  }
+  const connection = new SidecarConnection({
+    ...options,
   });
 
   return { connection, process };
@@ -131,6 +141,28 @@ function readJsonPayload(frame: Uint8Array): unknown {
     true,
   );
   return JSON.parse(new TextDecoder().decode(frame.slice(FRAME_HEADER_LENGTH, 5 + payloadLength)));
+}
+
+function transcriptReadyEvent(overrides: Partial<TranscriptReadyEvent> = {}): TranscriptReadyEvent {
+  return {
+    isFinal: true,
+    pauseMsBeforeUtterance: null,
+    processingDurationMs: 12,
+    revision: 0,
+    segments: [],
+    sessionId: 'session-1',
+    speakerIndex: null,
+    stageResults: [],
+    text: 'hello',
+    type: 'transcript_ready',
+    utteranceDurationMs: 1000,
+    utteranceEndMsInSession: 1000,
+    utteranceId: 'utterance-1',
+    utteranceIndex: 0,
+    utteranceStartMsInSession: 0,
+    warnings: [],
+    ...overrides,
+  };
 }
 
 async function flushMicrotasks(): Promise<void> {
@@ -283,5 +315,23 @@ describe('SidecarConnection', () => {
 
     expect(process.startCalls).toBe(0);
     expect(process.writtenFrames).toHaveLength(0);
+  });
+
+  it('logs final transcript events without logging partial transcript revisions', () => {
+    const logger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+    };
+    const { process } = createHarness(5_000, logger);
+
+    process.deliver(transcriptReadyEvent({ isFinal: false, revision: 1 }));
+    process.deliver(transcriptReadyEvent({ isFinal: true, revision: 2, text: 'hello world' }));
+
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'protocol',
+      'event: transcript_ready (session-1, final, 11 chars)',
+    );
   });
 });

--- a/test/sidecar-connection.test.ts
+++ b/test/sidecar-connection.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   type ErrorEvent,
   encodeJsonFrame,
+  FRAME_HEADER_LENGTH,
   type HealthOkEvent,
   type ModelInstallUpdateEvent,
   type SidecarEvent,
@@ -124,6 +125,14 @@ function healthOkEvent(overrides: Partial<HealthOkEvent> = {}): HealthOkEvent {
   };
 }
 
+function readJsonPayload(frame: Uint8Array): unknown {
+  const payloadLength = new DataView(frame.buffer, frame.byteOffset, frame.byteLength).getUint32(
+    1,
+    true,
+  );
+  return JSON.parse(new TextDecoder().decode(frame.slice(FRAME_HEADER_LENGTH, 5 + payloadLength)));
+}
+
 async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
 }
@@ -154,6 +163,21 @@ describe('SidecarConnection', () => {
     });
     expect(process.startCalls).toBe(1);
     expect(process.writtenFrames).toHaveLength(1);
+  });
+
+  it('probes system audio with the dedicated command and result event', async () => {
+    const { connection, process } = createHarness();
+
+    const resultPromise = connection.probeSystemAudio();
+    await flushMicrotasks();
+
+    expect(readJsonPayload(process.writtenFrames[0] ?? new Uint8Array())).toEqual({
+      type: 'probe_system_audio',
+    });
+
+    process.deliver({ ok: true, type: 'system_audio_probe_result' });
+
+    await expect(resultPromise).resolves.toEqual({ ok: true, type: 'system_audio_probe_result' });
   });
 
   it('notifies subscribed listeners until they unsubscribe', () => {

--- a/test/sidecar-connection.test.ts
+++ b/test/sidecar-connection.test.ts
@@ -140,7 +140,9 @@ function readJsonPayload(frame: Uint8Array): unknown {
     1,
     true,
   );
-  return JSON.parse(new TextDecoder().decode(frame.slice(FRAME_HEADER_LENGTH, 5 + payloadLength)));
+  return JSON.parse(
+    new TextDecoder().decode(frame.slice(FRAME_HEADER_LENGTH, FRAME_HEADER_LENGTH + payloadLength)),
+  );
 }
 
 function transcriptReadyEvent(overrides: Partial<TranscriptReadyEvent> = {}): TranscriptReadyEvent {

--- a/test/system-audio-permission-message.test.ts
+++ b/test/system-audio-permission-message.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatSystemAudioErrorMessage,
+  formatSystemAudioProbeResultMessage,
+  formatSystemAudioSidecarErrorMessage,
+  isElectronVersionOlderThan,
+} from '../src/audio/system-audio-permission-message';
+
+const PERMISSION_MESSAGE =
+  'System-audio recording permission is off for Obsidian. Open System Settings → Privacy & Security → Screen & System Audio Recording, enable Obsidian, and try again.';
+
+describe('formatSystemAudioErrorMessage', () => {
+  it('appends the Obsidian installer caveat for older Electron permission builds', () => {
+    const message = formatSystemAudioErrorMessage(
+      PERMISSION_MESSAGE,
+      'system_audio_permission_denied',
+      '39.5.9',
+    );
+
+    expect(message).toContain(PERMISSION_MESSAGE);
+    expect(message).toContain('Download a fresh installer from obsidian.md');
+  });
+
+  it('leaves permission copy unchanged once Electron includes the macOS permission key', () => {
+    expect(
+      formatSystemAudioErrorMessage(PERMISSION_MESSAGE, 'system_audio_permission_denied', '39.6.0'),
+    ).toBe(PERMISSION_MESSAGE);
+  });
+
+  it('does not append installer copy to unrelated system-audio errors', () => {
+    expect(
+      formatSystemAudioErrorMessage('device unavailable', 'system_audio_capture_failed', '39.5.9'),
+    ).toBe('device unavailable');
+  });
+});
+
+describe('formatSystemAudioProbeResultMessage', () => {
+  it('uses a fallback message when the sidecar returns a failed probe without copy', () => {
+    expect(
+      formatSystemAudioProbeResultMessage({ code: 'system_audio_capture_failed' }, '39.6.0'),
+    ).toBe('System audio is not ready.');
+  });
+});
+
+describe('formatSystemAudioSidecarErrorMessage', () => {
+  it('enriches permission-denied sidecar errors without handling unrelated errors', () => {
+    const error = Object.assign(new Error(PERMISSION_MESSAGE), {
+      code: 'system_audio_permission_denied',
+    });
+
+    expect(formatSystemAudioSidecarErrorMessage(error, '39.5.9')).toContain(
+      'Download a fresh installer from obsidian.md',
+    );
+    expect(
+      formatSystemAudioSidecarErrorMessage(
+        Object.assign(new Error('device unavailable'), { code: 'system_audio_capture_failed' }),
+        '39.5.9',
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('isElectronVersionOlderThan', () => {
+  it('compares semantic version components numerically', () => {
+    expect(isElectronVersionOlderThan('39.5.9', '39.6.0')).toBe(true);
+    expect(isElectronVersionOlderThan('39.6.0', '39.6.0')).toBe(false);
+    expect(isElectronVersionOlderThan('40.0.0', '39.6.0')).toBe(false);
+    expect(isElectronVersionOlderThan(undefined, '39.6.0')).toBe(false);
+  });
+});

--- a/test/system-audio-support.test.ts
+++ b/test/system-audio-support.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isMacOSVersionAtLeast,
+  isSystemAudioSupported,
+  type SystemAudioPlatform,
+} from '../src/settings/system-audio-support';
+
+const WINDOWS: SystemAudioPlatform = { isLinux: false, isMacOS: false, isWin: true };
+const LINUX: SystemAudioPlatform = { isLinux: true, isMacOS: false, isWin: false };
+const MACOS: SystemAudioPlatform = { isLinux: false, isMacOS: true, isWin: false };
+const OTHER: SystemAudioPlatform = { isLinux: false, isMacOS: false, isWin: false };
+
+describe('isSystemAudioSupported', () => {
+  it('keeps Windows and Linux enabled without consulting macOS version', () => {
+    expect(isSystemAudioSupported(WINDOWS, null)).toBe(true);
+    expect(isSystemAudioSupported(LINUX, null)).toBe(true);
+  });
+
+  it('requires macOS 14.2 or newer for native system audio', () => {
+    expect(isSystemAudioSupported(MACOS, '14.1.9')).toBe(false);
+    expect(isSystemAudioSupported(MACOS, '14.2')).toBe(true);
+    expect(isSystemAudioSupported(MACOS, '14.2.1')).toBe(true);
+    expect(isSystemAudioSupported(MACOS, '15.0')).toBe(true);
+  });
+
+  it('treats missing or malformed macOS versions as unsupported', () => {
+    expect(isSystemAudioSupported(MACOS, null)).toBe(false);
+    expect(isSystemAudioSupported(MACOS, 'not-a-version')).toBe(false);
+    expect(isSystemAudioSupported(OTHER, '15.0')).toBe(false);
+  });
+});
+
+describe('isMacOSVersionAtLeast', () => {
+  it('compares only major and minor version components', () => {
+    expect(isMacOSVersionAtLeast('14.10.3', 14, 2)).toBe(true);
+    expect(isMacOSVersionAtLeast('14', 14, 2)).toBe(false);
+    expect(isMacOSVersionAtLeast('13.9', 14, 2)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Native macOS system-audio backend via CoreAudio process taps, per the research + spec in #159 (see the [spec comment](https://github.com/brittain9/local-dictation-obsidian-plugin/issues/159#issuecomment-4919165083)).

Closes #159.

## Scope (from the spec)

- [x] `native/src/system_audio/macos.rs` — mono global tap + private tap-only aggregate; dlsym/ObjC-runtime resolution (single binary keeps loading on macOS < 14.2); permission probe via `kAudioTapPropertyDescription` get+set; IOProc → channel → `LoopbackFrameResampler`
- [x] `SystemAudioError::PermissionDenied` (`system_audio_permission_denied`) + macOS-specific `Unsupported` copy; cfg widening in `system_audio/mod.rs` and `resample.rs`
- [x] Protocol: `ProbeSystemAudio` command + `SystemAudioProbeResult` event (async, off the command loop)
- [x] Plugin: settings gate (macOS ≥ 14.2 via `process.getSystemVersion()`), toggle-time probe + Notice, permission copy enrichment for Electron < 39.6.0 installers
- [x] Docs: README, `docs/system-architecture.md`; research doc committed under `docs/specs/`
- [x] Tests: pure-function units, `FakeSystemAudio` PermissionDenied mapping, headless-CI-safe

## Also in this PR

- **#197 follow-up:** only final transcripts are logged; partial streaming revisions no longer flood the delivery diagnostics.
- **CUDA dev tooling:** `scripts/install-dev-cuda.mjs` + CONTRIBUTING / cuda-setup guide updates.

## Review + simplification pass

Fixed during review: teardown use-after-free window (device stopped before the IOProc context is freed), leaked tap-description copy in the permission probe, raw-pointer traversal of the variable-length `AudioBufferList`. Simplification pass (4 parallel reviewers): shared version comparator (`src/version.ts`), single cfg boundary in `macos.rs`, generic `load_symbol`, `onChange` hook on `addToggleSetting`, capacity reservation in the IOProc collectors, test cleanups.

Deliberately deferred (follow-up candidates): moving probe dispatch from `main.rs` into an `AppState` poll pattern; SPSC ring buffer instead of `sync_channel` for the IOProc handoff; consolidating the two controller error-message call sites (event path vs. rejected start promise).

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets`, `cargo test` (Linux host, macOS backend cfg'd out): clean, 244+ tests pass.
- `macos.rs` type-checked for `aarch64-apple-darwin` in an isolated harness (full-crate cross-check impossible on Linux — `ring`/`whisper.cpp` need a macOS toolchain); real compile gate is the release CI's macOS build.
- Plugin: `tsc --noEmit`, Biome, `eslint src` (obsidianmd), `vitest run` — 626 tests pass.

## Not verifiable in this PR without hardware

Manual QA checklist from the spec (TCC prompt attribution, grant-without-restart, device-switch mid-session, `plutil` check of `NSAudioCaptureUsageDescription`) — release-gated, needs a real Mac on ≥ 14.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
