### PR TITLE
Fix Windows CUDA release cache scope

### DIFF
--- a/.github/actions/build-windows-cuda-release/action.yml
+++ b/.github/actions/build-windows-cuda-release/action.yml
@@ -1,0 +1,74 @@
+name: Build Windows CUDA release sidecar
+description: Build the production Windows CUDA sidecar and populate its trusted caches.
+
+inputs:
+  node-version:
+    description: Node.js version resolved from .mise.toml.
+    required: true
+  rust-toolchain:
+    description: Rust version resolved from rust-toolchain.toml.
+    required: true
+  ggml-native:
+    description: Portable GGML native-build setting.
+    required: true
+  ort-cuda-version:
+    description: ONNX Runtime CUDA execution-provider major.
+    required: true
+  cuda-toolkit-version:
+    description: CUDA toolkit version used by release builds.
+    required: true
+  cuda-architectures:
+    description: CMake CUDA architecture target used by release builds.
+    required: true
+  windows-cuda-subpackages-manifest:
+    description: Repository-relative Windows CUDA subpackage manifest.
+    required: true
+
+outputs:
+  cuda-toolkit-cache-hit:
+    description: Whether the exact extracted-toolkit cache was restored.
+    value: ${{ steps.cuda.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    # Keep the cache-invalidating environment beside the authoritative build.
+    # setup-sidecar-rust hashes these prefixes before restoring target-cuda.
+    - name: Configure Windows CUDA release build
+      shell: pwsh
+      env:
+        CMAKE_CUDA_ARCHITECTURES_INPUT: ${{ inputs.cuda-architectures }}
+        GGML_NATIVE_INPUT: ${{ inputs.ggml-native }}
+        ORT_CUDA_VERSION_INPUT: ${{ inputs.ort-cuda-version }}
+      run: |
+        "GGML_NATIVE=$env:GGML_NATIVE_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Append
+        "ORT_CUDA_VERSION=$env:ORT_CUDA_VERSION_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Append
+        "CMAKE_CUDA_ARCHITECTURES=$env:CMAKE_CUDA_ARCHITECTURES_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+    - name: Setup Node.js + npm
+      uses: ./.github/actions/setup-node-npm
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    # Run toolkit setup before rust-cache so CUDA_TOOLKIT_VERSION participates
+    # in the Rust cache key on both a cache hit and a fresh install.
+    - id: cuda
+      name: Setup Windows CUDA toolkit
+      uses: ./.github/actions/setup-windows-cuda
+      with:
+        toolkit-version: ${{ inputs.cuda-toolkit-version }}
+        subpackages-manifest: ${{ inputs.windows-cuda-subpackages-manifest }}
+
+    - name: Setup Rust
+      uses: ./.github/actions/setup-sidecar-rust
+      with:
+        toolchain: ${{ inputs.rust-toolchain }}
+        cache-workspaces: native -> target-cuda
+        cache-shared-key: sidecar-windows-x86_64-cuda
+        cache-on-failure: 'false'
+
+    - name: Build Windows CUDA release sidecar
+      shell: pwsh
+      env:
+        CARGO_TIMINGS: '1'
+      run: npm run build:sidecar:cuda:windows:release

--- a/.github/actions/build-windows-cuda-release/action.yml
+++ b/.github/actions/build-windows-cuda-release/action.yml
@@ -23,6 +23,9 @@ inputs:
   windows-cuda-subpackages-manifest:
     description: Repository-relative Windows CUDA subpackage manifest.
     required: true
+  windows-cuda-rust-cache-env-vars:
+    description: Extra rust-cache environment prefixes preserving the production key.
+    required: true
 
 outputs:
   cuda-toolkit-cache-hit:
@@ -40,10 +43,12 @@ runs:
         CMAKE_CUDA_ARCHITECTURES_INPUT: ${{ inputs.cuda-architectures }}
         GGML_NATIVE_INPUT: ${{ inputs.ggml-native }}
         ORT_CUDA_VERSION_INPUT: ${{ inputs.ort-cuda-version }}
+        RUST_TOOLCHAIN_INPUT: ${{ inputs.rust-toolchain }}
       run: |
         "GGML_NATIVE=$env:GGML_NATIVE_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Append
         "ORT_CUDA_VERSION=$env:ORT_CUDA_VERSION_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Append
         "CMAKE_CUDA_ARCHITECTURES=$env:CMAKE_CUDA_ARCHITECTURES_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Append
+        "RUST_TOOLCHAIN=$env:RUST_TOOLCHAIN_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Append
 
     - name: Setup Node.js + npm
       uses: ./.github/actions/setup-node-npm
@@ -65,6 +70,10 @@ runs:
         toolchain: ${{ inputs.rust-toolchain }}
         cache-workspaces: native -> target-cuda
         cache-shared-key: sidecar-windows-x86_64-cuda
+        # rust-cache always includes CARGO/CC/CFLAGS/CXX/CMAKE/RUST. This
+        # explicit extra set includes the stable release inputs but deliberately
+        # excludes broad CUDA, which would hash derived CUDA_PATH variables.
+        cache-env-vars: ${{ inputs.windows-cuda-rust-cache-env-vars }}
         cache-on-failure: 'false'
 
     - name: Build Windows CUDA release sidecar
@@ -72,3 +81,12 @@ runs:
       env:
         CARGO_TIMINGS: '1'
       run: npm run build:sidecar:cuda:windows:release
+
+    # Save explicitly after the production build succeeds. The combined cache
+    # action's nested post step loses its path input inside a composite action.
+    - name: Save CUDA toolkit
+      if: success() && steps.cuda.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v6
+      with:
+        path: ${{ steps.cuda.outputs.install-dir }}
+        key: ${{ steps.cuda.outputs.cache-primary-key }}

--- a/.github/actions/resolve-release-build-config/action.yml
+++ b/.github/actions/resolve-release-build-config/action.yml
@@ -23,6 +23,9 @@ outputs:
   windows-cuda-subpackages-manifest:
     description: Repository-relative Windows CUDA subpackage manifest.
     value: ${{ steps.config.outputs.windows-cuda-subpackages-manifest }}
+  windows-cuda-rust-cache-env-vars:
+    description: Extra rust-cache environment prefixes for Windows CUDA compatibility.
+    value: ${{ steps.config.outputs.windows-cuda-rust-cache-env-vars }}
 
 runs:
   using: composite

--- a/.github/actions/resolve-release-build-config/action.yml
+++ b/.github/actions/resolve-release-build-config/action.yml
@@ -1,0 +1,33 @@
+name: Resolve release build configuration
+description: Read authoritative release and toolchain settings for downstream jobs.
+
+outputs:
+  node-version:
+    description: Node.js version pinned by .mise.toml.
+    value: ${{ steps.config.outputs.node-version }}
+  rust-toolchain:
+    description: Rust version pinned by rust-toolchain.toml.
+    value: ${{ steps.config.outputs.rust-toolchain }}
+  ggml-native:
+    description: Portable GGML native-build setting.
+    value: ${{ steps.config.outputs.ggml-native }}
+  ort-cuda-version:
+    description: ONNX Runtime CUDA execution-provider major.
+    value: ${{ steps.config.outputs.ort-cuda-version }}
+  cuda-toolkit-version:
+    description: CUDA toolkit version used by release builds.
+    value: ${{ steps.config.outputs.cuda-toolkit-version }}
+  cuda-architectures:
+    description: CMake CUDA architecture target used by release builds.
+    value: ${{ steps.config.outputs.cuda-architectures }}
+  windows-cuda-subpackages-manifest:
+    description: Repository-relative Windows CUDA subpackage manifest.
+    value: ${{ steps.config.outputs.windows-cuda-subpackages-manifest }}
+
+runs:
+  using: composite
+  steps:
+    - id: config
+      name: Resolve release build configuration
+      shell: bash
+      run: node scripts/read-release-build-config.mjs --github-output

--- a/.github/actions/setup-sidecar-rust/action.yml
+++ b/.github/actions/setup-sidecar-rust/action.yml
@@ -22,7 +22,7 @@ inputs:
     # calling release path. The version passed to Jimver/cuda-toolkit is not
     # otherwise visible to rust-cache, so a toolkit bump would restore stale
     # NVCC objects from target-cuda.
-    default: 'CARGO CC CFLAGS CXX CMAKE RUST GGML WHISPER ORT CUDA'
+    default: 'GGML WHISPER ORT CUDA_TOOLKIT_VERSION'
   cache-on-failure:
     description: Value passed to Swatinem/rust-cache 'cache-on-failure' input.
     required: false

--- a/.github/actions/setup-sidecar-rust/action.yml
+++ b/.github/actions/setup-sidecar-rust/action.yml
@@ -18,10 +18,10 @@ inputs:
   cache-env-vars:
     description: Value passed to Swatinem/rust-cache 'env-vars' input. Default extends defaults with GGML, WHISPER, ORT, and CUDA so build-affecting flips (CPU SIMD, whisper flags, ONNX Runtime CUDA major, CUDA toolkit version) bust the cache.
     required: false
-    # CUDA covers CUDA_TOOLKIT_VERSION, set as a workflow-level env var. The CUDA
-    # toolkit version otherwise lives only in the Jimver/cuda-toolkit `uses` input
-    # and is invisible to the rust-cache key, so a toolkit bump would silently
-    # restore stale NVCC objects from target-cuda. Hashing it forks the key.
+    # CUDA covers CUDA_TOOLKIT_VERSION, exported before this action by the
+    # calling release path. The version passed to Jimver/cuda-toolkit is not
+    # otherwise visible to rust-cache, so a toolkit bump would restore stale
+    # NVCC objects from target-cuda.
     default: 'CARGO CC CFLAGS CXX CMAKE RUST GGML WHISPER ORT CUDA'
   cache-on-failure:
     description: Value passed to Swatinem/rust-cache 'cache-on-failure' input.

--- a/.github/actions/setup-windows-cuda/action.yml
+++ b/.github/actions/setup-windows-cuda/action.yml
@@ -13,6 +13,12 @@ outputs:
   cache-hit:
     description: Whether the exact extracted-toolkit cache was restored.
     value: ${{ steps.cuda-cache.outputs.cache-hit }}
+  cache-primary-key:
+    description: Exact toolkit cache key attempted by the restore.
+    value: ${{ steps.cuda-cache.outputs.cache-primary-key }}
+  install-dir:
+    description: Windows CUDA toolkit directory restored or installed.
+    value: ${{ steps.config.outputs.install-dir }}
 
 runs:
   using: composite
@@ -33,30 +39,25 @@ runs:
 
         $manifest = Resolve-Path -LiteralPath $env:CUDA_SUBPACKAGES_MANIFEST
         $packages = @(Get-Content -Raw $manifest | ConvertFrom-Json)
-        if ($packages.Count -eq 0) {
-          throw "$manifest must contain at least one CUDA sub-package."
+        if ($packages.Count -eq 0 -or $packages.Where({ $_ -isnot [string] -or $_.Length -eq 0 }).Count -gt 0) {
+          throw "$manifest must contain at least one non-empty CUDA sub-package string."
         }
 
         $version = $env:CUDA_TOOLKIT_VERSION_INPUT.Split('.')
         $installDir = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$($version[0]).$($version[1])"
-        $manifestHash = (Get-FileHash -Algorithm SHA256 $manifest).Hash.ToLowerInvariant()
         $subpackages = ConvertTo-Json -Compress -InputObject $packages
 
         "install-dir=$installDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-        "manifest-hash=$manifestHash" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         "subpackages=$subpackages" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-        "CUDA_INSTALL_DIR=$installDir" | Out-File -FilePath $env:GITHUB_ENV -Append
-        "CUDA_TOOLKIT_VERSION=$env:CUDA_TOOLKIT_VERSION_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Append
 
-    # The combined cache action restores now and saves in its post step only
-    # when the complete job succeeds. A failed install or CUDA build therefore
-    # cannot publish an incomplete immutable cache entry.
     - id: cuda-cache
       name: Restore CUDA toolkit
-      uses: actions/cache@v6
+      uses: actions/cache/restore@v6
       with:
         path: ${{ steps.config.outputs.install-dir }}
-        key: cuda-${{ runner.os }}-${{ inputs.toolkit-version }}-${{ steps.config.outputs.manifest-hash }}
+        # Use GitHub's native hashFiles implementation to preserve the exact
+        # cache identity originally seeded on main. See #189.
+        key: cuda-${{ runner.os }}-${{ inputs.toolkit-version }}-${{ hashFiles(inputs.subpackages-manifest) }}
 
     - name: Install CUDA toolkit
       if: steps.cuda-cache.outputs.cache-hit != 'true'
@@ -81,6 +82,8 @@ runs:
         $version = $env:CUDA_TOOLKIT_VERSION_INPUT.Split('.')
         $versionedName = "CUDA_PATH_V$($version[0])_$($version[1])"
 
+        "CUDA_INSTALL_DIR=$env:CUDA_INSTALL_DIR_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Append
+        "CUDA_TOOLKIT_VERSION=$env:CUDA_TOOLKIT_VERSION_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Append
         "CUDA_PATH=$env:CUDA_INSTALL_DIR_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Append
         "$versionedName=$env:CUDA_INSTALL_DIR_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Append
         "CUDA_PATH_VX_Y=$versionedName" | Out-File -FilePath $env:GITHUB_ENV -Append

--- a/.github/actions/setup-windows-cuda/action.yml
+++ b/.github/actions/setup-windows-cuda/action.yml
@@ -1,0 +1,92 @@
+name: Setup Windows CUDA toolkit
+description: Restore or install the pinned Windows CUDA toolkit and export its build environment.
+
+inputs:
+  toolkit-version:
+    description: CUDA toolkit version installed by Jimver/cuda-toolkit.
+    required: true
+  subpackages-manifest:
+    description: Repository-relative JSON array of CUDA installer sub-packages.
+    required: true
+
+outputs:
+  cache-hit:
+    description: Whether the exact extracted-toolkit cache was restored.
+    value: ${{ steps.cuda-cache.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - id: config
+      name: Resolve Windows CUDA configuration
+      shell: pwsh
+      env:
+        CUDA_SUBPACKAGES_MANIFEST: ${{ inputs.subpackages-manifest }}
+        CUDA_TOOLKIT_VERSION_INPUT: ${{ inputs.toolkit-version }}
+      run: |
+        if ($env:RUNNER_OS -ne 'Windows') {
+          throw 'setup-windows-cuda only supports Windows runners.'
+        }
+        if ($env:CUDA_TOOLKIT_VERSION_INPUT -notmatch '^\d+\.\d+\.\d+$') {
+          throw "CUDA toolkit version must use major.minor.patch: $env:CUDA_TOOLKIT_VERSION_INPUT"
+        }
+
+        $manifest = Resolve-Path -LiteralPath $env:CUDA_SUBPACKAGES_MANIFEST
+        $packages = @(Get-Content -Raw $manifest | ConvertFrom-Json)
+        if ($packages.Count -eq 0) {
+          throw "$manifest must contain at least one CUDA sub-package."
+        }
+
+        $version = $env:CUDA_TOOLKIT_VERSION_INPUT.Split('.')
+        $installDir = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$($version[0]).$($version[1])"
+        $manifestHash = (Get-FileHash -Algorithm SHA256 $manifest).Hash.ToLowerInvariant()
+        $subpackages = ConvertTo-Json -Compress -InputObject $packages
+
+        "install-dir=$installDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        "manifest-hash=$manifestHash" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        "subpackages=$subpackages" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        "CUDA_INSTALL_DIR=$installDir" | Out-File -FilePath $env:GITHUB_ENV -Append
+        "CUDA_TOOLKIT_VERSION=$env:CUDA_TOOLKIT_VERSION_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+    # The combined cache action restores now and saves in its post step only
+    # when the complete job succeeds. A failed install or CUDA build therefore
+    # cannot publish an incomplete immutable cache entry.
+    - id: cuda-cache
+      name: Restore CUDA toolkit
+      uses: actions/cache@v6
+      with:
+        path: ${{ steps.config.outputs.install-dir }}
+        key: cuda-${{ runner.os }}-${{ inputs.toolkit-version }}-${{ steps.config.outputs.manifest-hash }}
+
+    - name: Install CUDA toolkit
+      if: steps.cuda-cache.outputs.cache-hit != 'true'
+      uses: Jimver/cuda-toolkit@v0.2.35
+      with:
+        cuda: ${{ inputs.toolkit-version }}
+        method: network
+        # CUDA 13 split the Windows toolkit into granular packages. This set
+        # includes the compiler, headers, device compiler, C++ templates,
+        # link-time libraries, and runtime DLLs shipped in the release archive.
+        sub-packages: ${{ steps.config.outputs.subpackages }}
+
+    # Jimver exports the same variables after an install. Export them on both
+    # paths so a restored toolkit and a fresh install have one environment
+    # contract, independent of third-party action internals.
+    - name: Export CUDA environment
+      shell: pwsh
+      env:
+        CUDA_INSTALL_DIR_INPUT: ${{ steps.config.outputs.install-dir }}
+        CUDA_TOOLKIT_VERSION_INPUT: ${{ inputs.toolkit-version }}
+      run: |
+        $version = $env:CUDA_TOOLKIT_VERSION_INPUT.Split('.')
+        $versionedName = "CUDA_PATH_V$($version[0])_$($version[1])"
+
+        "CUDA_PATH=$env:CUDA_INSTALL_DIR_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Append
+        "$versionedName=$env:CUDA_INSTALL_DIR_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Append
+        "CUDA_PATH_VX_Y=$versionedName" | Out-File -FilePath $env:GITHUB_ENV -Append
+        "$env:CUDA_INSTALL_DIR_INPUT\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+
+        $nvcc = Join-Path $env:CUDA_INSTALL_DIR_INPUT 'bin\nvcc.exe'
+        if (-not (Test-Path -LiteralPath $nvcc)) {
+          throw "CUDA setup completed without nvcc at $nvcc"
+        }

--- a/.github/release-build-config.json
+++ b/.github/release-build-config.json
@@ -3,5 +3,6 @@
   "ortCudaVersion": "13",
   "cudaToolkitVersion": "13.2.0",
   "cudaArchitectures": "75-virtual",
-  "windowsCudaSubpackagesManifest": ".github/cuda-windows-subpackages.json"
+  "windowsCudaSubpackagesManifest": ".github/cuda-windows-subpackages.json",
+  "windowsCudaRustCacheEnvVars": "RUST_TOOLCHAIN GGML WHISPER ORT CUDA_TOOLKIT_VERSION"
 }

--- a/.github/release-build-config.json
+++ b/.github/release-build-config.json
@@ -1,0 +1,7 @@
+{
+  "ggmlNative": "OFF",
+  "ortCudaVersion": "13",
+  "cudaToolkitVersion": "13.2.0",
+  "cudaArchitectures": "75-virtual",
+  "windowsCudaSubpackagesManifest": ".github/cuda-windows-subpackages.json"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,48 +17,32 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  # GGML_NATIVE=OFF forces a portable CPU feature baseline (falls back to
-  # GGML_AVX2). Without this, ggml's cmake probes the runner's CPU and bakes
-  # in whatever SIMD it supports (AVX-512 on current Azure ubuntu-latest /
-  # windows-latest runners), which crashes with STATUS_ILLEGAL_INSTRUCTION on
-  # consumer CPUs that don't execute AVX-512 (e.g. Alder Lake / Raptor Lake).
-  # Inherited by every job env so Swatinem/rust-cache (which runs before the
-  # Build sidecar step) sees it when computing its key, otherwise stale
-  # AVX-512-compiled artifacts get restored and silently re-shipped.
-  GGML_NATIVE: 'OFF'
-  # Pin the ONNX Runtime CUDA execution-provider major (cu13). Set here at the
-  # workflow env level — not only in build-cuda.{sh,ps1} — for the same reason
-  # as GGML_NATIVE: Swatinem/rust-cache computes its key before the build step,
-  # so the value must be visible at cache time (via the ORT env-vars prefix in
-  # setup-sidecar-rust) for an ORT CUDA-major flip to bust the cache instead of
-  # silently restoring a stale cu12 provider. The build scripts keep a :-13
-  # fallback so local builds stay deterministic too.
-  ORT_CUDA_VERSION: '13'
-  # Single source of truth for the CUDA toolkit: drives the Jimver/cuda-toolkit
-  # install AND is hashed into the rust-cache key (the 'CUDA' env-vars prefix in
-  # setup-sidecar-rust). Set at workflow env so it's visible when rust-cache
-  # computes its key — before the toolkit is installed — so a toolkit bump forks
-  # target-cuda instead of silently restoring stale NVCC objects. See #143.
-  CUDA_TOOLKIT_VERSION: '13.2.0'
-  NODE_VERSION: 24.14.1
-  RUST_TOOLCHAIN: 1.94.1
-
 jobs:
   metadata:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.value }}
       notes_path: ${{ steps.notes.outputs.path }}
+      node_version: ${{ steps.build-config.outputs.node-version }}
+      rust_toolchain: ${{ steps.build-config.outputs.rust-toolchain }}
+      ggml_native: ${{ steps.build-config.outputs.ggml-native }}
+      ort_cuda_version: ${{ steps.build-config.outputs.ort-cuda-version }}
+      cuda_toolkit_version: ${{ steps.build-config.outputs.cuda-toolkit-version }}
+      cuda_architectures: ${{ steps.build-config.outputs.cuda-architectures }}
+      windows_cuda_subpackages_manifest: ${{ steps.build-config.outputs.windows-cuda-subpackages-manifest }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - id: build-config
+        name: Resolve release build configuration
+        uses: ./.github/actions/resolve-release-build-config
+
       - name: Setup Node.js + npm
         uses: ./.github/actions/setup-node-npm
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ steps.build-config.outputs.node-version }}
 
       - id: version
         name: Resolve release version
@@ -87,7 +71,7 @@ jobs:
       - name: Setup Node.js + npm
         uses: ./.github/actions/setup-node-npm
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ needs.metadata.outputs.node_version }}
           cache: 'true'
           upgrade-npm: 'true'
 
