### PR TITLE
Unify developer logs and user notices

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,6 +38,39 @@ export default defineConfig([
       // mid-sentence words ("context Windows", "0 Is deterministic"). Our UI text
       // is already sentence case. The community-review bot does not run this rule.
       'obsidianmd/ui/sentence-case': 'off',
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              importNames: ['Notice'],
+              message:
+                'Use the typed user-feedback boundary; only the Obsidian feedback presenter may import Notice.',
+              name: 'obsidian',
+            },
+          ],
+        },
+      ],
+      'no-restricted-syntax': [
+        'error',
+        {
+          message:
+            'Construct notices through the typed user-feedback boundary, not directly with new Notice().',
+          selector: "NewExpression[callee.name='Notice']",
+        },
+        {
+          message:
+            'Construct notices through the typed user-feedback boundary, not through an Obsidian namespace import.',
+          selector: "NewExpression[callee.property.name='Notice']",
+        },
+      ],
+    },
+  },
+  {
+    files: ['src/shared/obsidian-feedback-presenter.ts'],
+    rules: {
+      'no-restricted-imports': 'off',
+      'no-restricted-syntax': 'off',
     },
   },
 ]);

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -820,11 +820,7 @@ export class DictationSessionController {
     try {
       result = entry.session.acceptTranscript(revision);
     } catch (error) {
-      this.cancelOnFatalTranscriptFailure(
-        sessionId,
-        FEEDBACK_FAILURES.transcriptWrite,
-        error,
-      );
+      this.cancelOnFatalTranscriptFailure(sessionId, FEEDBACK_FAILURES.transcriptWrite, error);
       return;
     }
     if (entry.fatalTranscriptFailureReported) {

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -24,6 +24,7 @@ import type { PluginSettings, SmartParagraphPauseSettings } from '../settings/pl
 import { formatErrorMessage } from '../shared/format-utils';
 import type { PluginLogger } from '../shared/plugin-logger';
 import { truncateLeadingText } from '../shared/text-truncation';
+import type { UserFeedback } from '../shared/user-feedback';
 import type {
   ContextRequestEvent,
   ContextWindow,
@@ -122,9 +123,9 @@ interface DictationSessionControllerDependencies {
     sessionId: string;
   }) => ControllerSession;
   createLlmRouter: (settings: PluginSettings) => LlmRouter;
+  feedback: Pick<UserFeedback, 'show'>;
   getSettings: () => PluginSettings;
   logger?: PluginLogger;
-  notice: (message: string) => void;
   onLlmCleanupFailure?: (failure: LlmCleanupFailure) => void;
   onLlmCleanupSuccess?: () => void;
   onModelMissing?: () => void;
@@ -146,10 +147,39 @@ interface DictationSessionControllerDependencies {
 
 const ANCHOR_VISIBLE_DELAY_MS = 2500;
 const MAX_CONTROLLER_SESSIONS = 5;
-const SURFACE_DESYNCHRONIZED_NOTICE =
-  'Dictation stopped because the note changed in a way Local Dictation could not safely track. Start dictation again to continue.';
-const TRANSCRIPT_WRITE_FAILURE_NOTICE =
-  'Dictation stopped because Local Dictation could not safely write to the note. Start dictation again to continue.';
+interface FeedbackFailure {
+  key: string;
+  message: string;
+}
+
+const FEEDBACK_FAILURES = {
+  recordTranscript: {
+    key: 'transcript-record-failed',
+    message: 'Could not record the transcript.',
+  },
+  sidecar: {
+    key: 'sidecar-session-error',
+    message: 'The speech engine reported an error.',
+  },
+  surfaceDesynchronized: {
+    key: 'dictation-surface-desynchronized',
+    message:
+      'Dictation stopped because the note changed in a way Local Dictation could not safely track. Start dictation again to continue.',
+  },
+  startDictation: {
+    key: 'dictation-start-failed',
+    message: 'Could not start dictation.',
+  },
+  stopDictation: {
+    key: 'dictation-stop-failed',
+    message: 'Could not stop dictation.',
+  },
+  transcriptWrite: {
+    key: 'transcript-write-failed',
+    message:
+      'Dictation stopped because Local Dictation could not safely write to the note. Start dictation again to continue.',
+  },
+} as const satisfies Record<string, FeedbackFailure>;
 
 export class DictationSessionController {
   private activeSessionId: string | null = null;
@@ -177,7 +207,11 @@ export class DictationSessionController {
     const sessionId = this.activeSessionId ?? this.latestSessionId();
 
     if (sessionId === null) {
-      this.dependencies.notice('Dictation is not currently active.');
+      this.dependencies.feedback.show({
+        intent: 'information',
+        key: 'dictation-not-active',
+        message: 'Dictation is not currently active.',
+      });
       return;
     }
 
@@ -238,7 +272,7 @@ export class DictationSessionController {
     try {
       await this.assertMicrophoneInputAvailable();
     } catch (error) {
-      this.handleError('Failed to start the dictation session', error);
+      this.handleError(FEEDBACK_FAILURES.startDictation, error);
       return;
     }
 
@@ -251,7 +285,7 @@ export class DictationSessionController {
         this.dependencies.onSidecarMissing?.();
         return;
       }
-      this.handleError('Failed to start the dictation session', error);
+      this.handleError(FEEDBACK_FAILURES.startDictation, error);
       return;
     }
 
@@ -275,9 +309,8 @@ export class DictationSessionController {
           onSurfaceDesynchronized: (failure) => {
             this.cancelOnFatalTranscriptFailure(
               sessionId,
-              'dictation note surface desynchronized',
+              FEEDBACK_FAILURES.surfaceDesynchronized,
               failure,
-              SURFACE_DESYNCHRONIZED_NOTICE,
             );
           },
         },
@@ -290,7 +323,7 @@ export class DictationSessionController {
         sessionId,
       });
     } catch (error) {
-      this.handleError('Failed to start the dictation session', error);
+      this.handleError(FEEDBACK_FAILURES.startDictation, error);
       return;
     }
 
@@ -374,7 +407,11 @@ export class DictationSessionController {
     const sessionId = this.activeSessionId;
 
     if (sessionId === null) {
-      this.dependencies.notice('Dictation is not currently active.');
+      this.dependencies.feedback.show({
+        intent: 'information',
+        key: 'dictation-not-active',
+        message: 'Dictation is not currently active.',
+      });
       return;
     }
 
@@ -392,7 +429,7 @@ export class DictationSessionController {
       this.dependencies.sidecarConnection.requestStopSession(sessionId);
     } catch (error) {
       this.disposeLocalSession(sessionId);
-      this.handleError('Failed to stop the dictation session', error);
+      this.handleError(FEEDBACK_FAILURES.stopDictation, error);
     }
   }
 
@@ -417,7 +454,7 @@ export class DictationSessionController {
     } else {
       await this.cancelSession(sessionId);
     }
-    this.handleError('Failed to start the dictation session', error);
+    this.handleError(FEEDBACK_FAILURES.startDictation, error);
   }
 
   private async assertMicrophoneInputAvailable(): Promise<void> {
@@ -715,9 +752,8 @@ export class DictationSessionController {
       // exactly like a typed surface failure instead of retrying every revision.
       this.cancelOnFatalTranscriptFailure(
         event.sessionId,
-        'failed to process transcript',
+        FEEDBACK_FAILURES.transcriptWrite,
         error,
-        TRANSCRIPT_WRITE_FAILURE_NOTICE,
       );
     } finally {
       entry.pendingTranscriptWork.delete(work);
@@ -728,7 +764,7 @@ export class DictationSessionController {
     entry: ManagedSession,
     event: TranscriptReadyEvent,
   ): Promise<void> {
-    if (event.isFinal) {
+    if (event.isFinal && event.text.length > 0) {
       this.dependencies.logger?.debug(
         'session',
         `final transcript received (${event.text.length} chars, ${event.processingDurationMs}ms processing)`,
@@ -786,9 +822,8 @@ export class DictationSessionController {
     } catch (error) {
       this.cancelOnFatalTranscriptFailure(
         sessionId,
-        'failed to process transcript',
+        FEEDBACK_FAILURES.transcriptWrite,
         error,
-        TRANSCRIPT_WRITE_FAILURE_NOTICE,
       );
       return;
     }
@@ -796,7 +831,7 @@ export class DictationSessionController {
       return;
     }
     if (result.kind === 'rejected') {
-      this.handleError('Failed to record the local transcript', new Error(result.reason));
+      this.handleError(FEEDBACK_FAILURES.recordTranscript, new Error(result.reason));
       await this.cancelSession(sessionId);
     }
   }
@@ -1147,11 +1182,10 @@ export class DictationSessionController {
       // Additive presets may legitimately find nothing to add (e.g. no action
       // items), but say so — a silently failing model would otherwise look
       // like success.
-      this.dependencies.notice('LLM transform returned nothing to add.');
-      this.dependencies.logger?.debug(
-        'llm',
-        'additive batch returned empty output; nothing inserted',
-      );
+      this.dependencies.feedback.show({
+        intent: 'information',
+        message: 'LLM transform returned nothing to add.',
+      });
       return;
     }
 
@@ -1203,7 +1237,7 @@ export class DictationSessionController {
     const detail = formatSystemAudioErrorMessage(rawDetail, event.code);
 
     if (event.sessionId === undefined) {
-      this.handleError('Local Dictation sidecar error', detail);
+      this.handleError(FEEDBACK_FAILURES.sidecar, detail);
       return;
     }
 
@@ -1214,7 +1248,7 @@ export class DictationSessionController {
 
     if (event.sessionId === this.activeSessionId) {
       this.applyUiState('error');
-      this.dependencies.notice(`Local Dictation: ${detail}`);
+      this.dependencies.feedback.show({ intent: 'error', message: detail });
     } else {
       this.dependencies.logger?.warn('session', detail);
     }
@@ -1243,7 +1277,11 @@ export class DictationSessionController {
 
     const detail = event.details ? `${event.message} (${event.details})` : event.message;
     if (sessionId === this.activeSessionId) {
-      this.dependencies.notice(`Local Dictation: ${detail}`);
+      this.dependencies.feedback.show({
+        intent: 'warning',
+        key: 'utterance-queue-overload',
+        message: detail,
+      });
     } else {
       this.dependencies.logger?.warn('session', detail);
     }
@@ -1267,16 +1305,14 @@ export class DictationSessionController {
         continue;
       }
       const droppedSegments = stage.payload?.droppedSegments;
-      if (Array.isArray(droppedSegments)) {
-        for (const segment of droppedSegments) {
-          this.dependencies.logger?.debug('session', 'hallucination segment dropped', segment);
-        }
-      }
       const editedSegments = stage.payload?.editedSegments;
-      if (Array.isArray(editedSegments)) {
-        for (const segment of editedSegments) {
-          this.dependencies.logger?.debug('session', 'hallucination segment edited', segment);
-        }
+      const dropped = Array.isArray(droppedSegments) ? droppedSegments.length : 0;
+      const edited = Array.isArray(editedSegments) ? editedSegments.length : 0;
+      if (dropped + edited > 0) {
+        this.dependencies.logger?.debug('session', 'hallucination filter adjusted segments', {
+          dropped,
+          edited,
+        });
       }
     }
   }
@@ -1292,9 +1328,8 @@ export class DictationSessionController {
 
   private cancelOnFatalTranscriptFailure(
     sessionId: string,
-    logMessage: string,
+    failure: FeedbackFailure,
     details: unknown,
-    noticeMessage: string,
   ): void {
     const entry = this.sessions.get(sessionId);
     if (entry === undefined || entry.fatalTranscriptFailureReported) {
@@ -1303,8 +1338,12 @@ export class DictationSessionController {
 
     entry.fatalTranscriptFailureReported = true;
     this.abortProviderCleanups(entry);
-    this.dependencies.logger?.error('session', logMessage, details);
-    this.dependencies.notice(noticeMessage);
+    this.dependencies.feedback.show({
+      cause: details,
+      intent: 'error',
+      key: failure.key,
+      message: failure.message,
+    });
 
     if (entry.phase === 'cancelling' || entry.phase === 'stopped') {
       return;
@@ -1316,7 +1355,7 @@ export class DictationSessionController {
     void this.cancelSession(sessionId);
   }
 
-  private handleError(message: string, error: unknown): void {
+  private handleError(failure: FeedbackFailure, error: unknown): void {
     this.applyUiState('error');
 
     // Microphone-capture failures get specific, actionable copy that stands on
@@ -1324,20 +1363,32 @@ export class DictationSessionController {
     // the instructions. The Settings mic picker shows the same copy for parity.
     const microphoneMessage = formatMicrophoneCaptureErrorMessage(error);
     if (microphoneMessage !== null) {
-      this.dependencies.logger?.warn('session', message, formatErrorMessage(error));
-      this.dependencies.notice(microphoneMessage);
+      this.dependencies.feedback.show({
+        cause: error,
+        intent: 'action-required',
+        key: 'microphone-permission',
+        message: microphoneMessage,
+      });
       return;
     }
 
     const systemAudioMessage = formatSystemAudioSidecarErrorMessage(error);
     if (systemAudioMessage !== null) {
-      this.dependencies.logger?.warn('session', message, formatErrorMessage(error));
-      this.dependencies.notice(systemAudioMessage);
+      this.dependencies.feedback.show({
+        cause: error,
+        intent: 'action-required',
+        key: 'system-audio-permission',
+        message: systemAudioMessage,
+      });
       return;
     }
 
-    this.dependencies.logger?.error('session', message, error);
-    this.dependencies.notice(`${message}: ${formatErrorMessage(error)}`);
+    this.dependencies.feedback.show({
+      cause: error,
+      intent: 'error',
+      key: failure.key,
+      message: failure.message,
+    });
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { dirname, join } from 'node:path';
 import { IS_PRODUCTION_BUILD } from 'virtual:build-mode';
-import { FileSystemAdapter, Notice, Platform, Plugin } from 'obsidian';
+import { FileSystemAdapter, Platform, Plugin } from 'obsidian';
 
 import { AudioCaptureStream } from './audio/audio-capture-stream';
 import { SidecarAudioLevelMeter } from './audio/sidecar-audio-level-meter';
@@ -30,8 +30,9 @@ import {
   type SidecarInstallActionDeps,
 } from './settings/sidecar-settings-section';
 import { SetupWizardModal } from './setup/setup-wizard-modal';
-import { formatErrorMessage } from './shared/format-utils';
+import { createObsidianFeedbackPresenter } from './shared/obsidian-feedback-presenter';
 import { createPluginLogger, type PluginLogger } from './shared/plugin-logger';
+import { createUserFeedback, type UserFeedback } from './shared/user-feedback';
 import { assertSidecarExecutableIsFresh } from './sidecar/sidecar-build-state';
 import { SidecarConnection } from './sidecar/sidecar-connection';
 import { formatSidecarExecutableName } from './sidecar/sidecar-executable';
@@ -54,6 +55,10 @@ export default class LocalSttPlugin extends Plugin {
   private audioLevelMeter: SidecarAudioLevelMeter | null = null;
   private dictationController: DictationSessionController | null = null;
   private logger: PluginLogger = createPluginLogger(() => this.settings.developerMode);
+  private readonly feedback: UserFeedback = createUserFeedback({
+    logger: this.logger,
+    presenter: createObsidianFeedbackPresenter(),
+  });
   private llmCleanupFailure: LlmCleanupFailure | null = null;
   private readonly llmCleanupFailureSubscribers = new Set<() => void>();
   private modelInstallManager: ModelInstallManager | null = null;
@@ -99,7 +104,11 @@ export default class LocalSttPlugin extends Plugin {
     this.audioCaptureStream = new AudioCaptureStream({
       logger: this.logger,
       onDeviceFallback: () => {
-        new Notice('Saved microphone unavailable. Using the default input device.');
+        this.feedback.show({
+          intent: 'warning',
+          key: 'microphone-device-fallback',
+          message: 'Saved microphone unavailable. Using the default input device.',
+        });
       },
     });
     this.modelInstallManager = new ModelInstallManager({
@@ -111,22 +120,18 @@ export default class LocalSttPlugin extends Plugin {
       sidecarConnection: this.sidecarConnection,
     });
     this.sidecarInstallManager = new SidecarInstallManager({
+      feedback: this.feedback,
       logger: this.logger,
-      notice: (message) => {
-        new Notice(message);
-      },
     });
     this.registerView(
       LOCAL_DICTATION_VIEW_TYPE,
       (leaf) =>
         new LocalDictationView(leaf, {
+          feedback: this.feedback,
           getOpenRouterApiKey: () => this.getOpenRouterApiKey(),
           getSettings: () => this.settings,
           getLlmCleanupFailure: () => this.llmCleanupFailure,
           logger: this.logger,
-          notice: (message) => {
-            new Notice(message);
-          },
           saveSettings: async (nextSettings) => {
             await this.updateSettings(nextSettings);
           },
@@ -169,10 +174,8 @@ export default class LocalSttPlugin extends Plugin {
           () => this.getOpenRouterApiKey(),
         ),
       getSettings: () => this.settings,
+      feedback: this.feedback,
       logger: this.logger,
-      notice: (message) => {
-        new Notice(message);
-      },
       onLlmCleanupFailure: (failure) => {
         this.llmCleanupFailure = failure;
         this.notifyLlmCleanupFailureSubscribers();
@@ -200,6 +203,7 @@ export default class LocalSttPlugin extends Plugin {
 
     this.addSettingTab(
       new LocalSttSettingTab(this.app, this, {
+        feedback: this.feedback,
         getSettings: () => this.settings,
         isDictationBusy: () => this.dictationController?.isBusy() ?? false,
         logger: this.logger,
@@ -316,6 +320,7 @@ export default class LocalSttPlugin extends Plugin {
 
     const modal = new SetupWizardModal({
       app: this.app,
+      feedback: this.feedback,
       hasSelectedModel: () => this.settings.selectedModel !== null,
       isSidecarInstalled: () => this.isSidecarInstalled(),
       logger: this.logger,
@@ -349,6 +354,7 @@ export default class LocalSttPlugin extends Plugin {
       return;
     }
     new ManageModelsModal(this.app, {
+      feedback: this.feedback,
       manager: this.requireModelInstallManager(),
       onChanged: options.onChanged ?? (() => {}),
       onRunSetup: () => {
@@ -400,6 +406,7 @@ export default class LocalSttPlugin extends Plugin {
       this.sidecarConnection?.dispose();
     }
 
+    this.feedback.dispose();
     this.ribbonController?.dispose();
   }
 
@@ -412,7 +419,10 @@ export default class LocalSttPlugin extends Plugin {
       );
 
       if (options.showNotice ?? true) {
-        new Notice(`Local Dictation sidecar is ready (${health.sidecarVersion}).`);
+        this.feedback.show({
+          intent: 'success',
+          message: `Sidecar is ready (${health.sidecarVersion}).`,
+        });
       }
     } catch (error) {
       this.handleError('Sidecar health check failed', error, options.showNotice ?? true);
@@ -422,13 +432,21 @@ export default class LocalSttPlugin extends Plugin {
 
   private handleError(message: string, error: unknown, showNotice: boolean): void {
     if (showNotice) {
-      new Notice(`${message}: ${formatErrorMessage(error)}`);
+      this.feedback.show({
+        cause: error,
+        intent: 'error',
+        key: message,
+        message: `${message}.`,
+      });
     }
   }
 
   private async restartSidecar(): Promise<void> {
     if (this.requireDictationController().isBusy()) {
-      new Notice('Restart the sidecar only when dictation is idle.');
+      this.feedback.show({
+        intent: 'warning',
+        message: 'Restart the sidecar only when dictation is idle.',
+      });
       return;
     }
 
@@ -439,7 +457,10 @@ export default class LocalSttPlugin extends Plugin {
         this.settings.sidecarStartupTimeoutSeconds * 1000,
       );
 
-      new Notice(`Restarted Local Dictation sidecar (${health.sidecarVersion}).`);
+      this.feedback.show({
+        intent: 'success',
+        message: `Restarted sidecar (${health.sidecarVersion}).`,
+      });
     } catch (error) {
       this.handleError('Sidecar restart failed', error, true);
     }
@@ -623,12 +644,6 @@ export default class LocalSttPlugin extends Plugin {
 
     if (drift.length === 0) return;
 
-    this.logger.debug(
-      'sidecar',
-      `sidecar version drift: ${drift
-        .map((entry) => `${entry.variant} ${entry.installedVersion}`)
-        .join(', ')}, plugin ${this.manifest.version}`,
-    );
     this.notifySidecarVersionDrift(drift, pluginDirectory);
   }
 
@@ -643,32 +658,26 @@ export default class LocalSttPlugin extends Plugin {
         : variants[0] === 'cuda'
           ? 'CUDA speech engine is'
           : 'speech engine is';
-    const notice = new Notice(
-      createFragment((fragment) => {
-        fragment.createDiv({
-          text: `Local Dictation updated to ${this.manifest.version}, but the installed ${engineLabel} out of date. Update now to keep them in sync.`,
-        });
-        fragment
-          .createEl('a', {
-            href: '#',
-            text: variants.length === 2 ? 'Update speech engines' : 'Update speech engine',
-          })
-          .addEventListener('click', (event) => {
-            event.preventDefault();
-            notice.hide();
-            openSidecarUpdateModal(this.buildSidecarInstallActionDeps(), {
-              pluginDirectory,
-              variants,
-            });
+    this.feedback.show({
+      action: {
+        label: variants.length === 2 ? 'Update speech engines' : 'Update speech engine',
+        run: () => {
+          openSidecarUpdateModal(this.buildSidecarInstallActionDeps(), {
+            pluginDirectory,
+            variants,
           });
-      }),
-      0,
-    );
+        },
+      },
+      intent: 'action-required',
+      key: 'sidecar-version-drift',
+      message: `Updated to ${this.manifest.version}, but the installed ${engineLabel} out of date. Update now to keep them in sync.`,
+    });
   }
 
   private buildSidecarInstallActionDeps(): SidecarInstallActionDeps {
     return {
       app: this.app,
+      feedback: this.feedback,
       isDictationBusy: () => this.dictationController?.isBusy() ?? false,
       logger: this.logger,
       modelInstallManager: this.requireModelInstallManager(),

--- a/src/models/manage-models-modal.ts
+++ b/src/models/manage-models-modal.ts
@@ -1,7 +1,8 @@
 import type { App } from 'obsidian';
-import { Modal, Notice, Setting, setIcon } from 'obsidian';
+import { Modal, Setting, setIcon } from 'obsidian';
 
-import { formatBytes, formatErrorMessage } from '../shared/format-utils';
+import { formatBytes } from '../shared/format-utils';
+import type { UserFeedback } from '../shared/user-feedback';
 import { resolveEngineCapabilities } from './capability-view';
 import { isCancellingPhase, type ModelInstallManager } from './model-install-manager';
 import {
@@ -24,6 +25,7 @@ import { deriveModelFamilyTabs, deriveModelRowStates, type ModelRowState } from 
 // ---------------------------------------------------------------------------
 
 interface ManageModelsModalDependencies {
+  feedback: Pick<UserFeedback, 'show'>;
   manager: ModelInstallManager;
   onChanged: () => void;
   onRunSetup?: () => void;
@@ -275,14 +277,17 @@ export class ManageModelsModal extends Modal {
               .setButtonText('Install')
               .setDisabled(this.actionInProgress)
               .onClick(() => {
-                void this.runAction(async () => {
-                  await this.deps.manager.install({
-                    familyId: row.model.familyId,
-                    kind: 'catalog_model',
-                    modelId: row.model.modelId,
-                    runtimeId: row.model.runtimeId,
-                  });
-                }, 'Model install started.');
+                void this.runAction(
+                  async () => {
+                    await this.deps.manager.install({
+                      familyId: row.model.familyId,
+                      kind: 'catalog_model',
+                      modelId: row.model.modelId,
+                      runtimeId: row.model.runtimeId,
+                    });
+                  },
+                  { failureMessage: 'Could not start the model install. Try again.' },
+                );
               });
           });
           break;
@@ -294,15 +299,22 @@ export class ManageModelsModal extends Modal {
               .setButtonText('Use')
               .setDisabled(this.actionInProgress)
               .onClick(() => {
-                void this.runAction(async () => {
-                  await this.deps.manager.select({
-                    familyId: row.model.familyId,
-                    kind: 'catalog_model',
-                    modelId: row.model.modelId,
-                    runtimeId: row.model.runtimeId,
-                  });
-                  this.close();
-                }, 'Model selected.');
+                void this.runAction(
+                  async () => {
+                    await this.deps.manager.select({
+                      familyId: row.model.familyId,
+                      kind: 'catalog_model',
+                      modelId: row.model.modelId,
+                      runtimeId: row.model.runtimeId,
+                    });
+                    this.close();
+                  },
+                  {
+                    failureMessage:
+                      'Could not select the model. Check that its files are available.',
+                    successMessage: 'Model selected.',
+                  },
+                );
               });
           });
           break;
@@ -325,7 +337,7 @@ export class ManageModelsModal extends Modal {
                 .onClick(() => {
                   void this.runAction(async () => {
                     await this.deps.manager.cancel();
-                  }, 'Install cancelled.');
+                  });
                 });
             }
           });
@@ -338,14 +350,21 @@ export class ManageModelsModal extends Modal {
               .setButtonText('Remove')
               .setDisabled(this.actionInProgress)
               .onClick(() => {
-                void this.runAction(async () => {
-                  await this.deps.manager.remove({
-                    familyId: row.model.familyId,
-                    kind: 'catalog_model',
-                    modelId: row.model.modelId,
-                    runtimeId: row.model.runtimeId,
-                  });
-                }, 'Model removed.');
+                void this.runAction(
+                  async () => {
+                    await this.deps.manager.remove({
+                      familyId: row.model.familyId,
+                      kind: 'catalog_model',
+                      modelId: row.model.modelId,
+                      runtimeId: row.model.runtimeId,
+                    });
+                  },
+                  {
+                    failureMessage:
+                      'Could not remove the model. Close any process using its files.',
+                    successMessage: 'Model removed.',
+                  },
+                );
               });
           });
           break;
@@ -432,7 +451,10 @@ export class ManageModelsModal extends Modal {
   // Action runner
   // -------------------------------------------------------------------------
 
-  private async runAction(action: () => Promise<void>, successMessage: string): Promise<void> {
+  private async runAction(
+    action: () => Promise<void>,
+    messages: { failureMessage?: string; successMessage?: string } = {},
+  ): Promise<void> {
     if (this.actionInProgress) {
       return;
     }
@@ -442,10 +464,18 @@ export class ManageModelsModal extends Modal {
 
     try {
       await action();
-      new Notice(`Local Dictation: ${successMessage}`);
+      if (messages.successMessage !== undefined) {
+        this.deps.feedback.show({ intent: 'success', message: messages.successMessage });
+      }
       this.deps.onChanged();
     } catch (error) {
-      new Notice(`Local Dictation: ${formatErrorMessage(error)}`);
+      if (messages.failureMessage !== undefined) {
+        this.deps.feedback.show({
+          cause: error,
+          intent: 'error',
+          message: messages.failureMessage,
+        });
+      }
     } finally {
       this.actionInProgress = false;
       this.renderModelList();

--- a/src/models/model-management-modals.ts
+++ b/src/models/model-management-modals.ts
@@ -1,7 +1,8 @@
 import type { App } from 'obsidian';
-import { Modal, Notice, Setting } from 'obsidian';
+import { Modal, Setting } from 'obsidian';
 
-import { formatBytes, formatErrorMessage } from '../shared/format-utils';
+import { formatBytes } from '../shared/format-utils';
+import type { UserFeedback } from '../shared/user-feedback';
 import { buildCapabilityLabels } from './capability-view';
 import type { ModelInstallManager } from './model-install-manager';
 import {
@@ -12,6 +13,7 @@ import {
 } from './model-management-types';
 
 interface ExternalModelFileModalDependencies {
+  feedback: Pick<UserFeedback, 'show'>;
   manager: ModelInstallManager;
   onChanged: () => Promise<void>;
 }
@@ -89,10 +91,18 @@ export class ExternalModelFileModal extends Modal {
           try {
             await this.dependencies.manager.validateAndSelectExternalFile(nextPath, this.engine);
             await this.dependencies.onChanged();
-            new Notice('Local Dictation: External model file validated and selected.');
+            this.dependencies.feedback.show({
+              intent: 'success',
+              message: 'External model file validated and selected.',
+            });
             this.close();
           } catch (error) {
-            new Notice(`Local Dictation: ${formatErrorMessage(error)}`);
+            this.dependencies.feedback.show({
+              cause: error,
+              intent: 'error',
+              message:
+                'Could not validate the external model file. Check the file path and model family, then try again.',
+            });
           }
         });
     });

--- a/src/settings/microphone-picker.ts
+++ b/src/settings/microphone-picker.ts
@@ -1,7 +1,8 @@
-import { Notice, Setting } from 'obsidian';
+import { Setting } from 'obsidian';
 
 import { formatMicrophoneCaptureErrorMessage } from '../audio/microphone-permission-message';
 import type { PluginLogger } from '../shared/plugin-logger';
+import type { UserFeedback } from '../shared/user-feedback';
 import type { AudioInputDevice } from './plugin-settings';
 import type { SettingAccess } from './setting-helpers';
 
@@ -24,6 +25,7 @@ const DEVICE_CHANGE_DEBOUNCE_MS = 300;
 
 export interface MicrophonePickerDependencies {
   access: SettingAccess;
+  feedback: Pick<UserFeedback, 'show'>;
   isDictationBusy: () => boolean;
   logger?: PluginLogger | undefined;
 }
@@ -179,7 +181,11 @@ export function renderMicrophonePicker(
     if (label.length === 0) {
       // Shouldn't happen — the user can only pick an unlabeled row before
       // priming permission, and we don't want to persist a blank label.
-      new Notice('Allow microphone access first to save this device.');
+      deps.feedback.show({
+        intent: 'action-required',
+        key: 'microphone-permission',
+        message: 'Allow microphone access first to save this device.',
+      });
       const saved = getSaved();
       if (selectEl !== null) {
         selectEl.value = saved?.deviceId ?? DEFAULT_OPTION_VALUE;
@@ -193,13 +199,16 @@ export function renderMicrophonePicker(
 
   async function primePermission(): Promise<void> {
     if (deps.isDictationBusy()) {
-      new Notice('Stop dictation to detect microphones.');
+      deps.feedback.show({ intent: 'warning', message: 'Stop dictation to detect microphones.' });
       return;
     }
 
     const mediaDevices = window.navigator?.mediaDevices;
     if (mediaDevices?.getUserMedia === undefined) {
-      new Notice('Microphone access is not available in this runtime.');
+      deps.feedback.show({
+        intent: 'error',
+        message: 'Microphone access is not available in this runtime.',
+      });
       return;
     }
 
@@ -210,11 +219,14 @@ export function renderMicrophonePicker(
       }
       await enumerate();
     } catch (error) {
-      new Notice(
-        formatMicrophoneCaptureErrorMessage(error) ??
+      deps.feedback.show({
+        cause: error,
+        intent: 'action-required',
+        key: 'microphone-permission',
+        message:
+          formatMicrophoneCaptureErrorMessage(error) ??
           'Could not detect microphones. Check your system audio settings.',
-      );
-      deps.logger?.warn('audio', 'priming microphone permission failed', error);
+      });
     }
   }
 

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -1,5 +1,5 @@
 import type { App, Plugin } from 'obsidian';
-import { Notice, Platform, PluginSettingTab, Setting } from 'obsidian';
+import { Platform, PluginSettingTab, Setting } from 'obsidian';
 
 import { formatSystemAudioProbeResultMessage } from '../audio/system-audio-permission-message';
 import { resolveEngineCapabilities } from '../models/capability-view';
@@ -7,8 +7,8 @@ import type { ModelInstallManager } from '../models/model-install-manager';
 import { updateInstallProgressElement } from '../models/model-install-progress';
 import { ExternalModelFileModal, ModelDetailsModal } from '../models/model-management-modals';
 import { matchesModelTriple } from '../models/model-management-types';
-import { formatErrorMessage } from '../shared/format-utils';
 import type { PluginLogger } from '../shared/plugin-logger';
+import type { UserFeedback } from '../shared/user-feedback';
 import type { SpeakingStyle } from '../sidecar/protocol';
 import type { SidecarConnection } from '../sidecar/sidecar-connection';
 import {
@@ -53,6 +53,7 @@ import { SmartParagraphSettingsModal } from './smart-paragraph-settings-modal';
 import { isSystemAudioSupportedOnCurrentPlatform } from './system-audio-support';
 
 interface SettingsTabDependencies {
+  feedback: Pick<UserFeedback, 'show'>;
   getSettings: () => PluginSettings;
   isDictationBusy: () => boolean;
   logger?: PluginLogger | undefined;
@@ -157,6 +158,7 @@ export class LocalSttSettingTab extends PluginSettingTab {
           this.app,
           selectedModel?.kind === 'external_file' ? selectedModel.filePath : '',
           {
+            feedback: this.dependencies.feedback,
             manager,
             onChanged: async () => {
               this.display();
@@ -174,6 +176,7 @@ export class LocalSttSettingTab extends PluginSettingTab {
 
     this.disposeMicrophoneSection = renderMicrophonePicker(captureCard, {
       access: this.access,
+      feedback: this.dependencies.feedback,
       isDictationBusy: this.dependencies.isDictationBusy,
       logger: this.dependencies.logger,
     });
@@ -349,13 +352,22 @@ export class LocalSttSettingTab extends PluginSettingTab {
     try {
       const result = await this.dependencies.sidecarConnection.probeSystemAudio();
       if (result.ok) {
-        new Notice('System audio is ready.');
+        this.dependencies.feedback.show({ intent: 'success', message: 'System audio is ready.' });
         return true;
       }
 
-      new Notice(formatSystemAudioProbeResultMessage(result));
+      this.dependencies.feedback.show({
+        intent: 'action-required',
+        key: 'system-audio-permission',
+        message: formatSystemAudioProbeResultMessage(result),
+      });
     } catch (error) {
-      new Notice(`Could not test system audio: ${formatErrorMessage(error)}`);
+      this.dependencies.feedback.show({
+        cause: error,
+        intent: 'error',
+        message:
+          'Could not test system audio. Check that the speech engine is installed and try again.',
+      });
     }
     return false;
   }
@@ -518,16 +530,27 @@ export class LocalSttSettingTab extends PluginSettingTab {
           toggle.setValue(settings.accelerationPreference === 'auto');
           toggle.onChange(async (value) => {
             if (this.dependencies.isDictationBusy()) {
-              new Notice('Cannot change hardware acceleration while dictating.');
+              this.dependencies.feedback.show({
+                intent: 'warning',
+                message: 'Cannot change hardware acceleration while dictating.',
+              });
               toggle.setValue(!value);
               return;
             }
             await this.access.persistOne('accelerationPreference', value ? 'auto' : 'cpu_only');
             try {
               await this.dependencies.restartSidecar();
-              new Notice(value ? 'Hardware acceleration on.' : 'Hardware acceleration off.');
+              this.dependencies.feedback.show({
+                intent: 'success',
+                message: value ? 'Hardware acceleration on.' : 'Hardware acceleration off.',
+              });
             } catch (error) {
-              new Notice(`Failed to apply hardware acceleration: ${formatErrorMessage(error)}`);
+              this.dependencies.feedback.show({
+                cause: error,
+                intent: 'error',
+                message:
+                  'Hardware acceleration was saved, but the speech engine could not restart. Restart Obsidian to apply it.',
+              });
             }
           });
         });
@@ -635,6 +658,7 @@ export class LocalSttSettingTab extends PluginSettingTab {
   private buildSidecarInstallActionDeps(): SidecarInstallActionDeps {
     return {
       app: this.app,
+      feedback: this.dependencies.feedback,
       isDictationBusy: this.dependencies.isDictationBusy,
       logger: this.dependencies.logger,
       modelInstallManager: this.dependencies.modelInstallManager,

--- a/src/settings/sidecar-settings-section.ts
+++ b/src/settings/sidecar-settings-section.ts
@@ -1,5 +1,5 @@
 import type { App } from 'obsidian';
-import { Notice, Platform, Setting } from 'obsidian';
+import { Platform, Setting } from 'obsidian';
 
 import type { ModelInstallManager } from '../models/model-install-manager';
 import { updateInstallProgressElement } from '../models/model-install-progress';
@@ -9,8 +9,8 @@ import {
   type InstallIntent,
 } from '../setup/sidecar-install-copy';
 import { SidecarInstallModal } from '../setup/sidecar-install-modal';
-import { formatErrorMessage } from '../shared/format-utils';
 import type { PluginLogger } from '../shared/plugin-logger';
+import type { UserFeedback } from '../shared/user-feedback';
 import { detectNvidiaDriver, type NvidiaDriverStatus } from '../sidecar/gpu-precheck';
 import type { SidecarConnection } from '../sidecar/sidecar-connection';
 import {
@@ -30,6 +30,7 @@ import { addPositiveIntSetting, addTextSetting, type SettingAccess } from './set
 
 export interface SidecarInstallActionDeps {
   app: App;
+  feedback: Pick<UserFeedback, 'show'>;
   isDictationBusy(): boolean;
   logger?: PluginLogger | undefined;
   modelInstallManager: ModelInstallManager;
@@ -293,9 +294,11 @@ export function openSidecarInstallModal(
   },
 ): void {
   if (deps.isDictationBusy()) {
-    new Notice(
-      'Stop dictation before installing a sidecar — the install restarts the engine. If a transcript is still processing, run "Cancel dictation" to stop it now.',
-    );
+    deps.feedback.show({
+      intent: 'warning',
+      message:
+        'Stop dictation before installing a sidecar — the install restarts the engine. If a transcript is still processing, run "Cancel dictation" to stop it now.',
+    });
     return;
   }
 
@@ -304,6 +307,7 @@ export function openSidecarInstallModal(
       await shutdownSidecarBeforeFileMutation(deps, `${opts.variant} install`);
     },
     copy: getInstallCopy(opts.variant, opts.intent),
+    feedback: deps.feedback,
     manager: deps.sidecarInstallManager,
     onInstalled: async () => {
       await opts.onInstalled?.();
@@ -325,9 +329,11 @@ export function openSidecarUpdateModal(
   },
 ): void {
   if (deps.isDictationBusy()) {
-    new Notice(
-      'Stop dictation before updating sidecars — the update restarts the engine. If a transcript is still processing, run "Cancel dictation" to stop it now.',
-    );
+    deps.feedback.show({
+      intent: 'warning',
+      message:
+        'Stop dictation before updating sidecars — the update restarts the engine. If a transcript is still processing, run "Cancel dictation" to stop it now.',
+    });
     return;
   }
 
@@ -336,6 +342,7 @@ export function openSidecarUpdateModal(
       await shutdownSidecarBeforeFileMutation(deps, 'sidecar update');
     },
     copy: getSidecarUpdateCopy(opts.variants),
+    feedback: deps.feedback,
     manager: deps.sidecarInstallManager,
     onInstalled: async () => {
       await deps.restartSidecar();
@@ -360,9 +367,10 @@ async function uninstallSidecarVariantWithUx(
   const userFacingName = Platform.isMacOS ? 'sidecar' : `${variantLabel} sidecar`;
 
   if (deps.isDictationBusy()) {
-    new Notice(
-      `Stop dictation before uninstalling the ${userFacingName}. If a transcript is still processing, run "Cancel dictation" to stop it now.`,
-    );
+    deps.feedback.show({
+      intent: 'warning',
+      message: `Stop dictation before uninstalling the ${userFacingName}. If a transcript is still processing, run "Cancel dictation" to stop it now.`,
+    });
     return;
   }
 
@@ -370,26 +378,33 @@ async function uninstallSidecarVariantWithUx(
     await shutdownSidecarBeforeFileMutation(deps, `${variantLabel} uninstall`);
     await uninstallSidecarVariant(pluginDirectory, variant);
   } catch (error) {
-    deps.logger?.error('installer', `failed to uninstall ${variantLabel} sidecar`, error);
-    new Notice(`Failed to uninstall ${userFacingName}: ${formatErrorMessage(error)}`);
+    deps.feedback.show({
+      cause: error,
+      intent: 'error',
+      message: `Could not uninstall the ${userFacingName}. Close other setup windows and try again.`,
+    });
     return;
   }
 
-  new Notice(
-    Platform.isMacOS
+  deps.feedback.show({
+    intent: 'success',
+    message: Platform.isMacOS
       ? 'Sidecar uninstalled.'
       : variant === 'cuda'
         ? 'CUDA sidecar uninstalled. Running on CPU.'
         : 'CPU sidecar uninstalled.',
-  );
+  });
   deps.refreshSettingsTab();
 
   try {
     await deps.restartSidecar();
   } catch (error) {
     if (error instanceof SidecarNotInstalledError) return;
-    deps.logger?.warn('installer', 'sidecar restart after uninstall failed', error);
-    new Notice(`Sidecar could not restart: ${formatErrorMessage(error)}`);
+    deps.feedback.show({
+      cause: error,
+      intent: 'warning',
+      message: 'The speech engine could not restart. Restart Obsidian before dictating.',
+    });
   }
 }
 

--- a/src/setup/setup-wizard-modal.ts
+++ b/src/setup/setup-wizard-modal.ts
@@ -1,8 +1,9 @@
 import type { App } from 'obsidian';
-import { Modal, Notice, Platform, setIcon } from 'obsidian';
+import { Modal, Platform, setIcon } from 'obsidian';
 import { ManageModelsModal } from '../models/manage-models-modal';
 import type { ModelInstallManager } from '../models/model-install-manager';
 import type { PluginLogger } from '../shared/plugin-logger';
+import type { UserFeedback } from '../shared/user-feedback';
 import type { SidecarConnection } from '../sidecar/sidecar-connection';
 import type { SidecarInstallManager } from '../sidecar/sidecar-install-manager';
 import { getInstallCopy } from './sidecar-install-copy';
@@ -10,6 +11,7 @@ import { SidecarInstallModal } from './sidecar-install-modal';
 
 interface WizardDependencies {
   app: App;
+  feedback: Pick<UserFeedback, 'show'>;
   hasSelectedModel: () => boolean;
   isSidecarInstalled: () => Promise<boolean>;
   logger?: PluginLogger;
@@ -172,6 +174,7 @@ export class SetupWizardModal extends Modal {
   private openSidecarInstall(): void {
     const modal = new SidecarInstallModal(this.deps.app, {
       copy: getInstallCopy('cpu', 'first-run'),
+      feedback: this.deps.feedback,
       manager: this.deps.sidecarInstallManager,
       onInstalled: async () => {
         await this.deps.postSidecarInstalled();
@@ -229,6 +232,7 @@ export class SetupWizardModal extends Modal {
 
   private openModelPicker(): void {
     const modal = new ManageModelsModal(this.deps.app, {
+      feedback: this.deps.feedback,
       manager: this.deps.modelInstallManager,
       onChanged: () => {
         // Re-check on any change so the wizard advances as soon as a model is selected.
@@ -296,8 +300,11 @@ export class SetupWizardModal extends Modal {
         tab.searchInputEl.dispatchEvent(new Event('input'));
       }
     } catch (error) {
-      this.deps.logger?.warn('setup', 'failed to open hotkey settings', error);
-      new Notice('Open Settings → Hotkeys and search for "Local Dictation".');
+      this.deps.feedback.show({
+        cause: error,
+        intent: 'warning',
+        message: 'Open Settings → Hotkeys and search for "Local Dictation".',
+      });
     }
   }
 

--- a/src/setup/sidecar-install-modal.ts
+++ b/src/setup/sidecar-install-modal.ts
@@ -1,11 +1,12 @@
 import type { App } from 'obsidian';
-import { Modal, Notice } from 'obsidian';
+import { Modal } from 'obsidian';
 
 import {
   createInstallProgressElement,
   updateInstallProgressElement,
 } from '../models/model-install-progress';
 import { formatErrorMessage } from '../shared/format-utils';
+import type { UserFeedback } from '../shared/user-feedback';
 import {
   type ActiveSidecarInstall,
   buildSidecarProgressState,
@@ -21,6 +22,7 @@ import type { InstallCopy } from './sidecar-install-copy';
 export interface SidecarInstallModalOptions {
   beforeReplace?: (() => Promise<void>) | undefined;
   copy: InstallCopy;
+  feedback: Pick<UserFeedback, 'show'>;
   manager: SidecarInstallManager;
   onInstalled: () => Promise<void>;
   onVariantInstalled?: ((variant: SidecarInstallVariant) => Promise<void>) | undefined;
@@ -215,7 +217,11 @@ export class SidecarInstallModal extends Modal {
         version: this.options.version,
       });
     } catch (error) {
-      new Notice(formatErrorMessage(error));
+      this.options.feedback.show({
+        cause: error,
+        intent: 'error',
+        message: 'Could not start the sidecar install. Close other setup windows and try again.',
+      });
     }
   }
 }

--- a/src/setup/sidecar-install-modal.ts
+++ b/src/setup/sidecar-install-modal.ts
@@ -32,6 +32,7 @@ export interface SidecarInstallModalOptions {
 }
 
 export class SidecarInstallModal extends Modal {
+  private inlineFailureVisible = false;
   private installProgressEl: HTMLDivElement | null = null;
   private unsubscribe: (() => void) | null = null;
   private wasActive = false;
@@ -44,6 +45,7 @@ export class SidecarInstallModal extends Modal {
   }
 
   override onOpen(): void {
+    this.inlineFailureVisible = true;
     this.modalEl.addClass('local-stt-sidecar-install');
     this.titleEl.setText(this.options.copy.title);
     this.unsubscribe = this.options.manager.subscribe(() => {
@@ -53,6 +55,7 @@ export class SidecarInstallModal extends Modal {
   }
 
   override onClose(): void {
+    this.inlineFailureVisible = false;
     this.unsubscribe?.();
     this.unsubscribe = null;
     this.contentEl.empty();
@@ -209,6 +212,11 @@ export class SidecarInstallModal extends Modal {
     try {
       this.options.manager.installBatch({
         beforeReplace: this.options.beforeReplace,
+        failureFeedback: {
+          isInlineVisible: () => this.inlineFailureVisible,
+          message:
+            'The speech engine install failed. Reopen setup or Settings to review the error and retry.',
+        },
         onInstalled: this.options.onInstalled,
         onVariantInstalled: this.options.onVariantInstalled,
         pluginDirectory: this.options.pluginDirectory,

--- a/src/shared/obsidian-feedback-presenter.ts
+++ b/src/shared/obsidian-feedback-presenter.ts
@@ -1,0 +1,29 @@
+import { Notice } from 'obsidian';
+
+import type { FeedbackPresenter } from './user-feedback';
+
+export function createObsidianFeedbackPresenter(): FeedbackPresenter {
+  return {
+    present(presentation) {
+      const message =
+        presentation.action === undefined
+          ? presentation.message
+          : createFragment((fragment) => {
+              fragment.createDiv({ text: presentation.message });
+              fragment
+                .createEl('a', { href: '#', text: presentation.action?.label ?? '' })
+                .addEventListener('click', (event) => {
+                  event.preventDefault();
+                  presentation.action?.run();
+                });
+            });
+      const notice = new Notice(message, presentation.durationMs);
+
+      return {
+        dismiss() {
+          notice.hide();
+        },
+      };
+    },
+  };
+}

--- a/src/shared/user-feedback.ts
+++ b/src/shared/user-feedback.ts
@@ -1,0 +1,145 @@
+import type { PluginLogger } from './plugin-logger';
+
+export type FeedbackIntent = 'information' | 'success' | 'warning' | 'error' | 'action-required';
+
+export interface FeedbackAction {
+  label: string;
+  run: () => void;
+}
+
+export interface FeedbackRequest {
+  action?: FeedbackAction;
+  cause?: unknown;
+  intent: FeedbackIntent;
+  key?: string;
+  message: string;
+}
+
+export interface FeedbackPresentation {
+  action?: FeedbackAction;
+  durationMs: number;
+  message: string;
+}
+
+export interface FeedbackPresentationHandle {
+  dismiss(): void;
+}
+
+export interface FeedbackPresenter {
+  present(presentation: FeedbackPresentation): FeedbackPresentationHandle;
+}
+
+export interface UserFeedback {
+  dispose(): void;
+  show(request: FeedbackRequest): void;
+}
+
+interface UserFeedbackDependencies {
+  logger: PluginLogger;
+  presenter: FeedbackPresenter;
+}
+
+interface ActiveFeedback {
+  expiryTimerId: number | null;
+  handle: FeedbackPresentationHandle;
+}
+
+const DEFAULT_DURATION_MS: Readonly<Record<FeedbackIntent, number>> = {
+  'action-required': 0,
+  error: 10_000,
+  information: 5_000,
+  success: 4_000,
+  warning: 8_000,
+};
+
+export function createUserFeedback(dependencies: UserFeedbackDependencies): UserFeedback {
+  const activeByKey = new Map<string, ActiveFeedback>();
+
+  const release = (key: string, active: ActiveFeedback, dismiss: boolean): void => {
+    if (active.expiryTimerId !== null) {
+      window.clearTimeout(active.expiryTimerId);
+    }
+    if (dismiss) {
+      active.handle.dismiss();
+    }
+    if (activeByKey.get(key) === active) {
+      activeByKey.delete(key);
+    }
+  };
+
+  return {
+    dispose() {
+      for (const [key, active] of activeByKey) {
+        release(key, active, true);
+      }
+    },
+    show(request) {
+      if (request.key !== undefined) {
+        const active = activeByKey.get(request.key);
+        if (active !== undefined) {
+          release(request.key, active, true);
+        }
+      }
+
+      logFeedback(dependencies.logger, request);
+
+      let handle: FeedbackPresentationHandle | null = null;
+      const action =
+        request.action === undefined
+          ? undefined
+          : {
+              label: request.action.label,
+              run: () => {
+                if (request.key !== undefined) {
+                  const active = activeByKey.get(request.key);
+                  if (active !== undefined && active.handle === handle) {
+                    release(request.key, active, true);
+                  } else {
+                    handle?.dismiss();
+                  }
+                } else {
+                  handle?.dismiss();
+                }
+                request.action?.run();
+              },
+            };
+      const durationMs = DEFAULT_DURATION_MS[request.intent];
+      handle = dependencies.presenter.present({
+        ...(action === undefined ? {} : { action }),
+        durationMs,
+        message: request.message.startsWith('Local Dictation')
+          ? request.message
+          : `Local Dictation: ${request.message}`,
+      });
+
+      if (request.key !== undefined) {
+        const key = request.key;
+        const active: ActiveFeedback = { expiryTimerId: null, handle };
+        activeByKey.set(key, active);
+        if (durationMs > 0) {
+          active.expiryTimerId = window.setTimeout(() => {
+            release(key, active, false);
+          }, durationMs);
+        }
+      }
+    },
+  };
+}
+
+function logFeedback(logger: PluginLogger, request: FeedbackRequest): void {
+  const message = `${request.intent}: ${request.message}`;
+  const data = request.cause === undefined ? [] : [request.cause];
+
+  switch (request.intent) {
+    case 'information':
+    case 'success':
+      logger.debug('feedback', message, ...data);
+      return;
+    case 'warning':
+    case 'action-required':
+      logger.warn('feedback', message, ...data);
+      return;
+    case 'error':
+      logger.error('feedback', message, ...data);
+  }
+}

--- a/src/sidecar/sidecar-connection.ts
+++ b/src/sidecar/sidecar-connection.ts
@@ -418,10 +418,6 @@ export class SidecarConnection {
   }
 
   private dispatchEvent(event: SidecarEvent): void {
-    if (shouldLogProtocolEvent(event)) {
-      this.options.logger?.debug('protocol', summarizeProtocolEvent(event));
-    }
-
     if (event.type === 'model_install_update' && event.state === 'failed') {
       this.options.logger?.warn(
         'model',
@@ -457,43 +453,5 @@ export class SidecarConnection {
       this.pendingWaiters.delete(waiter);
       waiter.reject(error);
     }
-  }
-}
-
-function shouldLogProtocolEvent(event: SidecarEvent): boolean {
-  switch (event.type) {
-    case 'error':
-    case 'session_started':
-    case 'session_state_changed':
-    case 'session_stopped':
-    case 'warning':
-      return true;
-    case 'transcript_ready':
-      return event.isFinal;
-    case 'model_install_update':
-      return false;
-    default:
-      return false;
-  }
-}
-
-function summarizeProtocolEvent(event: SidecarEvent): string {
-  switch (event.type) {
-    case 'model_install_update':
-      return `event: model_install_update (${event.modelId}, ${event.state})`;
-    case 'session_started':
-      return `event: session_started (${event.sessionId})`;
-    case 'session_state_changed':
-      return `event: session_state_changed (${event.sessionId}, ${event.state})`;
-    case 'session_stopped':
-      return `event: session_stopped (${event.sessionId}, ${event.reason})`;
-    case 'transcript_ready':
-      return `event: transcript_ready (${event.sessionId}, final, ${event.text.length} chars)`;
-    case 'warning':
-      return `event: warning (${event.code})`;
-    case 'error':
-      return `event: error (${event.code})`;
-    default:
-      return `event: ${event.type}`;
   }
 }

--- a/src/sidecar/sidecar-install-manager.ts
+++ b/src/sidecar/sidecar-install-manager.ts
@@ -25,6 +25,10 @@ export interface SidecarInstallManagerState {
 
 export interface SidecarInstallOptions {
   beforeReplace?: (() => Promise<void>) | undefined;
+  failureFeedback: {
+    isInlineVisible: () => boolean;
+    message: string;
+  };
   onInstalled: () => Promise<void>;
   pluginDirectory: string;
   successNotice: string;
@@ -167,8 +171,17 @@ export class SidecarInstallManager {
         this.lastError = null;
       } else {
         const message = formatErrorMessage(error);
-        this.deps.logger?.error('installer', 'sidecar install failed', error);
         this.lastError = message;
+        if (options.failureFeedback.isInlineVisible()) {
+          this.deps.logger?.error('installer', 'sidecar install failed', error);
+        } else {
+          this.deps.feedback.show({
+            cause: error,
+            intent: 'error',
+            key: 'sidecar-install-failed',
+            message: options.failureFeedback.message,
+          });
+        }
       }
     } finally {
       if (this.abortController?.signal === signal) {

--- a/src/sidecar/sidecar-install-manager.ts
+++ b/src/sidecar/sidecar-install-manager.ts
@@ -1,6 +1,7 @@
 import type { InstallProgressState } from '../models/model-install-progress';
 import { formatErrorMessage } from '../shared/format-utils';
 import type { PluginLogger } from '../shared/plugin-logger';
+import type { UserFeedback } from '../shared/user-feedback';
 import {
   type InstallProgress,
   installSidecar,
@@ -37,8 +38,8 @@ export interface SidecarInstallBatchOptions extends Omit<SidecarInstallOptions, 
 }
 
 interface SidecarInstallManagerDependencies {
+  feedback: Pick<UserFeedback, 'show'>;
   logger?: PluginLogger | undefined;
-  notice: (message: string) => void;
 }
 
 const INITIAL_PROGRESS: InstallProgress = {
@@ -158,17 +159,16 @@ export class SidecarInstallManager {
       }
 
       await options.onInstalled();
-      this.deps.notice(options.successNotice);
+      this.deps.feedback.show({ intent: 'success', message: options.successNotice });
       this.lastError = null;
     } catch (error) {
       if (isAbortError(error)) {
-        this.deps.notice('Sidecar install cancelled.');
+        this.deps.feedback.show({ intent: 'information', message: 'Sidecar install cancelled.' });
         this.lastError = null;
       } else {
         const message = formatErrorMessage(error);
         this.deps.logger?.error('installer', 'sidecar install failed', error);
         this.lastError = message;
-        this.deps.notice(`Sidecar install failed: ${message}`);
       }
     } finally {
       if (this.abortController?.signal === signal) {

--- a/src/ui/llm-routing-controls.ts
+++ b/src/ui/llm-routing-controls.ts
@@ -2,7 +2,6 @@ import {
   AbstractInputSuggest,
   type App,
   type ExtraButtonComponent,
-  Notice,
   SecretComponent,
   Setting,
   setIcon,
@@ -23,15 +22,16 @@ import {
 import { isLlmRouting, type PluginSettings } from '../settings/plugin-settings';
 import { appendInfoTooltip } from '../settings/setting-helpers';
 import type { PluginLogger } from '../shared/plugin-logger';
+import type { UserFeedback } from '../shared/user-feedback';
 import { formatCleanupFailureBanner, priceTier, providerHealthFromError } from './llm-provider-ui';
 import { deriveInlineStatus, INLINE_STATUS_PRESENTATION } from './llm-status';
 
 export interface LlmRoutingControlsDependencies {
   app: App;
+  feedback: Pick<UserFeedback, 'show'>;
   getOpenRouterApiKey: () => string;
   getSettings: () => PluginSettings;
   logger?: PluginLogger | undefined;
-  notice?: ((message: string) => void) | undefined;
   persist: (settings: PluginSettings, options?: { rerender?: boolean }) => Promise<void>;
   requestRerender: () => void;
 }
@@ -150,17 +150,13 @@ export class LlmRoutingControls {
     const refreshes: Promise<void>[] = [];
     if (!settings.llmRemoteFeaturesEnabled) {
       refreshes.push(
-        options.forceLocal === true
-          ? this.refreshModels('ollama', { silent: true })
-          : this.recheckModels('ollama'),
+        options.forceLocal === true ? this.refreshModels('ollama') : this.recheckModels('ollama'),
       );
       return Promise.all(refreshes).then(() => undefined);
     }
     if (settings.llmRouting === 'local' || settings.llmRouting === 'auto') {
       refreshes.push(
-        options.forceLocal === true
-          ? this.refreshModels('ollama', { silent: true })
-          : this.recheckModels('ollama'),
+        options.forceLocal === true ? this.refreshModels('ollama') : this.recheckModels('ollama'),
       );
     }
     if (settings.llmRouting === 'remote' || settings.llmRouting === 'auto') {
@@ -174,7 +170,7 @@ export class LlmRoutingControls {
     if (state.modelsLoaded && state.health.kind === 'ready') {
       return Promise.resolve();
     }
-    return this.refreshModels(providerId, { silent: true });
+    return this.refreshModels(providerId);
   }
 
   // Background warm: load a provider's catalog once. Unlike `recheckModels`,
@@ -185,7 +181,7 @@ export class LlmRoutingControls {
     if (state.modelsLoaded || this.modelsRefreshInFlight[providerId] === true) {
       return;
     }
-    void this.refreshModels(providerId, { silent: true });
+    void this.refreshModels(providerId);
   }
 
   render(parent: HTMLElement, settings: PluginSettings): void {
@@ -481,7 +477,7 @@ export class LlmRoutingControls {
       const failure = await this.testOpenRouter();
       button.setIcon(failure === null ? 'check' : 'x');
       if (failure !== null) {
-        this.notice(`Local Dictation: ${failure}`);
+        this.dependencies.feedback.show({ intent: 'warning', message: failure });
       }
       window.setTimeout(() => {
         button.setIcon('plug-zap');
@@ -530,10 +526,7 @@ export class LlmRoutingControls {
     this.dependencies.requestRerender();
   }
 
-  private async refreshModels(
-    providerId: LlmProviderId,
-    options: { silent?: boolean } = {},
-  ): Promise<void> {
+  private async refreshModels(providerId: LlmProviderId): Promise<void> {
     if (this.modelsRefreshInFlight[providerId] === true) {
       return;
     }
@@ -550,23 +543,12 @@ export class LlmRoutingControls {
       state.models = [];
       state.health = providerHealthFromError(error);
       this.dependencies.logger?.warn('llm', `${providerName} refresh failed`, error);
-      if (options.silent !== true) {
-        this.notice(`Local Dictation: ${providerName} is unavailable.`);
-      }
     } finally {
       state.modelsLoaded = true;
       this.modelsRefreshInFlight[providerId] = false;
     }
 
     this.dependencies.requestRerender();
-  }
-
-  private notice(message: string): void {
-    if (this.dependencies.notice !== undefined) {
-      this.dependencies.notice(message);
-      return;
-    }
-    new Notice(message);
   }
 
   private createProvider(

--- a/src/ui/local-dictation-view.ts
+++ b/src/ui/local-dictation-view.ts
@@ -19,6 +19,7 @@ import {
   createSettingGroup,
 } from '../settings/setting-helpers';
 import type { PluginLogger } from '../shared/plugin-logger';
+import type { UserFeedback } from '../shared/user-feedback';
 import { ConfirmModal } from './confirm-modal';
 import { FocusRefreshController } from './focus-refresh-controller';
 import { formatCleanupFailureBanner } from './llm-provider-ui';
@@ -40,12 +41,12 @@ const CLEANUP_MODE_OPTIONS: ReadonlyArray<{ label: string; value: LlmPresetTimin
 ];
 
 interface LocalDictationViewDependencies {
+  feedback: Pick<UserFeedback, 'show'>;
   getOpenRouterApiKey: () => string;
   getSettings: () => PluginSettings;
   getLlmCleanupFailure?: () => LlmCleanupFailure | null;
   logger?: PluginLogger | undefined;
   mutatePresetState: (mutation: LlmPresetStateMutation) => Promise<void>;
-  notice?: (message: string) => void;
   saveSettings: (settings: PluginSettings) => Promise<void>;
   subscribeLlmCleanupFailure?: (callback: () => void) => () => void;
   synchronizePresets: () => Promise<void>;
@@ -67,10 +68,10 @@ export class LocalDictationView extends ItemView {
     super(leaf);
     this.routingControls = new LlmRoutingControls({
       app: this.app,
+      feedback: this.dependencies.feedback,
       getOpenRouterApiKey: () => this.dependencies.getOpenRouterApiKey(),
       getSettings: () => this.dependencies.getSettings(),
       logger: this.dependencies.logger,
-      ...(this.dependencies.notice !== undefined ? { notice: this.dependencies.notice } : {}),
       persist: (settings, options) => this.persistSettings(settings, options),
       requestRerender: () => {
         this.scheduleRender();
@@ -291,6 +292,7 @@ export class LocalDictationView extends ItemView {
   private async openPresetManager(): Promise<void> {
     await this.dependencies.synchronizePresets();
     new PresetManagerModal(this.app, {
+      feedback: this.dependencies.feedback,
       getSettings: () => this.dependencies.getSettings(),
       mutatePresetState: async (mutation) => {
         await this.mutatePresetState(mutation);

--- a/src/ui/preset-manager-modal.ts
+++ b/src/ui/preset-manager-modal.ts
@@ -1,12 +1,5 @@
 import type { App, DropdownComponent } from 'obsidian';
-import {
-  Modal,
-  Notice,
-  prepareSimpleSearch,
-  renderMatches,
-  SearchComponent,
-  Setting,
-} from 'obsidian';
+import { Modal, prepareSimpleSearch, renderMatches, SearchComponent, Setting } from 'obsidian';
 
 import {
   formatStyleRef,
@@ -25,6 +18,7 @@ import {
   LLM_USER_PRESET_MAX_LABEL_CHARS,
   type PluginSettings,
 } from '../settings/plugin-settings';
+import type { UserFeedback } from '../shared/user-feedback';
 import { ConfirmModal } from './confirm-modal';
 import {
   applyPresetDraftSave,
@@ -37,6 +31,7 @@ import {
 import { type PresetSearchHit, searchPresetEntries } from './preset-search';
 
 interface PresetManagerModalDependencies {
+  feedback: Pick<UserFeedback, 'show'>;
   getSettings: () => PluginSettings;
   mutatePresetState: (mutation: LlmPresetStateMutation) => Promise<void>;
 }
@@ -464,7 +459,10 @@ export class PresetManagerModal extends Modal {
           };
         });
         if (wasActive) {
-          new Notice(`"${preset.label}" was active — switched to Clean up.`);
+          this.deps.feedback.show({
+            intent: 'information',
+            message: `"${preset.label}" was active — switched to Clean up.`,
+          });
         }
         this.render();
       },

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -10,6 +10,7 @@ import type { LlmRouter, LlmRouterCleanupResult } from '../src/llm/router';
 import type { SessionAcceptResult } from '../src/session/session';
 import type { TranscriptRevision } from '../src/session/session-journal';
 import { DEFAULT_PLUGIN_SETTINGS, type PluginSettings } from '../src/settings/plugin-settings';
+import type { UserFeedback } from '../src/shared/user-feedback';
 import type {
   ContextWindow,
   QueueBackpressureTier,
@@ -246,14 +247,16 @@ describe('DictationSessionController', () => {
     captureStream.start.mockRejectedValueOnce(
       Object.assign(new Error('Permission denied'), { name: 'NotAllowedError' }),
     );
-    const notice = vi.fn();
-    const controller = createController({ captureStream, notice });
+    const show = vi.fn();
+    const controller = createController({ captureStream, feedback: { show } });
 
     await controller.startDictation();
 
-    expect(notice).toHaveBeenCalledWith(formatMicrophonePermissionDeniedMessage());
-    expect(notice).not.toHaveBeenCalledWith(
-      expect.stringContaining('Failed to start the dictation session'),
+    expect(show).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: 'action-required',
+        message: formatMicrophonePermissionDeniedMessage(),
+      }),
     );
   });
 
@@ -263,19 +266,13 @@ describe('DictationSessionController', () => {
       Object.assign(new Error('Requested device not found'), { name: 'NotFoundError' }),
     );
     const logger = new FakeLogger();
-    const notice = vi.fn();
-    const controller = createController({ captureStream, logger, notice });
+    const show = vi.fn();
+    const controller = createController({ captureStream, feedback: { show }, logger });
 
     await controller.startDictation();
 
-    expect(notice).toHaveBeenCalledWith(expect.stringContaining('No microphone detected'));
-    expect(notice).not.toHaveBeenCalledWith(
-      expect.stringContaining('Failed to start the dictation session'),
-    );
-    expect(logger.warn).toHaveBeenCalledWith(
-      'session',
-      'Failed to start the dictation session',
-      'Requested device not found',
+    expect(show).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('No microphone detected') }),
     );
     expect(logger.error).not.toHaveBeenCalled();
   });
@@ -284,27 +281,24 @@ describe('DictationSessionController', () => {
     const captureStream = new FakeCaptureStream();
     const logger = new FakeLogger();
     const sidecarConnection = new FakeSidecarConnection();
-    const notice = vi.fn();
+    const show = vi.fn();
     const controller = createController({
       captureStream,
       countAudioInputDevices: async () => 0,
       logger,
-      notice,
+      feedback: { show },
       sidecarConnection,
     });
 
     await controller.startDictation();
 
-    expect(notice).toHaveBeenCalledWith(expect.stringContaining('No microphone detected'));
+    expect(show).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('No microphone detected') }),
+    );
     expect(sidecarConnection.ensureStarted).not.toHaveBeenCalled();
     expect(sidecarConnection.startSession).not.toHaveBeenCalled();
     expect(captureStream.start).not.toHaveBeenCalled();
     expect(controller.getState()).toBe('error');
-    expect(logger.warn).toHaveBeenCalledWith(
-      'session',
-      'Failed to start the dictation session',
-      'No audio input devices found.',
-    );
     expect(logger.error).not.toHaveBeenCalled();
   });
 
@@ -338,7 +332,7 @@ describe('DictationSessionController', () => {
     expect(controller.getState()).toBe('listening');
   });
 
-  it('debug-logs hallucination filter segment edits', async () => {
+  it('debug-logs hallucination filter counts without transcript text', async () => {
     const logger = new FakeLogger();
     const sidecarConnection = new FakeSidecarConnection();
     const controller = createController({ logger, sidecarConnection });
@@ -369,8 +363,14 @@ describe('DictationSessionController', () => {
     sidecarConnection.emit(event);
 
     await vi.waitFor(() => {
-      expect(logger.debug).toHaveBeenCalledWith('session', 'hallucination segment edited', edit);
+      expect(logger.debug).toHaveBeenCalledWith(
+        'session',
+        'hallucination filter adjusted segments',
+        { dropped: 0, edited: 1 },
+      );
     });
+    expect(JSON.stringify(logger.debug.mock.calls)).not.toContain('Gorglosa');
+    expect(JSON.stringify(logger.debug.mock.calls)).not.toContain('Let me join');
   });
 
   it('debug-logs final transcript summaries without logging partial revision summaries', async () => {
@@ -402,11 +402,17 @@ describe('DictationSessionController', () => {
     );
 
     sidecarConnection.emit(transcriptReady(sessionId, 'final', { isFinal: true, revision: 2 }));
+    sidecarConnection.emit(transcriptReady(sessionId, '', { isFinal: true, revision: 3 }));
 
     await vi.waitFor(() => {
-      expect(logger.debug).toHaveBeenCalledWith(
-        'session',
-        'final transcript received (5 chars, 12ms processing)',
+      expect(
+        logger.debug.mock.calls.filter(
+          ([category, message]) =>
+            category === 'session' && String(message).includes('final transcript received'),
+        ),
+      ).toEqual([['session', 'final transcript received (5 chars, 12ms processing)']]);
+      expect(sessions[0]?.acceptTranscript).toHaveBeenCalledWith(
+        expect.objectContaining({ isFinal: true, revision: 3, text: '' }),
       );
     });
   });
@@ -652,6 +658,7 @@ describe('DictationSessionController', () => {
   it('does not accept queued utterances after cancellation, even when capture teardown rejects', async () => {
     const captureStream = new FakeCaptureStream();
     const logger = new FakeLogger();
+    const show = vi.fn();
     const sidecarConnection = new FakeSidecarConnection();
     const sessions: FakeSession[] = [];
     const controller = createController({
@@ -659,6 +666,7 @@ describe('DictationSessionController', () => {
       createSession: (session) => {
         sessions.push(session);
       },
+      feedback: { show },
       logger,
       sidecarConnection,
     });
@@ -698,10 +706,12 @@ describe('DictationSessionController', () => {
     sidecarConnection.emit(transcriptReady(sessionId, 'second utterance'));
 
     await vi.waitFor(() => {
-      expect(logger.error).toHaveBeenCalledWith(
-        'session',
-        'Failed to record the local transcript',
-        expect.any(Error),
+      expect(show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          intent: 'error',
+          key: 'transcript-record-failed',
+          message: 'Could not record the transcript.',
+        }),
       );
     });
     // The rejected capture teardown must not stop cancellation from completing:
@@ -730,8 +740,7 @@ describe('DictationSessionController', () => {
 
   it('contains a fatal note-surface desynchronization once and drops later transcripts', async () => {
     const captureStream = new FakeCaptureStream();
-    const logger = new FakeLogger();
-    const notice = vi.fn();
+    const show = vi.fn();
     const sidecarConnection = new FakeSidecarConnection();
     const sessions: FakeSession[] = [];
     const cleanup = vi.fn(
@@ -755,9 +764,8 @@ describe('DictationSessionController', () => {
           llmPostprocessSkipMinWords: 0,
           selectedModel: createExternalModelSelection(),
         }),
-      logger,
+      feedback: { show },
       llmRouter: createFakeLlmRouter({ cleanup }),
-      notice,
       sidecarConnection,
     });
     const failure: SurfaceDesynchronization = {
@@ -778,16 +786,14 @@ describe('DictationSessionController', () => {
     });
     expect(sidecarConnection.cancelSession).toHaveBeenCalledWith(sessionId);
     expect(captureStream.stop).toHaveBeenCalledOnce();
-    expect(logger.error).toHaveBeenCalledOnce();
-    expect(logger.error).toHaveBeenCalledWith(
-      'session',
-      'dictation note surface desynchronized',
-      failure,
-    );
-    expect(notice).toHaveBeenCalledOnce();
-    expect(notice).toHaveBeenCalledWith(
-      'Dictation stopped because the note changed in a way Local Dictation could not safely track. Start dictation again to continue.',
-    );
+    expect(show).toHaveBeenCalledOnce();
+    expect(show).toHaveBeenCalledWith({
+      cause: failure,
+      intent: 'error',
+      key: 'dictation-surface-desynchronized',
+      message:
+        'Dictation stopped because the note changed in a way Local Dictation could not safely track. Start dictation again to continue.',
+    });
     await vi.waitFor(() => {
       expect(sessions[0]?.acceptTranscript).not.toHaveBeenCalled();
     });
@@ -836,8 +842,7 @@ describe('DictationSessionController', () => {
   });
 
   it('reports a pending fatal desynchronization after the sidecar has already stopped', async () => {
-    const logger = new FakeLogger();
-    const notice = vi.fn();
+    const show = vi.fn();
     const sidecarConnection = new FakeSidecarConnection();
     const sessions: FakeSession[] = [];
     let onSurfaceDesynchronized: ((failure: SurfaceDesynchronization) => void) | undefined;
@@ -855,8 +860,7 @@ describe('DictationSessionController', () => {
           return { kind: 'accepted' };
         });
       },
-      logger,
-      notice,
+      feedback: { show },
       sidecarConnection,
     });
 
@@ -869,20 +873,12 @@ describe('DictationSessionController', () => {
       expect(sessions[0]?.dispose).toHaveBeenCalledOnce();
     });
     expect(sidecarConnection.cancelSession).not.toHaveBeenCalled();
-    expect(logger.error).toHaveBeenCalledOnce();
-    expect(logger.error).toHaveBeenCalledWith(
-      'session',
-      'dictation note surface desynchronized',
-      failure,
-    );
-    expect(notice).toHaveBeenCalledOnce();
-    expect(notice).toHaveBeenCalledWith(
-      'Dictation stopped because the note changed in a way Local Dictation could not safely track. Start dictation again to continue.',
-    );
+    expect(show).toHaveBeenCalledOnce();
+    expect(show).toHaveBeenCalledWith(expect.objectContaining({ cause: failure }));
   });
 
   it('aborts pending provider work when a fatal surface failure arrives after stop', async () => {
-    const notice = vi.fn();
+    const show = vi.fn();
     const sidecarConnection = new FakeSidecarConnection();
     let cleanupSignal: AbortSignal | undefined;
     let resolveCleanup: ((result: LlmRouterCleanupResult) => void) | undefined;
@@ -907,8 +903,8 @@ describe('DictationSessionController', () => {
           llmPostprocessSkipMinWords: 0,
           selectedModel: createExternalModelSelection(),
         }),
+      feedback: { show },
       llmRouter: createFakeLlmRouter({ cleanup }),
-      notice,
       sidecarConnection,
     });
 
@@ -927,7 +923,7 @@ describe('DictationSessionController', () => {
 
     expect(cleanupSignal?.aborted).toBe(true);
     expect(sidecarConnection.cancelSession).not.toHaveBeenCalled();
-    expect(notice).toHaveBeenCalledOnce();
+    expect(show).toHaveBeenCalledOnce();
 
     resolveCleanup?.({ model: 'm', providerId: 'ollama', text: 'ignored' });
     await vi.waitFor(() => {
@@ -938,8 +934,7 @@ describe('DictationSessionController', () => {
 
   it('contains an unexpected projection exception with accurate single-shot notice copy', async () => {
     const captureStream = new FakeCaptureStream();
-    const logger = new FakeLogger();
-    const notice = vi.fn();
+    const show = vi.fn();
     const sidecarConnection = new FakeSidecarConnection();
     const sessions: FakeSession[] = [];
     const controller = createController({
@@ -950,8 +945,7 @@ describe('DictationSessionController', () => {
           throw new RangeError('Invalid change range 4314 to 4314 (in doc of length 4280)');
         });
       },
-      logger,
-      notice,
+      feedback: { show },
       sidecarConnection,
     });
 
@@ -976,16 +970,14 @@ describe('DictationSessionController', () => {
       expect(sidecarConnection.cancelSession).toHaveBeenCalledOnce();
     });
     expect(captureStream.stop).toHaveBeenCalledOnce();
-    expect(logger.error).toHaveBeenCalledOnce();
-    expect(logger.error).toHaveBeenCalledWith(
-      'session',
-      'failed to process transcript',
-      expect.any(RangeError),
-    );
-    expect(notice).toHaveBeenCalledOnce();
-    expect(notice).toHaveBeenCalledWith(
-      'Dictation stopped because Local Dictation could not safely write to the note. Start dictation again to continue.',
-    );
+    expect(show).toHaveBeenCalledOnce();
+    expect(show).toHaveBeenCalledWith({
+      cause: expect.any(RangeError),
+      intent: 'error',
+      key: 'transcript-write-failed',
+      message:
+        'Dictation stopped because Local Dictation could not safely write to the note. Start dictation again to continue.',
+    });
     expect(sessions[0]?.acceptTranscript).toHaveBeenCalledOnce();
   });
 
@@ -1238,13 +1230,13 @@ describe('DictationSessionController', () => {
   it('additive batch treats empty output as nothing to add and says so', async () => {
     const sidecarConnection = new FakeSidecarConnection();
     const sessions: FakeSession[] = [];
-    const notice = vi.fn();
+    const show = vi.fn();
     const onLlmCleanupFailure = vi.fn();
     const controller = createController({
       createSession: (session) => {
         sessions.push(session);
       },
-      notice,
+      feedback: { show },
       getSettings: () =>
         createSettings({
           llmFeaturesEnabled: true,
@@ -1270,7 +1262,10 @@ describe('DictationSessionController', () => {
     });
     expect(sessions[0]?.insertAdjacentToSessionRange).not.toHaveBeenCalled();
     expect(onLlmCleanupFailure).not.toHaveBeenCalled();
-    expect(notice).toHaveBeenCalledWith('LLM transform returned nothing to add.');
+    expect(show).toHaveBeenCalledWith({
+      intent: 'information',
+      message: 'LLM transform returned nothing to add.',
+    });
   });
 
   it('drains pending utterance accepts before the batch read when stop arrives in the same turn', async () => {
@@ -1548,7 +1543,7 @@ describe('DictationSessionController', () => {
     ],
   ] as const)('suppresses misleading %s batch logs and success after result application reports fatal', async (_description, activePresetRef, misleadingWarning) => {
     const logger = new FakeLogger();
-    const notice = vi.fn();
+    const show = vi.fn();
     const onLlmCleanupSuccess = vi.fn();
     const sidecarConnection = new FakeSidecarConnection();
     const sessions: FakeSession[] = [];
@@ -1576,8 +1571,8 @@ describe('DictationSessionController', () => {
           }),
         ),
       }),
+      feedback: { show },
       logger,
-      notice,
       onLlmCleanupSuccess,
       sidecarConnection,
     });
@@ -1614,7 +1609,7 @@ describe('DictationSessionController', () => {
     });
     expect(logger.warn).not.toHaveBeenCalledWith('llm', misleadingWarning);
     expect(onLlmCleanupSuccess).not.toHaveBeenCalled();
-    expect(notice).toHaveBeenCalledOnce();
+    expect(show).toHaveBeenCalledOnce();
   });
 
   it('keeps raw transcript when a batch cleanup fails and reports it', async () => {
@@ -1715,7 +1710,7 @@ describe('DictationSessionController', () => {
   it('cleans up silently when the sidecar rejects capacity as a backstop', async () => {
     const captureStream = new FakeCaptureStream();
     const logger = new FakeLogger();
-    const notice = vi.fn();
+    const show = vi.fn();
     const sidecarConnection = new FakeSidecarConnection();
     const sessions: FakeSession[] = [];
     const controller = createController({
@@ -1724,7 +1719,7 @@ describe('DictationSessionController', () => {
         sessions.push(session);
       },
       logger,
-      notice,
+      feedback: { show },
       sidecarConnection,
     });
 
@@ -1740,7 +1735,7 @@ describe('DictationSessionController', () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(notice).not.toHaveBeenCalled();
+    expect(show).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalled();
     expect(captureStream.stop).toHaveBeenCalledTimes(1);
     await vi.waitFor(() => {
@@ -1751,7 +1746,7 @@ describe('DictationSessionController', () => {
 
   it('drains queued work on queue overload instead of cancelling the session', async () => {
     const captureStream = new FakeCaptureStream();
-    const notice = vi.fn();
+    const show = vi.fn();
     const sidecarConnection = new FakeSidecarConnection();
     const sessions: FakeSession[] = [];
     const controller = createController({
@@ -1759,7 +1754,7 @@ describe('DictationSessionController', () => {
       createSession: (session) => {
         sessions.push(session);
       },
-      notice,
+      feedback: { show },
       sidecarConnection,
     });
 
@@ -1787,7 +1782,9 @@ describe('DictationSessionController', () => {
     // queue the sidecar is still draining.
     expect(sidecarConnection.cancelSession).not.toHaveBeenCalled();
     expect(session.dispose).not.toHaveBeenCalled();
-    expect(notice).toHaveBeenCalledWith(expect.stringContaining('backlog reached capacity'));
+    expect(show).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('backlog reached capacity') }),
+    );
     expect(controller.getState()).toBe('idle');
 
     // Already-accepted utterances still land while the queue drains. On the
@@ -2024,7 +2021,7 @@ function createController({
   llmRouter = createFakeLlmRouter(),
   getSettings = () => createSettings({ selectedModel: createExternalModelSelection() }),
   logger = new FakeLogger(),
-  notice = vi.fn(),
+  feedback = { show: vi.fn() },
   sidecarConnection = new FakeSidecarConnection(),
   onLlmCleanupFailure,
   onLlmCleanupSuccess,
@@ -2036,7 +2033,7 @@ function createController({
   getSettings?: () => PluginSettings;
   llmRouter?: LlmRouter;
   logger?: FakeLogger;
-  notice?: (message: string) => void;
+  feedback?: Pick<UserFeedback, 'show'>;
   onLlmCleanupFailure?: (failure: LlmCleanupFailure) => void;
   onLlmCleanupSuccess?: () => void;
   sidecarConnection?: FakeSidecarConnection;
@@ -2051,9 +2048,9 @@ function createController({
       return session;
     },
     createLlmRouter: () => llmRouter,
+    feedback,
     getSettings,
     logger,
-    notice,
     ...(onLlmCleanupFailure !== undefined ? { onLlmCleanupFailure } : {}),
     ...(onLlmCleanupSuccess !== undefined ? { onLlmCleanupSuccess } : {}),
     onModelMissing: vi.fn(),

--- a/test/llm-routing-controls.test.ts
+++ b/test/llm-routing-controls.test.ts
@@ -13,15 +13,17 @@ import { LlmRoutingControls } from '../src/ui/llm-routing-controls';
 import { createFakeLlmProvider } from './fixtures/llm';
 
 function createControls(overrides: Partial<PluginSettings> = {}, openRouterApiKey = '') {
+  const show = vi.fn();
   const requestRerender = vi.fn();
   const controls = new LlmRoutingControls({
     app: {} as App,
+    feedback: { show },
     getOpenRouterApiKey: () => openRouterApiKey,
     getSettings: () => ({ ...DEFAULT_PLUGIN_SETTINGS, ...overrides }),
     persist: vi.fn(async () => {}),
     requestRerender,
   });
-  return { controls, requestRerender };
+  return { controls, requestRerender, show };
 }
 
 async function flushAsyncWork(): Promise<void> {
@@ -46,6 +48,18 @@ describe('LlmRoutingControls.refreshActiveProviders', () => {
     controls.refreshActiveProviders();
     await flushAsyncWork();
     expect(listModels).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps provider refresh failures inline without also showing a notice', async () => {
+    createProviderMock.mockReturnValue(
+      createFakeLlmProvider({ listModels: vi.fn().mockRejectedValue(new Error('offline')) }),
+    );
+    const { controls, requestRerender, show } = createControls();
+
+    await controls.refreshActiveProviders();
+
+    expect(requestRerender).toHaveBeenCalled();
+    expect(show).not.toHaveBeenCalled();
   });
 
   it('does not refetch a provider that already loaded successfully', async () => {

--- a/test/plugin-logger.test.ts
+++ b/test/plugin-logger.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createPluginLogger } from '../src/shared/plugin-logger';
+
+describe('plugin logger', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('gates debug records while preserving warnings and errors outside developer mode', () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let developerMode = false;
+    const logger = createPluginLogger(() => developerMode);
+    const cause = new Error('network failed');
+
+    logger.debug('installer', 'download started');
+    logger.warn('installer', 'download is slow');
+    logger.error('installer', 'download failed', cause);
+
+    expect(debug).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith('[Local Dictation] [installer]', 'download is slow');
+    expect(error).toHaveBeenCalledWith('[Local Dictation] [installer]', 'download failed', cause);
+
+    developerMode = true;
+    logger.debug('installer', 'retry started');
+
+    expect(debug).toHaveBeenCalledWith('[Local Dictation] [installer]', 'retry started');
+  });
+});

--- a/test/sidecar-connection.test.ts
+++ b/test/sidecar-connection.test.ts
@@ -4,6 +4,7 @@ import {
   encodeJsonFrame,
   FRAME_HEADER_LENGTH,
   type HealthOkEvent,
+  MAX_FRAME_PAYLOAD_BYTES,
   type ModelInstallUpdateEvent,
   type SidecarEvent,
   type TranscriptReadyEvent,
@@ -61,6 +62,14 @@ class FakeSidecarProcess {
   exit(code: number | null = 1, signal: NodeJS.Signals | null = null): void {
     this.running = false;
     this.handlers?.onExit(code, signal);
+  }
+
+  stderr(line: string): void {
+    this.handlers?.onStderrLine(line);
+  }
+
+  stdout(chunk: Uint8Array): void {
+    this.handlers?.onStdoutChunk(chunk);
   }
 }
 
@@ -319,7 +328,53 @@ describe('SidecarConnection', () => {
     expect(process.writtenFrames).toHaveLength(0);
   });
 
-  it('logs final transcript events without logging partial transcript revisions', () => {
+  it('does not mirror routine session lifecycle or transcript events into protocol logs', () => {
+    const logger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+    };
+    const { connection, process } = createHarness(5_000, logger);
+    const listener = vi.fn();
+    connection.subscribe(listener);
+
+    process.deliver({ mode: 'always_on', sessionId: 'session-1', type: 'session_started' });
+    process.deliver({ sessionId: 'session-1', state: 'listening', type: 'session_state_changed' });
+    process.deliver(transcriptReadyEvent({ isFinal: false, revision: 1 }));
+    process.deliver(transcriptReadyEvent({ isFinal: true, revision: 2, text: 'hello world' }));
+    process.deliver({ reason: 'user_stop', sessionId: 'session-1', type: 'session_stopped' });
+
+    expect(listener).toHaveBeenCalledTimes(5);
+    expect(listener).toHaveBeenLastCalledWith({
+      reason: 'user_stop',
+      sessionId: 'session-1',
+      type: 'session_stopped',
+    });
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+
+  it('logs fatal protocol corruption and stops the sidecar', () => {
+    const logger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+    };
+    const { process } = createHarness(5_000, logger);
+    const corruptHeader = new Uint8Array(FRAME_HEADER_LENGTH);
+    corruptHeader[0] = 1;
+    new DataView(corruptHeader.buffer).setUint32(1, MAX_FRAME_PAYLOAD_BYTES + 1, true);
+
+    process.stdout(corruptHeader);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'protocol',
+      'fatal sidecar stream error; restarting',
+      expect.any(Error),
+    );
+    expect(process.stopCalls).toBe(1);
+  });
+
+  it('keeps native warnings, system-audio diagnostics, and unexpected exits observable', () => {
     const logger = {
       debug: vi.fn(),
       error: vi.fn(),
@@ -327,13 +382,18 @@ describe('SidecarConnection', () => {
     };
     const { process } = createHarness(5_000, logger);
 
-    process.deliver(transcriptReadyEvent({ isFinal: false, revision: 1 }));
-    process.deliver(transcriptReadyEvent({ isFinal: true, revision: 2, text: 'hello world' }));
+    process.stderr('system-audio diagnostics: received=42 silent=0 dropped=0 mixed=42 mic_only=0');
+    process.stderr('error: native worker failed');
+    process.exit(9, null);
 
-    expect(logger.debug).toHaveBeenCalledTimes(1);
     expect(logger.debug).toHaveBeenCalledWith(
-      'protocol',
-      'event: transcript_ready (session-1, final, 11 chars)',
+      'sidecar',
+      'sidecar: system-audio diagnostics: received=42 silent=0 dropped=0 mixed=42 mic_only=0',
+    );
+    expect(logger.warn).toHaveBeenCalledWith('sidecar', 'sidecar: error: native worker failed');
+    expect(logger.warn).toHaveBeenCalledWith(
+      'sidecar',
+      'sidecar process exited unexpectedly (code: 9, signal: null)',
     );
   });
 });

--- a/test/sidecar-install-manager.test.ts
+++ b/test/sidecar-install-manager.test.ts
@@ -27,6 +27,10 @@ beforeEach(() => {
 
 function defaultInstallOptions() {
   return {
+    failureFeedback: {
+      isInlineVisible: () => true,
+      message: 'The speech engine install failed. Reopen setup or Settings to retry.',
+    },
     onInstalled: vi.fn(async () => {}),
     pluginDirectory: '/plugin',
     successNotice: 'Installed.',
@@ -213,6 +217,10 @@ describe('SidecarInstallManager', () => {
 
     manager.installBatch({
       ...defaultInstallOptions(),
+      failureFeedback: {
+        isInlineVisible: () => false,
+        message: 'The speech engine update failed. Reopen Settings to retry.',
+      },
       onInstalled,
       variants: ['cpu', 'cuda'],
     });
@@ -221,7 +229,12 @@ describe('SidecarInstallManager', () => {
     expect(installSidecarMock).toHaveBeenCalledTimes(2);
     expect(onInstalled).not.toHaveBeenCalled();
     expect(manager.getState().lastError).toBe('CUDA download failed');
-    expect(show).not.toHaveBeenCalled();
+    expect(show).toHaveBeenCalledWith({
+      cause: expect.any(Error),
+      intent: 'error',
+      key: 'sidecar-install-failed',
+      message: 'The speech engine update failed. Reopen Settings to retry.',
+    });
   });
 
   it('deduplicates variants and rejects an empty batch', async () => {
@@ -247,13 +260,19 @@ describe('SidecarInstallManager', () => {
   it('records install failures and clears active state', async () => {
     installSidecarMock.mockRejectedValueOnce(new Error('network failed'));
     const show = vi.fn();
-    const manager = new SidecarInstallManager({ feedback: { show } });
+    const logger = { debug: vi.fn(), error: vi.fn(), warn: vi.fn() };
+    const manager = new SidecarInstallManager({ feedback: { show }, logger });
 
     manager.install(defaultInstallOptions());
     await vi.waitFor(() => expect(manager.getState().activeInstall).toBeNull());
 
     expect(manager.getState().lastError).toBe('network failed');
     expect(show).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      'installer',
+      'sidecar install failed',
+      expect.any(Error),
+    );
   });
 
   it('treats AbortError as a user-initiated cancel, not a failure', async () => {

--- a/test/sidecar-install-manager.test.ts
+++ b/test/sidecar-install-manager.test.ts
@@ -50,7 +50,7 @@ function successfulInstallResult(variant: 'cpu' | 'cuda' = 'cpu') {
 describe('SidecarInstallManager', () => {
   it('rejects concurrent installs while one is in flight', () => {
     installSidecarMock.mockImplementationOnce(() => new Promise(() => {}));
-    const manager = new SidecarInstallManager({ notice: vi.fn() });
+    const manager = new SidecarInstallManager({ feedback: { show: vi.fn() } });
 
     manager.install(defaultInstallOptions());
 
@@ -61,7 +61,7 @@ describe('SidecarInstallManager', () => {
 
   it('aborts the installer signal when cancel is called and marks phase canceling', () => {
     installSidecarMock.mockImplementationOnce(() => new Promise(() => {}));
-    const manager = new SidecarInstallManager({ notice: vi.fn() });
+    const manager = new SidecarInstallManager({ feedback: { show: vi.fn() } });
 
     manager.install(defaultInstallOptions());
     const captured = installSidecarMock.mock.calls[0]?.[0] as InstallSidecarOptions | undefined;
@@ -73,15 +73,15 @@ describe('SidecarInstallManager', () => {
 
   it('clears state, invokes the onInstalled hook, and shows the success notice', async () => {
     installSidecarMock.mockResolvedValueOnce(successfulInstallResult());
-    const notice = vi.fn();
+    const show = vi.fn();
     const onInstalled = vi.fn(async () => {});
-    const manager = new SidecarInstallManager({ notice });
+    const manager = new SidecarInstallManager({ feedback: { show } });
 
     manager.install({ ...defaultInstallOptions(), onInstalled });
     await vi.waitFor(() => expect(manager.getState().activeInstall).toBeNull());
 
     expect(onInstalled).toHaveBeenCalledOnce();
-    expect(notice).toHaveBeenCalledWith('Installed.');
+    expect(show).toHaveBeenCalledWith({ intent: 'success', message: 'Installed.' });
     expect(manager.getState().lastError).toBeNull();
   });
 
@@ -89,10 +89,10 @@ describe('SidecarInstallManager', () => {
     installSidecarMock
       .mockResolvedValueOnce(successfulInstallResult('cpu'))
       .mockResolvedValueOnce(successfulInstallResult('cuda'));
-    const notice = vi.fn();
+    const show = vi.fn();
     const firstInstalled = vi.fn(async () => {});
     const secondInstalled = vi.fn(async () => {});
-    const manager = new SidecarInstallManager({ notice });
+    const manager = new SidecarInstallManager({ feedback: { show } });
 
     manager.install({
       ...defaultInstallOptions(),
@@ -113,8 +113,8 @@ describe('SidecarInstallManager', () => {
     expect(installSidecarMock).toHaveBeenCalledTimes(2);
     expect(firstInstalled).toHaveBeenCalledOnce();
     expect(secondInstalled).toHaveBeenCalledOnce();
-    expect(notice).toHaveBeenNthCalledWith(1, 'CPU installed.');
-    expect(notice).toHaveBeenNthCalledWith(2, 'CUDA installed.');
+    expect(show).toHaveBeenNthCalledWith(1, { intent: 'success', message: 'CPU installed.' });
+    expect(show).toHaveBeenNthCalledWith(2, { intent: 'success', message: 'CUDA installed.' });
     expect(manager.getState().lastError).toBeNull();
   });
 
@@ -122,10 +122,10 @@ describe('SidecarInstallManager', () => {
     installSidecarMock
       .mockResolvedValueOnce(successfulInstallResult('cpu'))
       .mockResolvedValueOnce(successfulInstallResult('cuda'));
-    const notice = vi.fn();
+    const show = vi.fn();
     const onInstalled = vi.fn(async () => {});
     const onVariantInstalled = vi.fn(async () => {});
-    const manager = new SidecarInstallManager({ notice });
+    const manager = new SidecarInstallManager({ feedback: { show } });
 
     manager.installBatch({
       ...defaultInstallOptions(),
@@ -143,8 +143,8 @@ describe('SidecarInstallManager', () => {
     expect(onVariantInstalled).toHaveBeenCalledOnce();
     expect(onVariantInstalled).toHaveBeenCalledWith('cpu');
     expect(onInstalled).toHaveBeenCalledOnce();
-    expect(notice).toHaveBeenCalledOnce();
-    expect(notice).toHaveBeenCalledWith('Sidecars updated.');
+    expect(show).toHaveBeenCalledOnce();
+    expect(show).toHaveBeenCalledWith({ intent: 'success', message: 'Sidecars updated.' });
   });
 
   it('continues the batch when an intermediate restart fails', async () => {
@@ -153,7 +153,7 @@ describe('SidecarInstallManager', () => {
       .mockResolvedValueOnce(successfulInstallResult('cuda'));
     const logger = { debug: vi.fn(), error: vi.fn(), warn: vi.fn() };
     const onInstalled = vi.fn(async () => {});
-    const manager = new SidecarInstallManager({ logger, notice: vi.fn() });
+    const manager = new SidecarInstallManager({ feedback: { show: vi.fn() }, logger });
 
     manager.installBatch({
       ...defaultInstallOptions(),
@@ -182,7 +182,7 @@ describe('SidecarInstallManager', () => {
           resolveCpu = resolve;
         }),
     );
-    const manager = new SidecarInstallManager({ notice: vi.fn() });
+    const manager = new SidecarInstallManager({ feedback: { show: vi.fn() } });
 
     manager.installBatch({
       ...defaultInstallOptions(),
@@ -207,9 +207,9 @@ describe('SidecarInstallManager', () => {
     installSidecarMock
       .mockResolvedValueOnce(successfulInstallResult('cpu'))
       .mockRejectedValueOnce(new Error('CUDA download failed'));
-    const notice = vi.fn();
+    const show = vi.fn();
     const onInstalled = vi.fn(async () => {});
-    const manager = new SidecarInstallManager({ notice });
+    const manager = new SidecarInstallManager({ feedback: { show } });
 
     manager.installBatch({
       ...defaultInstallOptions(),
@@ -221,12 +221,12 @@ describe('SidecarInstallManager', () => {
     expect(installSidecarMock).toHaveBeenCalledTimes(2);
     expect(onInstalled).not.toHaveBeenCalled();
     expect(manager.getState().lastError).toBe('CUDA download failed');
-    expect(notice).toHaveBeenCalledWith('Sidecar install failed: CUDA download failed');
+    expect(show).not.toHaveBeenCalled();
   });
 
   it('deduplicates variants and rejects an empty batch', async () => {
     installSidecarMock.mockResolvedValueOnce(successfulInstallResult('cpu'));
-    const manager = new SidecarInstallManager({ notice: vi.fn() });
+    const manager = new SidecarInstallManager({ feedback: { show: vi.fn() } });
 
     expect(() =>
       manager.installBatch({
@@ -246,26 +246,29 @@ describe('SidecarInstallManager', () => {
 
   it('records install failures and clears active state', async () => {
     installSidecarMock.mockRejectedValueOnce(new Error('network failed'));
-    const notice = vi.fn();
-    const manager = new SidecarInstallManager({ notice });
+    const show = vi.fn();
+    const manager = new SidecarInstallManager({ feedback: { show } });
 
     manager.install(defaultInstallOptions());
     await vi.waitFor(() => expect(manager.getState().activeInstall).toBeNull());
 
     expect(manager.getState().lastError).toBe('network failed');
-    expect(notice).toHaveBeenCalledWith('Sidecar install failed: network failed');
+    expect(show).not.toHaveBeenCalled();
   });
 
   it('treats AbortError as a user-initiated cancel, not a failure', async () => {
     const abortError = Object.assign(new Error('aborted'), { name: 'AbortError' });
     installSidecarMock.mockRejectedValueOnce(abortError);
-    const notice = vi.fn();
-    const manager = new SidecarInstallManager({ notice });
+    const show = vi.fn();
+    const manager = new SidecarInstallManager({ feedback: { show } });
 
     manager.install(defaultInstallOptions());
     await vi.waitFor(() => expect(manager.getState().activeInstall).toBeNull());
 
-    expect(notice).toHaveBeenCalledWith('Sidecar install cancelled.');
+    expect(show).toHaveBeenCalledWith({
+      intent: 'information',
+      message: 'Sidecar install cancelled.',
+    });
     expect(manager.getState().lastError).toBeNull();
   });
 });

--- a/test/sidecar-install-manager.test.ts
+++ b/test/sidecar-install-manager.test.ts
@@ -207,23 +207,32 @@ describe('SidecarInstallManager', () => {
     await vi.waitFor(() => expect(installSidecarMock).toHaveBeenCalledTimes(2));
   });
 
-  it('stops a batch after the failing variant without running final initialization', async () => {
-    installSidecarMock
-      .mockResolvedValueOnce(successfulInstallResult('cpu'))
-      .mockRejectedValueOnce(new Error('CUDA download failed'));
+  it('surfaces a batch failure when its inline owner closes before the failing variant', async () => {
+    const cudaFailure: { reject?: (error: Error) => void } = {};
+    installSidecarMock.mockResolvedValueOnce(successfulInstallResult('cpu')).mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          cudaFailure.reject = reject;
+        }),
+    );
     const show = vi.fn();
     const onInstalled = vi.fn(async () => {});
     const manager = new SidecarInstallManager({ feedback: { show } });
+    let inlineVisible = true;
 
     manager.installBatch({
       ...defaultInstallOptions(),
       failureFeedback: {
-        isInlineVisible: () => false,
+        isInlineVisible: () => inlineVisible,
         message: 'The speech engine update failed. Reopen Settings to retry.',
       },
       onInstalled,
       variants: ['cpu', 'cuda'],
     });
+    await vi.waitFor(() => expect(installSidecarMock).toHaveBeenCalledTimes(2));
+
+    inlineVisible = false;
+    cudaFailure.reject?.(new Error('CUDA download failed'));
     await vi.waitFor(() => expect(manager.getState().activeInstall).toBeNull());
 
     expect(installSidecarMock).toHaveBeenCalledTimes(2);

--- a/test/user-feedback.test.ts
+++ b/test/user-feedback.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createUserFeedback,
+  type FeedbackPresentation,
+  type FeedbackPresenter,
+} from '../src/shared/user-feedback';
+
+function createHarness(): {
+  feedback: ReturnType<typeof createUserFeedback>;
+  logger: {
+    debug: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+  };
+  presentations: FeedbackPresentation[];
+  dismissals: Array<ReturnType<typeof vi.fn>>;
+} {
+  const presentations: FeedbackPresentation[] = [];
+  const dismissals: Array<ReturnType<typeof vi.fn>> = [];
+  const presenter: FeedbackPresenter = {
+    present(presentation) {
+      presentations.push(presentation);
+      const dismiss = vi.fn();
+      dismissals.push(dismiss);
+      return { dismiss };
+    },
+  };
+  const logger = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  return {
+    dismissals,
+    feedback: createUserFeedback({ logger, presenter }),
+    logger,
+    presentations,
+  };
+}
+
+describe('user feedback', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ['information', 5_000, 'debug'],
+    ['success', 4_000, 'debug'],
+    ['warning', 8_000, 'warn'],
+    ['error', 10_000, 'error'],
+    ['action-required', 0, 'warn'],
+  ] as const)('maps %s feedback to its presentation and log policy', (intent, durationMs, level) => {
+    const { feedback, logger, presentations } = createHarness();
+
+    feedback.show({ intent, message: 'Speech engine needs attention.' });
+
+    expect(presentations).toEqual([
+      expect.objectContaining({
+        durationMs,
+        message: 'Local Dictation: Speech engine needs attention.',
+      }),
+    ]);
+    expect(logger[level]).toHaveBeenCalledWith(
+      'feedback',
+      `${intent}: Speech engine needs attention.`,
+    );
+  });
+
+  it('keeps a technical cause out of user copy while retaining it in the durable log', () => {
+    const { feedback, logger, presentations } = createHarness();
+    const cause = new Error('native process exited with code 7');
+
+    feedback.show({ cause, intent: 'error', message: 'The speech engine stopped.' });
+
+    expect(presentations[0]?.message).toBe('Local Dictation: The speech engine stopped.');
+    expect(logger.error).toHaveBeenCalledWith(
+      'feedback',
+      'error: The speech engine stopped.',
+      cause,
+    );
+  });
+
+  it('does not add a second product prefix to already branded copy', () => {
+    const { feedback, presentations } = createHarness();
+
+    feedback.show({ intent: 'warning', message: 'Local Dictation is unavailable.' });
+
+    expect(presentations[0]?.message).toBe('Local Dictation is unavailable.');
+  });
+
+  it('replaces an active keyed notice instead of stacking it', () => {
+    const { dismissals, feedback, presentations } = createHarness();
+
+    feedback.show({ intent: 'warning', key: 'sidecar-startup', message: 'First failure.' });
+    feedback.show({ intent: 'warning', key: 'sidecar-startup', message: 'Second failure.' });
+
+    expect(dismissals[0]).toHaveBeenCalledOnce();
+    expect(presentations).toHaveLength(2);
+  });
+
+  it('releases a transient keyed handle when its presentation duration elapses', () => {
+    vi.useFakeTimers();
+    const { dismissals, feedback } = createHarness();
+
+    feedback.show({ intent: 'warning', key: 'sidecar-startup', message: 'First failure.' });
+    vi.advanceTimersByTime(8_000);
+    feedback.show({ intent: 'warning', key: 'sidecar-startup', message: 'Later failure.' });
+
+    expect(dismissals[0]).not.toHaveBeenCalled();
+  });
+
+  it('dismisses an actionable notice before invoking its action', () => {
+    const { dismissals, feedback, presentations } = createHarness();
+    const run = vi.fn();
+
+    feedback.show({
+      action: { label: 'Update speech engine', run },
+      intent: 'action-required',
+      key: 'sidecar-version-drift',
+      message: 'The installed speech engine is out of date.',
+    });
+    presentations[0]?.action?.run();
+
+    expect(dismissals[0]).toHaveBeenCalledOnce();
+    expect(run).toHaveBeenCalledOnce();
+    expect(dismissals[0]?.mock.invocationCallOrder[0]).toBeLessThan(
+      run.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+  });
+});


### PR DESCRIPTION
Closes #214.

## Summary

Local Dictation currently mirrors routine sidecar protocol envelopes into the console and constructs Obsidian notices throughout unrelated UI and service modules. This change makes information delivery one cohesive subsystem: the controller owns meaningful session diagnostics, and one typed feedback boundary owns notice presentation plus its durable log record.

The branch is rebased onto current `main`, including #221's stale-note-surface containment. That terminal failure now uses the shared feedback boundary while retaining its single-shot cancellation behavior.

## Decisions

- Keep the existing developer-mode setting as the only debug gate; do not add a trace setting.
- Remove routine protocol start/state/stop/final mirroring from `SidecarConnection`.
- Keep one controller-owned summary for each non-empty final transcript, with character count and processing duration; omit empty finals.
- Preserve fatal protocol parsing, unexpected sidecar exits, native warnings, system-audio delivery diagnostics, acceleration fallback, and install/provider failures.
- Route every user notice through one typed feedback service with `information`, `success`, `warning`, `error`, and `action-required` intents.
- Map information/success logs to developer-gated debug output; warnings/action-required to warning; errors to error.
- Keep technical causes in logs without placing unreviewed raw exception text in user-facing copy.
- Use intent-based default durations: ordinary feedback is transient; action-required feedback may persist.
- Let keyed feedback replace an active notice rather than stack. Release transient bookkeeping after its display window and dismiss actionable feedback before running its action.
- Keep the sidecar-version drift notice persistent and actionable.
- Treat inline modal/settings failures as authoritative while their owning surface remains visible.
- If a sidecar install continues after its modal closes and then fails, emit one keyed error notice that directs the user back to setup/Settings; retain the detailed error in manager state for the retry surface.
- Make the product prefix idempotent so migrated copy is not double branded.
- Allow Obsidian `Notice` construction only in the presentation adapter. ESLint blocks named imports, direct construction, and namespace construction elsewhere.

## Review follow-ups

- Confirmed and regression-tested that only `debug` is developer-gated. `warn` and `error`, including error-intent causes, are emitted unconditionally when developer mode is off.
- Covered the reported walk-away case: a multi-variant install can lose its inline owner between variants; a later failure now produces one keyed error notice instead of becoming silent.
- Preserved the no-duplicate-toast rule while an install modal is open: the modal renders the failure inline and the installer writes one error record.
- Integrated #221's fatal note-surface and unexpected projection failures into the feedback boundary without duplicating logs/notices or weakening its single-flight cancellation guarantees.

## Verification

Completed locally on the rebased branch:

- Focused logger/feedback/controller/installer suite: 4 files, 68 tests passed.
- Detached multi-variant installer regression: 1 file, 11 tests passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed (Biome's existing schema-version informational message only).
- `npm run lint:obsidian` — passed with the pre-existing declarative SettingsTab search warning only.
- `npm run check:frontend` — 53 files / 680 tests passed and the production bundle built.
- `git diff --check origin/main...HEAD` — passed.
- Direct Notice audit — only the authorized adapter imports and constructs `Notice`.

Representative capture accounting remains:

- 474 total lines inspected.
- 197 routine protocol entries removed by ownership change.
- 3 empty controller final summaries removed.
- 53 non-empty controller final summaries retained once.
- The stale-anchor RangeError cause is now fixed on `main` by #221 and its terminal feedback is integrated here.

## Review status

Fresh independent reviews completed against `origin/main...7a33bc7` after the rebase and review follow-ups:

- Standards: clean, 0 findings.
- Spec (#214 plus the latest owner follow-up): clean, 0 findings.

All GitHub CI and CodeQL jobs are green on the reviewed head. Ready for maintainer review.

## Scope

This PR changes information delivery and integrates the already-merged stale-surface terminal feedback. It does not redesign settings/sidebar/ribbon UI, add persisted logs, change speech recognition or transcript rendering, or implement navigation pinning.
