### PR TITLE
Fix macOS aggregate-device creation ('nope') and probe-failure toggle revert

### DIFF
--- a/native/src/system_audio/macos.rs
+++ b/native/src/system_audio/macos.rs
@@ -56,6 +56,8 @@ struct MacLoopbackFormat {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AggregateDeviceDescription {
+    name: &'static str,
+    uid: String,
     is_private: bool,
     tap_auto_start: bool,
     tap_uid: String,
@@ -98,8 +100,13 @@ fn parse_tap_format(
     })
 }
 
-fn aggregate_device_description(tap_uid: String) -> AggregateDeviceDescription {
+// AudioHardwareCreateAggregateDevice requires kAudioAggregateDeviceNameKey and
+// kAudioAggregateDeviceUIDKey at minimum; omitting them fails with 'nope'
+// (kAudioHardwareIllegalOperationError).
+fn aggregate_device_description(uid: String, tap_uid: String) -> AggregateDeviceDescription {
     AggregateDeviceDescription {
+        name: "Local Dictation System Audio",
+        uid,
         is_private: true,
         tap_auto_start: false,
         tap_uid,
@@ -181,6 +188,8 @@ mod platform {
     const K_AUDIO_OBJECT_UNKNOWN: AudioObjectID = 0;
     const K_AUDIO_TAP_PROPERTY_DESCRIPTION: super::AudioObjectPropertySelector = 0x7464_7363;
 
+    const K_AUDIO_AGGREGATE_DEVICE_NAME_KEY: &str = "name";
+    const K_AUDIO_AGGREGATE_DEVICE_UID_KEY: &str = "uid";
     const K_AUDIO_AGGREGATE_DEVICE_IS_PRIVATE_KEY: &str = "private";
     const K_AUDIO_AGGREGATE_DEVICE_TAP_LIST_KEY: &str = "taps";
     const K_AUDIO_AGGREGATE_DEVICE_TAP_AUTO_START_KEY: &str = "tapautostart";
@@ -417,7 +426,8 @@ mod platform {
                 SystemAudioError::Capture("CoreAudio returned an unknown process-tap id".into())
             } else {
                 SystemAudioError::Capture(format!(
-                    "AudioHardwareCreateProcessTap failed with CoreAudio status {status}"
+                    "AudioHardwareCreateProcessTap failed with CoreAudio status {}",
+                    format_os_status(status)
                 ))
             };
             let _ = init_tx.send(Err(error));
@@ -445,7 +455,8 @@ mod platform {
                 )
             } else {
                 SystemAudioError::Capture(format!(
-                    "AudioHardwareCreateAggregateDevice failed with CoreAudio status {status}"
+                    "AudioHardwareCreateAggregateDevice failed with CoreAudio status {}",
+                    format_os_status(status)
                 ))
             };
             let _ = init_tx.send(Err(error));
@@ -477,7 +488,8 @@ mod platform {
         };
         if status != 0 {
             let _ = init_tx.send(Err(SystemAudioError::Capture(format!(
-                "AudioDeviceCreateIOProcID failed with CoreAudio status {status}"
+                "AudioDeviceCreateIOProcID failed with CoreAudio status {}",
+                format_os_status(status)
             ))));
             return Ok(());
         }
@@ -486,7 +498,8 @@ mod platform {
         let status = unsafe { AudioDeviceStart(aggregate_device, io_proc_id) };
         if status != 0 {
             let _ = init_tx.send(Err(SystemAudioError::Capture(format!(
-                "AudioDeviceStart failed with CoreAudio status {status}"
+                "AudioDeviceStart failed with CoreAudio status {}",
+                format_os_status(status)
             ))));
             return Ok(());
         }
@@ -609,7 +622,7 @@ mod platform {
     fn create_aggregate_description(
         tap_uid: String,
     ) -> Retained<NSDictionary<NSString, AnyObject>> {
-        let description = aggregate_device_description(tap_uid);
+        let description = aggregate_device_description(uuid::Uuid::new_v4().to_string(), tap_uid);
         let tap_uid = NSString::from_str(&description.tap_uid);
         let drift_compensation = NSNumber::new_bool(description.drift_compensation);
         let tap_entry = NSDictionary::<NSString, AnyObject>::from_slices(
@@ -620,16 +633,20 @@ mod platform {
             &[&*tap_uid, &*drift_compensation],
         );
         let tap_list = NSArray::<NSDictionary<NSString, AnyObject>>::from_slice(&[&*tap_entry]);
+        let name = NSString::from_str(description.name);
+        let uid = NSString::from_str(&description.uid);
         let is_private = NSNumber::new_bool(description.is_private);
         let tap_auto_start = NSNumber::new_bool(description.tap_auto_start);
 
         NSDictionary::<NSString, AnyObject>::from_slices(
             &[
+                &*NSString::from_str(K_AUDIO_AGGREGATE_DEVICE_NAME_KEY),
+                &*NSString::from_str(K_AUDIO_AGGREGATE_DEVICE_UID_KEY),
                 &*NSString::from_str(K_AUDIO_AGGREGATE_DEVICE_IS_PRIVATE_KEY),
                 &*NSString::from_str(K_AUDIO_AGGREGATE_DEVICE_TAP_LIST_KEY),
                 &*NSString::from_str(K_AUDIO_AGGREGATE_DEVICE_TAP_AUTO_START_KEY),
             ],
-            &[&*is_private, &*tap_list, &*tap_auto_start],
+            &[&*name, &*uid, &*is_private, &*tap_list, &*tap_auto_start],
         )
     }
 
@@ -840,11 +857,14 @@ mod tests {
 
     #[test]
     fn aggregate_description_is_private_tap_only_and_does_not_auto_start() {
-        let description = aggregate_device_description("tap-uid".to_string());
+        let description =
+            aggregate_device_description("device-uid".to_string(), "tap-uid".to_string());
 
         assert_eq!(
             description,
             AggregateDeviceDescription {
+                name: "Local Dictation System Audio",
+                uid: "device-uid".to_string(),
                 is_private: true,
                 tap_auto_start: false,
                 tap_uid: "tap-uid".to_string(),

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -185,8 +185,11 @@ export class LocalSttSettingTab extends PluginSettingTab {
         key: 'includeSystemAudio',
         onChange: async (value) => {
           // First-ever probe is the designed moment for the macOS TCC prompt.
-          if (value && Platform.isMacOS) {
-            await this.probeSystemAudio();
+          if (value && Platform.isMacOS && !(await this.probeSystemAudio())) {
+            // Capture cannot work; leaving the toggle on would just fail
+            // every session start with the same error.
+            await this.access.persistOne('includeSystemAudio', false);
+            this.display();
           }
         },
       });
@@ -341,18 +344,20 @@ export class LocalSttSettingTab extends PluginSettingTab {
     this.missingSidecarProgressEl = null;
   }
 
-  private async probeSystemAudio(): Promise<void> {
+  /** Returns whether the probe confirmed capture is usable. */
+  private async probeSystemAudio(): Promise<boolean> {
     try {
       const result = await this.dependencies.sidecarConnection.probeSystemAudio();
       if (result.ok) {
         new Notice('System audio is ready.');
-        return;
+        return true;
       }
 
       new Notice(formatSystemAudioProbeResultMessage(result));
     } catch (error) {
       new Notice(`Could not test system audio: ${formatErrorMessage(error)}`);
     }
+    return false;
   }
 
   private renderTranscriptFormattingSetting(parent: HTMLElement): void {


### PR DESCRIPTION
## What

First round of macOS hardware QA for #159 (merged in #210) found:

1. **`AudioHardwareCreateAggregateDevice` failed with status 1852797029** — the four-char code `'nope'` (`kAudioHardwareIllegalOperationError`). The aggregate description dictionary requires `kAudioAggregateDeviceNameKey` and `kAudioAggregateDeviceUIDKey` at minimum (per the AudioHardware.h contract; Chromium's tap-only aggregate carries both). Ours had neither. Added a fixed name and a per-capture UUID.
2. **UX**: when the settings-time probe fails, the "Include system audio" toggle now flips back off instead of persisting a setting that fails every session start.
3. CoreAudio create/start failures now format the status through `format_os_status`, so the message reads `'nope' (1852797029)` instead of a bare decimal.

QA also confirmed working as designed: Electron < 39.6.0 reinstall hint (fired on installer 1.11.7, gone after reinstall), TCC prompt attribution to Obsidian, permission probe.

## Verification

- cargo fmt/clippy/test clean; `macos.rs` type-checked for `aarch64-apple-darwin` in the isolated harness.
- tsc, Biome, vitest: 626 tests pass.
- Needs re-test on the Mac: aggregate creation → live capture → transcription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)