@@ -118,6 +102,11 @@ jobs:
   native-quality:
     needs: metadata
     runs-on: ubuntu-latest
+    env:
+      # These values must exist before rust-cache computes its environment key.
+      GGML_NATIVE: ${{ needs.metadata.outputs.ggml_native }}
+      ORT_CUDA_VERSION: ${{ needs.metadata.outputs.ort_cuda_version }}
+      CUDA_TOOLKIT_VERSION: ${{ needs.metadata.outputs.cuda_toolkit_version }}
 
     steps:
       - name: Checkout
@@ -126,14 +115,14 @@ jobs:
       - name: Setup Node.js + npm
         uses: ./.github/actions/setup-node-npm
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ needs.metadata.outputs.node_version }}
           cache: 'true'
           upgrade-npm: 'true'
 
       - name: Setup Rust
         uses: ./.github/actions/setup-sidecar-rust
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          toolchain: ${{ needs.metadata.outputs.rust_toolchain }}
           components: rustfmt, clippy
           cache-workspaces: native -> target
           cache-shared-key: native-quality
@@ -158,11 +147,12 @@ jobs:
       id-token: write
       attestations: write
     env:
-      # ggml's CUDA default builds PTX/SASS for many architecture variants,
-      # which dominates release CUDA jobs (especially on Windows). Ship one
-      # forward-compatible Turing PTX target instead. That requires a Turing-or-
-      # newer NVIDIA GPU for CUDA acceleration; older GPUs use the CPU sidecar.
-      CMAKE_CUDA_ARCHITECTURES: ${{ matrix.cuda_architectures }}
+      # These values must exist before rust-cache computes its environment key.
+      GGML_NATIVE: ${{ needs.metadata.outputs.ggml_native }}
+      ORT_CUDA_VERSION: ${{ needs.metadata.outputs.ort_cuda_version }}
+      CUDA_TOOLKIT_VERSION: ${{ needs.metadata.outputs.cuda_toolkit_version }}
+      # Only the CUDA matrix leg consumes this shared release target.
+      CMAKE_CUDA_ARCHITECTURES: ${{ matrix.cuda && needs.metadata.outputs.cuda_architectures || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -174,7 +164,6 @@ jobs:
             build_command: npm run build:sidecar:release
             cache_workspaces: native -> target
             cuda: false
-            cuda_architectures: ''
           - runner: ubuntu-latest
             asset_name: sidecar-linux-x86_64-cpu
             archive_name: sidecar-linux-x86_64-cpu.tar.gz
@@ -182,7 +171,6 @@ jobs:
             build_command: npm run build:sidecar:release
             cache_workspaces: native -> target
             cuda: false
-            cuda_architectures: ''
           - runner: ubuntu-latest
             asset_name: sidecar-linux-x86_64-cuda
             archive_name: sidecar-linux-x86_64-cuda.tar.gz
@@ -190,7 +178,6 @@ jobs:
             build_command: npm run build:sidecar:cuda:release
             cache_workspaces: native -> target-cuda
             cuda: true
-            cuda_architectures: '75-virtual'
 
     runs-on: ${{ matrix.runner }}
 
@@ -201,12 +188,12 @@ jobs:
       - name: Setup Node.js + npm
         uses: ./.github/actions/setup-node-npm
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ needs.metadata.outputs.node_version }}
 
       - name: Setup Rust
         uses: ./.github/actions/setup-sidecar-rust
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          toolchain: ${{ needs.metadata.outputs.rust_toolchain }}
           cache-workspaces: ${{ matrix.cache_workspaces }}
           cache-shared-key: ${{ matrix.asset_name }}
           # Never save a cache from a failed build. A failed CUDA configure would
@@ -219,7 +206,7 @@ jobs:
         if: matrix.cuda
         uses: Jimver/cuda-toolkit@v0.2.35
         with:
-          cuda: ${{ env.CUDA_TOOLKIT_VERSION }}
+          cuda: ${{ needs.metadata.outputs.cuda_toolkit_version }}
           method: network
 
       - name: Build sidecar
@@ -271,8 +258,6 @@ jobs:
       contents: read
       id-token: write
       attestations: write
-    env:
-      CMAKE_CUDA_ARCHITECTURES: ${{ matrix.cuda_architectures }}
     strategy:
       fail-fast: false
       matrix:
@@ -283,18 +268,14 @@ jobs:
             build_command: npm run build:sidecar:release
             cache_workspaces: native -> target
             cuda: false
-            cuda_architectures: ''
           - asset_name: sidecar-windows-x86_64-cuda
             archive_name: sidecar-windows-x86_64-cuda.tar.gz
             binary_path: native/target-cuda/release/local-dictation-sidecar.exe
-            build_command: npm run build:sidecar:cuda:windows:release
-            cache_workspaces: native -> target-cuda
             cuda: true
-            cuda_architectures: '75-virtual'
 
     # windows-2025 is the Windows Server 2025 image, which now ships Visual
-    # Studio 2026 (v18) by default. CUDA 13.2 is the first toolkit to support
-    # MSVC v18 as a host compiler, so the VS CUDA generator works here. We pin
+    # Studio 2026 (v18) by default. The pinned toolkit supports MSVC v18 as a
+    # host compiler, so the VS CUDA generator works here. We pin
     # this OS label rather than windows-latest for determinism (it won't roll to
     # a future Server major), and deliberately avoid the windows-2025-vs2026
     # alias — that one is testing-only and collapses into windows-2025 after the
@@ -308,15 +289,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Configure Windows CPU release build
+        if: '!matrix.cuda'
+        shell: pwsh
+        env:
+          CUDA_TOOLKIT_VERSION_INPUT: ${{ needs.metadata.outputs.cuda_toolkit_version }}
+          GGML_NATIVE_INPUT: ${{ needs.metadata.outputs.ggml_native }}
+          ORT_CUDA_VERSION_INPUT: ${{ needs.metadata.outputs.ort_cuda_version }}
+        run: |
+          "GGML_NATIVE=$env:GGML_NATIVE_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "ORT_CUDA_VERSION=$env:ORT_CUDA_VERSION_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "CUDA_TOOLKIT_VERSION=$env:CUDA_TOOLKIT_VERSION_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       - name: Setup Node.js + npm
+        if: '!matrix.cuda'
         uses: ./.github/actions/setup-node-npm
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ needs.metadata.outputs.node_version }}
 
       - name: Setup Rust
+        if: '!matrix.cuda'
         uses: ./.github/actions/setup-sidecar-rust
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          toolchain: ${{ needs.metadata.outputs.rust_toolchain }}
           cache-workspaces: ${{ matrix.cache_workspaces }}
           cache-shared-key: ${{ matrix.asset_name }}
           # Never save a cache from a failed build. A failed CUDA configure would
@@ -325,92 +320,24 @@ jobs:
           # warm-build path (the Windows-CUDA regression in #143).
           cache-on-failure: 'false'
 
-      # Resolve the toolkit install dir from CUDA_TOOLKIT_VERSION (Jimver installs
-      # to ...\CUDA\v<major>.<minor>). Derived, not hardcoded, so a toolkit bump
-      # moves the cache path in lockstep with the version-keyed cache below.
-      - name: Resolve CUDA install dir
+      - name: Build Windows CUDA release sidecar
         if: matrix.cuda
-        shell: pwsh
-        run: |
-          $v = '${{ env.CUDA_TOOLKIT_VERSION }}'.Split('.')
-          $dir = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$($v[0]).$($v[1])"
-          "CUDA_INSTALL_DIR=$dir" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      # Cache the EXTRACTED toolkit dir and skip the (network-variable, 3-9 min)
-      # Jimver install on a hit. CMake's CUDA language support only needs nvcc on
-      # PATH + CUDA_PATH; it never reads the VS BuildCustomizations .props the
-      # installer drops outside CUDA_PATH, so caching CUDA_PATH alone suffices.
-      # Key busts on toolkit version (env) OR sub-package set (committed JSON). See #143.
-      - name: Restore CUDA toolkit
-        if: matrix.cuda
-        id: cuda-cache
-        uses: actions/cache/restore@v6
+        uses: ./.github/actions/build-windows-cuda-release
         with:
-          path: ${{ env.CUDA_INSTALL_DIR }}
-          key: cuda-${{ runner.os }}-${{ env.CUDA_TOOLKIT_VERSION }}-${{ hashFiles('.github/cuda-windows-subpackages.json') }}
-
-      - name: Read CUDA sub-packages
-        if: matrix.cuda && steps.cuda-cache.outputs.cache-hit != 'true'
-        id: cuda-subpkgs
-        shell: pwsh
-        run: |
-          $json = (Get-Content -Raw .github/cuda-windows-subpackages.json) -replace '\s', ''
-          "list=$json" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-
-      - name: Install CUDA toolkit
-        if: matrix.cuda && steps.cuda-cache.outputs.cache-hit != 'true'
-        uses: Jimver/cuda-toolkit@v0.2.35
-        with:
-          cuda: ${{ env.CUDA_TOOLKIT_VERSION }}
-          method: network
-          # CUDA 13 split the monolithic CUDA 12.x toolkit into granular Windows
-          # installer components, so the compiler toolchain now needs pieces that
-          # nvcc/cudart bundled implicitly under 12.9:
-          #   crt    -> include/crt/host_config.h (pulled in by cuda_runtime.h)
-          #   nvvm   -> the cicc device compiler + libdevice (nvvm/bin, nvvm/libdevice)
-          #   thrust -> include/cccl (Thrust/CUB) used by ggml-cuda kernels
-          # Without them CMake's CUDA compiler probe fails (C1083 on host_config.h,
-          # then "cannot find the path" for nvvm/bin). cufft is NOT a build/link
-          # dependency (ggml/whisper never link it) but it ships cufft64_*.dll,
-          # which onnxruntime_providers_cuda.dll loads at runtime; we redistribute
-          # that DLL (native/cuda-artifacts.json), so its runtime package must be
-          # installed here for the packager to copy — dropping it breaks the
-          # release archive (Linux gets cufft free via its full-toolkit install).
-          # cublas_dev stays (ships cublas.lib / cublasLt.lib — the MSVC import
-          # libs the final link needs; LNK1181 without it, since the runtime cublas
-          # package ships only the DLLs). The set lives in
-          # .github/cuda-windows-subpackages.json so it also feeds the cache key.
-          # See #139, #143.
-          sub-packages: ${{ steps.cuda-subpkgs.outputs.list }}
-
-      # On a hit we skip Jimver, so replicate the env vars + PATH entry it would
-      # have exported (verified against Jimver/cuda-toolkit src/update-path.ts).
-      - name: Set CUDA env from cache
-        if: matrix.cuda && steps.cuda-cache.outputs.cache-hit == 'true'
-        shell: pwsh
-        run: |
-          $v = '${{ env.CUDA_TOOLKIT_VERSION }}'.Split('.')
-          $name = "CUDA_PATH_V$($v[0])_$($v[1])"
-          "CUDA_PATH=$env:CUDA_INSTALL_DIR" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "$name=$env:CUDA_INSTALL_DIR" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "CUDA_PATH_VX_Y=$name" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "$env:CUDA_INSTALL_DIR\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+          node-version: ${{ needs.metadata.outputs.node_version }}
+          rust-toolchain: ${{ needs.metadata.outputs.rust_toolchain }}
+          ggml-native: ${{ needs.metadata.outputs.ggml_native }}
+          ort-cuda-version: ${{ needs.metadata.outputs.ort_cuda_version }}
+          cuda-toolkit-version: ${{ needs.metadata.outputs.cuda_toolkit_version }}
+          cuda-architectures: ${{ needs.metadata.outputs.cuda_architectures }}
+          windows-cuda-subpackages-manifest: ${{ needs.metadata.outputs.windows_cuda_subpackages_manifest }}
 
       - name: Build sidecar
+        if: '!matrix.cuda'
         shell: pwsh
         env:
           CARGO_TIMINGS: '1'
         run: ${{ matrix.build_command }}
-
-      # Save only after a green build, and only on a miss. Mirrors the build cache's
-      # cache-on-failure:false — a failed/partial install never poisons the
-      # immutable-keyed toolkit cache.
-      - name: Save CUDA toolkit
-        if: success() && matrix.cuda && steps.cuda-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v6
-        with:
-          path: ${{ env.CUDA_INSTALL_DIR }}
-          key: ${{ steps.cuda-cache.outputs.cache-primary-key }}
 
       - name: Upload cargo timings
         if: always()
@@ -464,7 +391,7 @@ jobs:
       - name: Setup Node.js + npm
         uses: ./.github/actions/setup-node-npm
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ needs.metadata.outputs.node_version }}
 
       - name: Download plugin bundle
         uses: actions/download-artifact@v8
@@ -530,7 +457,7 @@ jobs:
       - name: Setup Node.js + npm
         uses: ./.github/actions/setup-node-npm
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ needs.metadata.outputs.node_version }}
 
       - name: Render release timing report
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       cuda_toolkit_version: ${{ steps.build-config.outputs.cuda-toolkit-version }}
       cuda_architectures: ${{ steps.build-config.outputs.cuda-architectures }}
       windows_cuda_subpackages_manifest: ${{ steps.build-config.outputs.windows-cuda-subpackages-manifest }}
+      windows_cuda_rust_cache_env_vars: ${{ steps.build-config.outputs.windows-cuda-rust-cache-env-vars }}
 
     steps:
       - name: Checkout
@@ -331,6 +332,7 @@ jobs:
           cuda-toolkit-version: ${{ needs.metadata.outputs.cuda_toolkit_version }}
           cuda-architectures: ${{ needs.metadata.outputs.cuda_architectures }}
           windows-cuda-subpackages-manifest: ${{ needs.metadata.outputs.windows_cuda_subpackages_manifest }}
+          windows-cuda-rust-cache-env-vars: ${{ needs.metadata.outputs.windows_cuda_rust_cache_env_vars }}
 
       - name: Build sidecar
         if: '!matrix.cuda'

--- a/.github/workflows/windows-cuda-cache.yml
+++ b/.github/workflows/windows-cuda-cache.yml
@@ -1,0 +1,88 @@
+name: windows-cuda-cache
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      # Release metadata: a version bump should warm the exact commit that will
+      # be tagged, even when its native source is otherwise unchanged.
+      - manifest.json
+      - package.json
+      - versions.json
+      - docs/release/notes/**
+      # Production sidecar inputs compiled into the Windows CUDA binary.
+      - native/Cargo.lock
+      - native/Cargo.toml
+      - native/catalog.json
+      - native/cuda-artifacts.json
+      - native/models/**
+      - native/src/**
+      # Build scripts, toolchain setup, and cache identity.
+      - .mise.toml
+      - rust-toolchain.toml
+      - scripts/build-cuda.ps1
+      - scripts/read-release-build-config.mjs
+      - scripts/list-cuda-artifacts.mjs
+      - scripts/lib/cuda-artifacts.mjs
+      - .github/actions/build-windows-cuda-release/action.yml
+      - .github/actions/resolve-release-build-config/action.yml
+      - .github/actions/setup-node-npm/action.yml
+      - .github/actions/setup-sidecar-rust/action.yml
+      - .github/actions/setup-windows-cuda/action.yml
+      - .github/cuda-windows-subpackages.json
+      - .github/release-build-config.json
+      - .github/workflows/release.yml
+      - .github/workflows/windows-cuda-cache.yml
+
+permissions:
+  contents: read
+
+# The newest relevant main commit supersedes an older warm in progress. Cache
+# actions save only after a green job, so a cancelled build cannot poison cache.
+concurrency:
+  group: windows-cuda-cache-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  warm-windows-cuda:
+    runs-on: windows-2025
+    steps:
+      # workflow_dispatch allows branch selection. Fail clearly rather than
+      # creating a branch-scoped cache that future release tags cannot restore.
+      - name: Require the default branch
+        shell: pwsh
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          $expected = "refs/heads/$env:DEFAULT_BRANCH"
+          if ($env:GITHUB_REF -ne $expected) {
+            throw "Dispatch this workflow from $expected, not $env:GITHUB_REF."
+          }
+
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - id: build-config
+        name: Resolve release build configuration
+        uses: ./.github/actions/resolve-release-build-config
+
+      - name: Build Windows CUDA release sidecar
+        uses: ./.github/actions/build-windows-cuda-release
+        with:
+          node-version: ${{ steps.build-config.outputs.node-version }}
+          rust-toolchain: ${{ steps.build-config.outputs.rust-toolchain }}
+          ggml-native: ${{ steps.build-config.outputs.ggml-native }}
+          ort-cuda-version: ${{ steps.build-config.outputs.ort-cuda-version }}
+          cuda-toolkit-version: ${{ steps.build-config.outputs.cuda-toolkit-version }}
+          cuda-architectures: ${{ steps.build-config.outputs.cuda-architectures }}
+          windows-cuda-subpackages-manifest: ${{ steps.build-config.outputs.windows-cuda-subpackages-manifest }}
+
+      - name: Upload cargo timings
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: timings-sidecar-windows-x86_64-cuda
+          path: native/target-cuda/cargo-timings/*.html
+          if-no-files-found: ignore

--- a/.github/workflows/windows-cuda-cache.yml
+++ b/.github/workflows/windows-cuda-cache.yml
@@ -78,6 +78,7 @@ jobs:
           cuda-toolkit-version: ${{ steps.build-config.outputs.cuda-toolkit-version }}
           cuda-architectures: ${{ steps.build-config.outputs.cuda-architectures }}
           windows-cuda-subpackages-manifest: ${{ steps.build-config.outputs.windows-cuda-subpackages-manifest }}
+          windows-cuda-rust-cache-env-vars: ${{ steps.build-config.outputs.windows-cuda-rust-cache-env-vars }}
 
       - name: Upload cargo timings
         if: always()

--- a/docs/release/cutting-a-release.md
+++ b/docs/release/cutting-a-release.md
@@ -53,8 +53,25 @@ just bit us (a stale `native/Cargo.toml`) is caught here in seconds.
 ```bash
 # 1. Land all the bumps on main via a PR — main is protected, so direct
 #    pushes are rejected by branch-protection rules.
-# 2. Tag main HEAD with the bare version and push:
+# 2. Wait for the Windows CUDA cache warmer at that exact main commit. The
+#    release-metadata bump triggers it automatically; dispatch it on main if a
+#    retry is needed. Do not tag while this run is queued or in progress:
 git fetch origin
+main_sha=$(git rev-parse origin/main)
+gh run list --workflow windows-cuda-cache.yml --commit "$main_sha" --limit 1
+# If no run exists, or the matching run needs a clean retry:
+gh workflow run windows-cuda-cache.yml --ref main
+run_id=$(gh run list --workflow windows-cuda-cache.yml --commit "$main_sha" --limit 1 --json databaseId --jq '.[0].databaseId')
+test -n "$run_id"
+gh run watch "$run_id" --exit-status
+
+# 3. The successful exact-commit run above is the release gate. List the two
+#    default-branch cache families as a diagnostic; broad key prefixes alone do
+#    not prove that a cache matches the commit being tagged.
+gh cache list --ref refs/heads/main --limit 100 --json key,ref,createdAt,lastAccessedAt --jq \
+  '.[] | select(.key | startswith("cuda-Windows-") or contains("sidecar-windows-x86_64-cuda"))'
+
+# 4. Tag main HEAD with the bare version and push:
 node scripts/read-release-version.mjs --tag <version>   # final check against the merged main content
 git tag <version> origin/main
 git push origin <version>                               # fires .github/workflows/release.yml
@@ -87,12 +104,14 @@ CUDA archives also bundle the ONNX Runtime provider libraries and the reviewed
 CUDA runtime libraries declared in `native/cuda-artifacts.json`. The macOS sidecar
 is ad-hoc signed before packaging.
 
-CUDA release builds target one forward-compatible Turing PTX target
-(`CMAKE_CUDA_ARCHITECTURES=75-virtual`), and all release jobs set `GGML_NATIVE=OFF`
-so sidecars don't inherit runner-only CPU SIMD. On licensing: the ONNX Runtime
-provider libraries are MIT and safe to bundle; the bundled CUDA runtime libraries
-ship after CUDA EULA review; cuDNN is NVIDIA-licensed and is **not** bundled, so
-Cohere CUDA users supply it themselves.
+Cross-platform release-build invariants live in
+`.github/release-build-config.json`; the metadata job resolves that file once
+and feeds every native release leg. Its CUDA architecture targets one
+forward-compatible Turing PTX variant, and its `GGML_NATIVE` setting prevents
+sidecars from inheriting runner-only CPU SIMD. On licensing: the ONNX Runtime
+provider libraries are MIT and safe to bundle; the bundled CUDA runtime
+libraries ship after CUDA EULA review; cuDNN is NVIDIA-licensed and is **not**
+bundled, so Cohere CUDA users supply it themselves.
 
 Obsidian's updater only replaces `main.js`/`manifest.json`/`styles.css`, so the
 plugin installs the sidecar itself: it downloads the archive matching
@@ -129,5 +148,9 @@ new one publishes so "Latest" is never broken.
   legs. Always run the pre-flight.
 - **Never pipe `gh run watch` through `tail`/`head`.** A pipeline's exit status
   is the last command's, so a failed run looks like success.
+- **Wait for `windows-cuda-cache` before tagging.** GitHub lets a release tag
+  restore caches created on the default branch, but it cannot restore a cache
+  created by a different release tag. The warmer must finish successfully at
+  the exact `origin/main` commit being tagged.
 - **CUDA build legs are warm-cache fast** (~3 min) but cold runs are ~20+ min;
   don't assume a hang.

--- a/scripts/build-cuda.ps1
+++ b/scripts/build-cuda.ps1
@@ -30,7 +30,7 @@ function Invoke-TimedStep($Name, [scriptblock]$Action) {
   }
 }
 
-foreach ($tool in 'cargo', 'nvcc') {
+foreach ($tool in 'cargo', 'node', 'nvcc') {
   if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
     throw "required tool not found on PATH: $tool"
   }
@@ -39,8 +39,13 @@ foreach ($tool in 'cargo', 'nvcc') {
 $jobs = Read-PositiveInt 'BUILD_JOBS' ([Environment]::ProcessorCount)
 $env:CARGO_BUILD_JOBS = "$jobs"
 $env:CMAKE_BUILD_PARALLEL_LEVEL = "$jobs"
-# Pin the ONNX Runtime CUDA execution-provider major (see build-cuda.sh).
-if (-not $env:ORT_CUDA_VERSION) { $env:ORT_CUDA_VERSION = '13' }
+# Pin the ONNX Runtime CUDA execution-provider major (see build-cuda.sh). The
+# release config is authoritative; callers may override it for compatibility
+# testing.
+if (-not $env:ORT_CUDA_VERSION) {
+  $env:ORT_CUDA_VERSION = & node scripts/read-release-build-config.mjs --field ortCudaVersion
+  if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
 
 # Disable the whisper/ggml ccache probe (no ccache on the runner; the rust-cache
 # target-cuda restore is what makes warm builds fast, not ccache), matching

--- a/scripts/build-cuda.sh
+++ b/scripts/build-cuda.sh
@@ -143,9 +143,14 @@ export WHISPER_CCACHE=OFF
 export GGML_CCACHE=OFF
 export CMAKE_ARGS="${CMAKE_ARGS:+$CMAKE_ARGS }-DWHISPER_CCACHE=OFF -DGGML_CCACHE=OFF"
 # Pin the ONNX Runtime CUDA execution-provider major so local and CI builds
-# resolve the same pyke cu13 binaries instead of auto-detecting from whatever
-# CUDA toolkit happens to be on PATH. ort reads this in ort-sys' build script.
-export ORT_CUDA_VERSION=${ORT_CUDA_VERSION:-13}
+# resolve the same pyke binaries instead of auto-detecting from whatever CUDA
+# toolkit happens to be on PATH. The release config is authoritative; callers
+# may still override it explicitly for local compatibility testing.
+if [[ -z "${ORT_CUDA_VERSION:-}" ]]; then
+  require_cmd node
+  ORT_CUDA_VERSION=$(node scripts/read-release-build-config.mjs --field ortCudaVersion)
+fi
+export ORT_CUDA_VERSION
 
 require_cmd cargo
 require_cmd rustc

--- a/scripts/read-release-build-config.mjs
+++ b/scripts/read-release-build-config.mjs
@@ -7,6 +7,7 @@ const CONFIG_OUTPUT_NAMES = {
   cudaToolkitVersion: 'cuda-toolkit-version',
   cudaArchitectures: 'cuda-architectures',
   windowsCudaSubpackagesManifest: 'windows-cuda-subpackages-manifest',
+  windowsCudaRustCacheEnvVars: 'windows-cuda-rust-cache-env-vars',
 };
 const OUTPUT_NAMES = {
   nodeVersion: 'node-version',

--- a/scripts/read-release-build-config.mjs
+++ b/scripts/read-release-build-config.mjs
@@ -1,0 +1,95 @@
+import { appendFile, readFile } from 'node:fs/promises';
+
+const CONFIG_PATH = '.github/release-build-config.json';
+const CONFIG_OUTPUT_NAMES = {
+  ggmlNative: 'ggml-native',
+  ortCudaVersion: 'ort-cuda-version',
+  cudaToolkitVersion: 'cuda-toolkit-version',
+  cudaArchitectures: 'cuda-architectures',
+  windowsCudaSubpackagesManifest: 'windows-cuda-subpackages-manifest',
+};
+const OUTPUT_NAMES = {
+  nodeVersion: 'node-version',
+  rustToolchain: 'rust-toolchain',
+  ...CONFIG_OUTPUT_NAMES,
+};
+
+const [configJson, mise, rustToolchainToml] = await Promise.all([
+  readFile(CONFIG_PATH, 'utf8'),
+  readFile('.mise.toml', 'utf8'),
+  readFile('rust-toolchain.toml', 'utf8'),
+]);
+const config = JSON.parse(configJson);
+const configKeys = Object.keys(CONFIG_OUTPUT_NAMES);
+const unknownKeys = Object.keys(config).filter((key) => !configKeys.includes(key));
+
+if (unknownKeys.length > 0) {
+  throw new Error(`${CONFIG_PATH} contains unknown keys: ${unknownKeys.join(', ')}.`);
+}
+
+for (const key of configKeys) {
+  if (typeof config[key] !== 'string' || config[key].trim().length === 0) {
+    throw new Error(`${CONFIG_PATH} must define a non-empty string for ${key}.`);
+  }
+}
+
+if (!/^\d+\.\d+\.\d+$/.test(config.cudaToolkitVersion)) {
+  throw new Error(`${CONFIG_PATH} cudaToolkitVersion must use major.minor.patch.`);
+}
+if (!/^\d+$/.test(config.ortCudaVersion)) {
+  throw new Error(`${CONFIG_PATH} ortCudaVersion must be a numeric major version.`);
+}
+
+const nodeVersion = matchRequiredVersion('.mise.toml', mise, /^\s*node\s*=\s*"([^"]+)"\s*$/m);
+const rustToolchain = matchRequiredVersion(
+  'rust-toolchain.toml',
+  rustToolchainToml,
+  /^\s*channel\s*=\s*"([^"]+)"\s*$/m,
+);
+const resolved = { nodeVersion, rustToolchain, ...config };
+
+const field = readFlagValue('--field');
+const githubOutput = process.argv.includes('--github-output');
+
+if (field !== null && githubOutput) {
+  throw new Error('--field and --github-output are mutually exclusive.');
+}
+
+if (field !== null) {
+  if (!Object.hasOwn(resolved, field)) {
+    throw new Error(`Unknown release build config field: ${field}.`);
+  }
+  process.stdout.write(resolved[field]);
+} else if (githubOutput) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) {
+    throw new Error('GITHUB_OUTPUT is required with --github-output.');
+  }
+  const lines = Object.entries(OUTPUT_NAMES)
+    .map(([key, outputName]) => `${outputName}=${resolved[key]}`)
+    .join('\n');
+  await appendFile(outputPath, `${lines}\n`);
+} else {
+  process.stdout.write(`${JSON.stringify(resolved, null, 2)}\n`);
+}
+
+function matchRequiredVersion(path, contents, pattern) {
+  const match = contents.match(pattern);
+  if (match === null) {
+    throw new Error(`Could not resolve the version from ${path}.`);
+  }
+  return match[1];
+}
+
+function readFlagValue(flagName) {
+  const flagIndex = process.argv.indexOf(flagName);
+  if (flagIndex < 0) {
+    return null;
+  }
+
+  const value = process.argv[flagIndex + 1];
+  if (value === undefined) {
+    throw new Error(`${flagName} requires a value.`);
+  }
+  return value;
+}


### PR DESCRIPTION
Closes #189.

## Summary

Windows CUDA release caches were saved under each release tag. GitHub isolates caches by tag name, so the next release could never restore them even when the key was unchanged. This change warms the exact production Windows CUDA build in trusted `main` scope before tagging, where release tags are allowed to restore it.

## Decisions

- Add a main-only automatic/manual Windows CUDA warmer. A non-main manual dispatch fails instead of creating another unusable branch cache.
- Run the warmer when release metadata or any Windows CUDA build/cache input changes, not on unrelated main pushes.
- Use the same composite Windows CUDA release build in the warmer and release workflow.
- Use one shared toolkit restore/install/environment action; toolkit caches save only after the entire job succeeds.
- Keep Rust `cache-on-failure: false` and the existing dedicated `target-cuda`/asset cache identity.
- Make `.github/release-build-config.json` the sole source for cross-platform GGML, ORT CUDA, toolkit, CUDA architecture, and Windows package-manifest settings. Node/Rust continue to come from `.mise.toml` and `rust-toolchain.toml`.
- Feed the resolved config to POSIX, Windows CPU/CUDA, the warmer, and local CUDA scripts so release paths cannot drift.
- Gate the release runbook on a successful warmer for the exact `origin/main` commit. Cache-prefix listing is diagnostic only; it is not treated as proof of compatibility.
- Keep tag publication, release assets, and provenance behavior unchanged.

## Verification

Local and review gates:

- `npm run check` — 626 Vitest tests plus Rust build/fmt/clippy/tests passed.
- `actionlint 1.7.12 .github/workflows/*.yml` — passed.
- Composite action schema validation — passed.
- Release config normal/field/GitHub-output modes and negative validation — passed.
- `bash -n scripts/build-cuda.sh` and `git diff --check main...HEAD` — passed.
- Independent Standards review after two correction rounds — no findings.
- Independent Spec review — implementation matches #189; live post-push evidence tracked below.

Live GitHub Actions evidence:

- Baseline/default-branch seed: https://github.com/brittain9/local-dictation-obsidian-plugin/actions/runs/29051968265
  - Cold Windows CUDA build: 17m23s.
  - Created both toolkit and Rust caches under `refs/heads/main`.
- Pre-correction cross-ref run: https://github.com/brittain9/local-dictation-obsidian-plugin/actions/runs/29053676228
  - Falsified the first implementation: both identities drifted, toolkit post-save failed, and CUDA remained cold.
- Corrected cross-ref run: https://github.com/brittain9/local-dictation-obsidian-plugin/actions/runs/29056165575
  - Exact main-scoped toolkit and Rust keys restored; toolkit install skipped; no broken post hook.
  - CUDA cargo build: 1m53s (from 14m29s); shared Windows CUDA step: 3m05s (from 19m19s).

## Scope

This fixes Windows CUDA release latency. It does not change CUDA versions, architectures, bundled DLLs, Linux caching, publication flow, or runtime behavior.
