### PR TITLE
Contain stale note-surface failures

### DIFF
--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -9,7 +9,7 @@ import {
   formatSystemAudioErrorMessage,
   formatSystemAudioSidecarErrorMessage,
 } from '../audio/system-audio-permission-message';
-import type { NotePlacementOptions } from '../editor/note-surface';
+import type { NotePlacementOptions, SurfaceDesynchronization } from '../editor/note-surface';
 import {
   type LlmPostprocessMode,
   type LlmPresetOutput,
@@ -18,7 +18,7 @@ import {
 } from '../llm/presets';
 import { type LlmCleanupFailure, type LlmProviderId, ProviderError } from '../llm/provider';
 import type { LlmRouter } from '../llm/router';
-import type { Session } from '../session/session';
+import type { Session, SessionAcceptResult } from '../session/session';
 import type { StageId, StageOutcome, TranscriptRevision } from '../session/session-journal';
 import type { PluginSettings, SmartParagraphPauseSettings } from '../settings/plugin-settings';
 import { formatErrorMessage } from '../shared/format-utils';
@@ -100,6 +100,7 @@ interface ManagedSession {
   // in final-event order. Partials bypass it and project immediately.
   cleanupChain: Promise<void>;
   cleanupAbortControllers: Set<AbortController>;
+  fatalTranscriptFailureReported: boolean;
   llmFailureLogged: boolean;
   pendingTranscriptWork: Set<Promise<void>>;
   phase: SessionPhase;
@@ -114,6 +115,7 @@ interface DictationSessionControllerDependencies {
     callbacks: {
       onLockedNoteClosed: () => void;
       onLockedNoteDeleted: () => void;
+      onSurfaceDesynchronized: (failure: SurfaceDesynchronization) => void;
     };
     placement: NotePlacementOptions;
     rendererOptions: TranscriptRenderOptions;
@@ -144,9 +146,14 @@ interface DictationSessionControllerDependencies {
 
 const ANCHOR_VISIBLE_DELAY_MS = 2500;
 const MAX_CONTROLLER_SESSIONS = 5;
+const SURFACE_DESYNCHRONIZED_NOTICE =
+  'Dictation stopped because the note changed in a way Local Dictation could not safely track. Start dictation again to continue.';
+const TRANSCRIPT_WRITE_FAILURE_NOTICE =
+  'Dictation stopped because Local Dictation could not safely write to the note. Start dictation again to continue.';
 
 export class DictationSessionController {
   private activeSessionId: string | null = null;
+  private readonly cancellationPromises = new Map<string, Promise<void>>();
   private readonly releaseSidecarSubscription: () => void;
   private readonly sessions = new Map<string, ManagedSession>();
   private state: DictationControllerState = 'idle';
@@ -265,6 +272,14 @@ export class DictationSessionController {
           onLockedNoteDeleted: () => {
             this.cancelOnLockedNoteEvent(sessionId, 'deleted');
           },
+          onSurfaceDesynchronized: (failure) => {
+            this.cancelOnFatalTranscriptFailure(
+              sessionId,
+              'dictation note surface desynchronized',
+              failure,
+              SURFACE_DESYNCHRONIZED_NOTICE,
+            );
+          },
         },
         placement: { anchor: snapshot.dictationAnchor },
         rendererOptions: {
@@ -283,6 +298,7 @@ export class DictationSessionController {
       anchorTimerId: null,
       cleanupChain: Promise.resolve(),
       cleanupAbortControllers: new Set(),
+      fatalTranscriptFailureReported: false,
       llmFailureLogged: false,
       pendingTranscriptWork: new Set(),
       phase: 'starting',
@@ -418,13 +434,40 @@ export class DictationSessionController {
     }
   }
 
-  private async cancelSession(sessionId: string): Promise<void> {
-    const entry = this.sessions.get(sessionId);
-    if (entry !== undefined) {
-      entry.phase = 'cancelling';
-      this.abortProviderCleanups(entry);
+  private cancelSession(sessionId: string): Promise<void> {
+    const inFlightCancellation = this.cancellationPromises.get(sessionId);
+    if (inFlightCancellation !== undefined) {
+      return inFlightCancellation;
     }
 
+    const entry = this.sessions.get(sessionId);
+    if (entry === undefined) {
+      return Promise.resolve();
+    }
+
+    // Establish the terminal state before capture teardown yields. Every caller
+    // then joins the same promise, so concurrent failure sources cannot send
+    // duplicate cancellation commands to the sidecar.
+    entry.phase = 'cancelling';
+    this.abortProviderCleanups(entry);
+    const cancellation = Promise.resolve().then(() => this.completeSessionCancellation(sessionId));
+    this.cancellationPromises.set(sessionId, cancellation);
+    void cancellation.then(
+      () => {
+        if (this.cancellationPromises.get(sessionId) === cancellation) {
+          this.cancellationPromises.delete(sessionId);
+        }
+      },
+      () => {
+        if (this.cancellationPromises.get(sessionId) === cancellation) {
+          this.cancellationPromises.delete(sessionId);
+        }
+      },
+    );
+    return cancellation;
+  }
+
+  private async completeSessionCancellation(sessionId: string): Promise<void> {
     await this.clearActiveSession(sessionId);
 
     try {
@@ -658,7 +701,7 @@ export class DictationSessionController {
 
   private async handleTranscriptReady(event: TranscriptReadyEvent): Promise<void> {
     const entry = this.sessions.get(event.sessionId);
-    if (entry === undefined) {
+    if (entry === undefined || entry.fatalTranscriptFailureReported) {
       return;
     }
 
@@ -667,10 +710,15 @@ export class DictationSessionController {
     try {
       await work;
     } catch (error) {
-      // processTranscriptReady handles cleanup failures itself; this guards the
-      // rare case where acceptTranscript throws, so it cannot escape as an
-      // unhandled rejection from the void-ed sidecar event handler.
-      this.dependencies.logger?.error('session', 'failed to process transcript', error);
+      // processTranscriptReady handles cleanup failures itself. A projection
+      // exception means this session can no longer write safely, so contain it
+      // exactly like a typed surface failure instead of retrying every revision.
+      this.cancelOnFatalTranscriptFailure(
+        event.sessionId,
+        'failed to process transcript',
+        error,
+        TRANSCRIPT_WRITE_FAILURE_NOTICE,
+      );
     } finally {
       entry.pendingTranscriptWork.delete(work);
     }
@@ -724,10 +772,29 @@ export class DictationSessionController {
     // 'stopped' must NOT be gated — the sidecar can deliver the final
     // transcript_ready and session_stopped in one I/O chunk, and the stop
     // path drains these in-flight accepts after the phase flips.
-    if (revision === null || !this.sessions.has(sessionId) || entry.phase === 'cancelling') {
+    if (
+      revision === null ||
+      !this.sessions.has(sessionId) ||
+      entry.phase === 'cancelling' ||
+      entry.fatalTranscriptFailureReported
+    ) {
       return;
     }
-    const result = entry.session.acceptTranscript(revision);
+    let result: SessionAcceptResult;
+    try {
+      result = entry.session.acceptTranscript(revision);
+    } catch (error) {
+      this.cancelOnFatalTranscriptFailure(
+        sessionId,
+        'failed to process transcript',
+        error,
+        TRANSCRIPT_WRITE_FAILURE_NOTICE,
+      );
+      return;
+    }
+    if (entry.fatalTranscriptFailureReported) {
+      return;
+    }
     if (result.kind === 'rejected') {
       this.handleError('Failed to record the local transcript', new Error(result.reason));
       await this.cancelSession(sessionId);
@@ -942,12 +1009,15 @@ export class DictationSessionController {
     // transcript — otherwise the batch rewrite would miss the last utterance(s).
     if (entry.pendingTranscriptWork.size > 0) {
       await this.drainPendingTranscriptWork(entry);
-      if (this.sessions.get(sessionId) !== entry) {
-        return;
-      }
+    }
+    if (this.stopTerminatedBatchCleanup(sessionId, entry)) {
+      return;
     }
 
     const transcriptText = entry.session.readCurrentSessionText();
+    if (this.stopTerminatedBatchCleanup(sessionId, entry)) {
+      return;
+    }
 
     if (transcriptText.length === 0) {
       this.dependencies.logger?.warn(
@@ -968,7 +1038,13 @@ export class DictationSessionController {
     // The flashing processing range is now the "working" indicator, so the
     // cursor steps aside for the batch rewrite.
     entry.session.setAnchorMode('hidden');
+    if (this.stopTerminatedBatchCleanup(sessionId, entry)) {
+      return;
+    }
     entry.session.markSessionRangeAsProcessing();
+    if (this.stopTerminatedBatchCleanup(sessionId, entry)) {
+      return;
+    }
 
     const abortController = new AbortController();
     entry.cleanupAbortControllers.add(abortController);
@@ -985,33 +1061,46 @@ export class DictationSessionController {
       if (abortController.signal.aborted) {
         if (this.sessions.get(sessionId) === entry) {
           entry.session.clearSessionProcessingMark();
-          this.disposeLocalSession(sessionId);
+          if (!this.stopTerminatedBatchCleanup(sessionId, entry)) {
+            this.disposeLocalSession(sessionId);
+          }
         }
         return;
       }
-      if (!this.sessions.has(sessionId)) {
+      if (this.stopTerminatedBatchCleanup(sessionId, entry)) {
         return;
       }
 
       entry.session.clearSessionProcessingMark();
+      if (this.stopTerminatedBatchCleanup(sessionId, entry)) {
+        return;
+      }
 
-      this.applyBatchCleanupResult(entry, result.text.trim(), transcriptText);
+      this.applyBatchCleanupResult(sessionId, entry, result.text.trim(), transcriptText);
+      if (this.stopTerminatedBatchCleanup(sessionId, entry)) {
+        return;
+      }
       this.dependencies.onLlmCleanupSuccess?.();
       this.disposeLocalSession(sessionId);
     } catch (error) {
       if (abortController.signal.aborted) {
         if (this.sessions.get(sessionId) === entry) {
           entry.session.clearSessionProcessingMark();
-          this.disposeLocalSession(sessionId);
+          if (!this.stopTerminatedBatchCleanup(sessionId, entry)) {
+            this.disposeLocalSession(sessionId);
+          }
         }
         return;
       }
-      if (!this.sessions.has(sessionId)) {
+      if (this.stopTerminatedBatchCleanup(sessionId, entry)) {
         return;
       }
 
       this.handleProviderCleanupFailure(failedProviderId(error, providerId), error);
       entry.session.clearSessionProcessingMark();
+      if (this.stopTerminatedBatchCleanup(sessionId, entry)) {
+        return;
+      }
       this.disposeLocalSession(sessionId);
     } finally {
       entry.cleanupAbortControllers.delete(abortController);
@@ -1023,6 +1112,7 @@ export class DictationSessionController {
   // transcript. Throws ProviderError for an empty replace result so the caller's
   // failure path keeps the raw text.
   private applyBatchCleanupResult(
+    sessionId: string,
     entry: ManagedSession,
     cleanedText: string,
     transcriptText: string,
@@ -1036,6 +1126,9 @@ export class DictationSessionController {
         rawTextForCallout: transcriptText,
         showRawBelow: entry.snapshot.llmPostprocessShowRawBelow,
       });
+      if (this.stopTerminatedBatchCleanup(sessionId, entry)) {
+        return;
+      }
 
       if (!replaced) {
         this.dependencies.logger?.warn(
@@ -1064,6 +1157,9 @@ export class DictationSessionController {
 
     const placement = entry.snapshot.llmPostprocessOutput === 'add_above' ? 'above' : 'below';
     const inserted = entry.session.insertAdjacentToSessionRange(cleanedText, placement);
+    if (this.stopTerminatedBatchCleanup(sessionId, entry)) {
+      return;
+    }
 
     if (!inserted) {
       this.dependencies.logger?.warn(
@@ -1076,6 +1172,18 @@ export class DictationSessionController {
         placement,
       });
     }
+  }
+
+  private stopTerminatedBatchCleanup(sessionId: string, entry: ManagedSession): boolean {
+    if (this.sessions.get(sessionId) !== entry) {
+      return true;
+    }
+    if (!entry.fatalTranscriptFailureReported) {
+      return false;
+    }
+
+    this.disposeLocalSession(sessionId);
+    return true;
   }
 
   private async handleErrorEvent(event: Extract<SidecarEvent, { type: 'error' }>): Promise<void> {
@@ -1179,6 +1287,32 @@ export class DictationSessionController {
     }
 
     this.dependencies.logger?.warn('session', `locked note ${reason} for session ${sessionId}`);
+    void this.cancelSession(sessionId);
+  }
+
+  private cancelOnFatalTranscriptFailure(
+    sessionId: string,
+    logMessage: string,
+    details: unknown,
+    noticeMessage: string,
+  ): void {
+    const entry = this.sessions.get(sessionId);
+    if (entry === undefined || entry.fatalTranscriptFailureReported) {
+      return;
+    }
+
+    entry.fatalTranscriptFailureReported = true;
+    this.abortProviderCleanups(entry);
+    this.dependencies.logger?.error('session', logMessage, details);
+    this.dependencies.notice(noticeMessage);
+
+    if (entry.phase === 'cancelling' || entry.phase === 'stopped') {
+      return;
+    }
+
+    // Mark cancellation before any await so concurrent queued transcript work
+    // observes the terminal phase and cannot repeat the failure.
+    entry.phase = 'cancelling';
     void this.cancelSession(sessionId);
   }
 

--- a/src/editor/note-surface.ts
+++ b/src/editor/note-surface.ts
@@ -47,7 +47,16 @@ export interface ProjectedSpan {
   utteranceId: UtteranceId;
 }
 
-export type AppendDenialReason = { kind: 'disposed' } | { kind: 'already_projected' };
+export interface SurfaceDesynchronization {
+  readonly documentLength: number;
+  readonly kind: 'surface_desynchronized';
+  readonly trackedPosition: number;
+}
+
+export type AppendDenialReason =
+  | { kind: 'disposed' }
+  | { kind: 'already_projected' }
+  | SurfaceDesynchronization;
 
 export type AppendResult =
   | {
@@ -64,7 +73,8 @@ export type ReplaceDenialReason =
   | { kind: 'disposed' }
   | { kind: 'not_found' }
   | { kind: 'user_edited' }
-  | { currentText: string; kind: 'span_mismatch' };
+  | { currentText: string; kind: 'span_mismatch' }
+  | SurfaceDesynchronization;
 
 export type ReplaceResult =
   | {
@@ -91,7 +101,8 @@ export type RewriteDenialReason =
   | { kind: 'range_invalid' }
   | { kind: 'range_partial' }
   | { kind: 'user_edited' }
-  | { kind: 'span_mismatch' };
+  | { kind: 'span_mismatch' }
+  | SurfaceDesynchronization;
 
 export type RewriteResult =
   | {
@@ -141,6 +152,7 @@ export function noteSurfaceUpdateListenerExtension(): Extension {
 
 export class NoteSurface {
   private readonly createdAt = nextSurfaceOrder;
+  private desynchronization: SurfaceDesynchronization | null = null;
   private disposed = false;
   private initialAnchorPos: number;
   private readonly initialBoundaryPos: number;
@@ -150,6 +162,7 @@ export class NoteSurface {
   constructor(
     readonly view: EditorView,
     private readonly placement: NotePlacementOptions,
+    private readonly onSurfaceDesynchronized?: (failure: SurfaceDesynchronization) => void,
   ) {
     nextSurfaceOrder += 1;
     this.initialAnchorPos = this.computePinPosition();
@@ -164,9 +177,18 @@ export class NoteSurface {
     }
   }
 
-  observeTransaction(update: ViewUpdate): void {
+  observeTransaction(update: ViewUpdate): SurfaceDesynchronization | null {
     if (this.disposed || update.view !== this.view || !update.docChanged) {
-      return;
+      return null;
+    }
+    if (this.desynchronization !== null) {
+      return this.desynchronization;
+    }
+
+    const desynchronization = this.detectOwnedDesynchronization(update.startState.doc.length);
+    if (desynchronization !== null) {
+      this.onSurfaceDesynchronized?.(desynchronization);
+      return desynchronization;
     }
 
     const spansBefore = [...this.spans.values()].map(cloneSpan);
@@ -175,7 +197,7 @@ export class NoteSurface {
     this.mapSpans(update);
 
     if (!this.hasLatchableUserChange(update)) {
-      return;
+      return null;
     }
 
     for (const before of spansBefore) {
@@ -192,6 +214,7 @@ export class NoteSurface {
     }
 
     this.clearProvisional(latchedUtteranceIds);
+    return null;
   }
 
   readProjectionContext(): NoteProjectionContext {
@@ -206,6 +229,11 @@ export class NoteSurface {
   appendProjection(utteranceId: UtteranceId, projection: TranscriptInsertProjection): AppendResult {
     if (this.disposed) {
       return { kind: 'denied', reason: { kind: 'disposed' }, utteranceId };
+    }
+
+    const desynchronization = this.detectDesynchronization();
+    if (desynchronization !== null) {
+      return { kind: 'denied', reason: desynchronization, utteranceId };
     }
 
     if (this.spans.has(utteranceId)) {
@@ -245,6 +273,11 @@ export class NoteSurface {
   ): ReplaceResult {
     if (this.disposed) {
       return { kind: 'denied', reason: { kind: 'disposed' }, utteranceId };
+    }
+
+    const desynchronization = this.detectDesynchronization();
+    if (desynchronization !== null) {
+      return { kind: 'denied', reason: desynchronization, utteranceId };
     }
 
     const span = this.spans.get(utteranceId);
@@ -301,6 +334,11 @@ export class NoteSurface {
       return { kind: 'denied', reason: { kind: 'disposed' } };
     }
 
+    const desynchronization = this.detectDesynchronization();
+    if (desynchronization !== null) {
+      return { kind: 'denied', reason: desynchronization };
+    }
+
     if (!this.isValidRange(range)) {
       return { kind: 'denied', reason: { kind: 'range_invalid' } };
     }
@@ -351,9 +389,14 @@ export class NoteSurface {
     return { kind: 'rewritten', range };
   }
 
-  validateExternalModification(): void {
+  validateExternalModification(): SurfaceDesynchronization | null {
     if (this.disposed) {
-      return;
+      return null;
+    }
+
+    const desynchronization = this.detectDesynchronization();
+    if (desynchronization !== null) {
+      return desynchronization;
     }
 
     const latchedUtteranceIds: string[] = [];
@@ -368,29 +411,47 @@ export class NoteSurface {
       }
     }
     this.clearProvisional(latchedUtteranceIds);
+    return null;
   }
 
-  setAnchorMode(mode: DictationAnchorMode): void {
+  setAnchorMode(mode: DictationAnchorMode): SurfaceDesynchronization | null {
+    if (this.disposed) {
+      return null;
+    }
+    const desynchronization = this.detectDesynchronization();
+    if (desynchronization !== null) {
+      return desynchronization;
+    }
     if (this.isAnchorOwner()) {
       this.view.dispatch({ effects: setAnchorModeEffect.of(mode) });
     }
+    return null;
   }
 
-  setProcessingRange(range: SessionProcessingRange | null): void {
+  setProcessingRange(range: SessionProcessingRange | null): SurfaceDesynchronization | null {
     if (this.disposed) {
-      return;
+      return null;
+    }
+    const desynchronization = this.detectDesynchronization();
+    if (desynchronization !== null) {
+      return desynchronization;
     }
     this.view.dispatch({ effects: setSessionProcessingEffect.of(range) });
+    return null;
   }
 
-  setProvisional(utteranceId: UtteranceId, provisional: boolean): void {
+  setProvisional(utteranceId: UtteranceId, provisional: boolean): SurfaceDesynchronization | null {
     if (this.disposed) {
-      return;
+      return null;
+    }
+    const desynchronization = this.detectDesynchronization();
+    if (desynchronization !== null) {
+      return desynchronization;
     }
     const span = this.spans.get(utteranceId);
     if (!provisional || span === undefined || span.latched !== undefined) {
       this.clearProvisional([utteranceId]);
-      return;
+      return null;
     }
     this.view.dispatch({
       effects: setProvisionalTranscriptEffect.of({
@@ -399,11 +460,19 @@ export class NoteSurface {
         utteranceId,
       }),
     });
+    return null;
   }
 
-  trimPendingInitialPrefix(): void {
-    if (this.disposed || this.pendingInitialPrefix.length === 0) {
-      return;
+  trimPendingInitialPrefix(): SurfaceDesynchronization | null {
+    if (this.disposed) {
+      return null;
+    }
+    const desynchronization = this.detectDesynchronization();
+    if (desynchronization !== null) {
+      return desynchronization;
+    }
+    if (this.pendingInitialPrefix.length === 0) {
+      return null;
     }
 
     const pending = this.pendingInitialPrefix;
@@ -421,10 +490,18 @@ export class NoteSurface {
     }
 
     this.pendingInitialPrefix = '';
+    return null;
   }
 
-  dispose(): void {
-    this.trimPendingInitialPrefix();
+  dispose(): SurfaceDesynchronization | null {
+    if (this.disposed) {
+      return this.desynchronization;
+    }
+
+    const desynchronization = this.detectDesynchronization();
+    if (desynchronization === null) {
+      this.trimPendingInitialPrefix();
+    }
     const provisionalUtteranceIds = [...this.spans.keys()];
     this.disposed = true;
     unregisterNoteSurface(this);
@@ -441,6 +518,7 @@ export class NoteSurface {
       effects.push(clearAnchorEffect.of(null));
     }
     this.view.dispatch({ effects });
+    return desynchronization;
   }
 
   // The shared cursor belongs to the newest live surface for this view. With
@@ -574,6 +652,58 @@ export class NoteSurface {
     return tail;
   }
 
+  private detectDesynchronization(
+    documentLength = this.view.state.doc.length,
+  ): SurfaceDesynchronization | null {
+    const ownedDesynchronization = this.detectOwnedDesynchronization(documentLength);
+    if (ownedDesynchronization !== null) {
+      return ownedDesynchronization;
+    }
+
+    const writingRegionTail = this.writingRegionTail();
+    if (!isDocumentPosition(writingRegionTail, documentLength)) {
+      return this.markDesynchronized(writingRegionTail, documentLength);
+    }
+
+    return null;
+  }
+
+  private detectOwnedDesynchronization(documentLength: number): SurfaceDesynchronization | null {
+    if (this.desynchronization !== null) {
+      return this.desynchronization;
+    }
+
+    if (!isDocumentPosition(this.initialAnchorPos, documentLength)) {
+      return this.markDesynchronized(this.initialAnchorPos, documentLength);
+    }
+
+    for (const span of this.spans.values()) {
+      const positions = [span.start, span.textStart, span.textEnd, span.end];
+      let previous = -1;
+      for (const position of positions) {
+        if (!isDocumentPosition(position, documentLength) || position < previous) {
+          return this.markDesynchronized(position, documentLength);
+        }
+        previous = position;
+      }
+    }
+
+    return null;
+  }
+
+  private markDesynchronized(
+    trackedPosition: number,
+    documentLength: number,
+  ): SurfaceDesynchronization {
+    const failure: SurfaceDesynchronization = {
+      documentLength,
+      kind: 'surface_desynchronized',
+      trackedPosition,
+    };
+    this.desynchronization = failure;
+    return failure;
+  }
+
   private lastSpan(): ProjectedSpan | null {
     let last: ProjectedSpan | null = null;
 
@@ -636,6 +766,10 @@ export class NoteSurface {
       range.to <= this.view.state.doc.length
     );
   }
+}
+
+function isDocumentPosition(position: number, documentLength: number): boolean {
+  return Number.isInteger(position) && position >= 0 && position <= documentLength;
 }
 
 function changeIntersectsSpan(update: ViewUpdate, span: ProjectedSpan): boolean {

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -12,6 +12,7 @@ import {
   type ReplaceResult,
   type RewriteRange,
   type RewriteResult,
+  type SurfaceDesynchronization,
 } from '../editor/note-surface';
 import type { PluginLogger } from '../shared/plugin-logger';
 import { truncateLeadingText } from '../shared/text-truncation';
@@ -55,6 +56,7 @@ export type SessionAcceptResult =
 export interface SessionLifecycleCallbacks {
   onLockedNoteClosed: () => void;
   onLockedNoteDeleted: () => void;
+  onSurfaceDesynchronized: (failure: SurfaceDesynchronization) => void;
 }
 
 export interface SessionDependencies {
@@ -62,7 +64,11 @@ export interface SessionDependencies {
   callbacks: SessionLifecycleCallbacks;
   logger?: PluginLogger;
   lockedFile: TFile;
-  noteSurfaceFactory?: (view: EditorView, placement: NotePlacementOptions) => NoteSurfaceLike;
+  noteSurfaceFactory?: (
+    view: EditorView,
+    placement: NotePlacementOptions,
+    onSurfaceDesynchronized: (failure: SurfaceDesynchronization) => void,
+  ) => NoteSurfaceLike;
   placement: NotePlacementOptions;
   rendererOptions: TranscriptRenderOptions;
   sessionId: string;
@@ -88,10 +94,10 @@ interface NoteSurfaceLike {
     newText: string,
     preservedSpans: PreservedSpan[],
   ): RewriteResult;
-  setAnchorMode(mode: DictationAnchorMode): void;
-  setProcessingRange(range: { from: number; to: number } | null): void;
-  setProvisional(utteranceId: UtteranceId, provisional: boolean): void;
-  validateExternalModification(): void;
+  setAnchorMode(mode: DictationAnchorMode): SurfaceDesynchronization | null;
+  setProcessingRange(range: { from: number; to: number } | null): SurfaceDesynchronization | null;
+  setProvisional(utteranceId: UtteranceId, provisional: boolean): SurfaceDesynchronization | null;
+  validateExternalModification(): SurfaceDesynchronization | null;
 }
 
 interface RawSessionEntry {
@@ -110,6 +116,7 @@ export class Session {
   private readonly rawSessionEntryIndexByUtterance = new Map<UtteranceId, number>();
   private readonly refs: Array<{ offref: (ref: EventRef) => void; ref: EventRef }> = [];
   private surface: NoteSurfaceLike | null;
+  private surfaceDesynchronized = false;
 
   static createFromActiveEditor(
     app: Pick<App, 'vault' | 'workspace'>,
@@ -151,6 +158,9 @@ export class Session {
     this.surface = (dependencies.noteSurfaceFactory ?? createNoteSurface)(
       dependencies.view,
       dependencies.placement,
+      (failure) => {
+        this.handleSurfaceDesynchronization(failure);
+      },
     );
     this.registerLifecycleSubscriptions();
   }
@@ -247,6 +257,11 @@ export class Session {
       this.rawSessionEntries.map((entry) => ({ utteranceId: entry.utteranceId })),
     );
 
+    if (result.kind === 'denied' && result.reason.kind === 'surface_desynchronized') {
+      this.handleSurfaceDesynchronization(result.reason);
+      return false;
+    }
+
     return result.kind === 'rewritten';
   }
 
@@ -277,11 +292,19 @@ export class Session {
       this.rawSessionEntries.map((entry) => ({ utteranceId: entry.utteranceId })),
     );
 
+    if (result.kind === 'denied' && result.reason.kind === 'surface_desynchronized') {
+      this.handleSurfaceDesynchronization(result.reason);
+      return false;
+    }
+
     return result.kind === 'rewritten';
   }
 
   setAnchorMode(mode: DictationAnchorMode): void {
-    this.surface?.setAnchorMode(mode);
+    const result = this.surface?.setAnchorMode(mode);
+    if (result !== undefined && result !== null) {
+      this.handleSurfaceDesynchronization(result);
+    }
   }
 
   markSessionRangeAsProcessing(): boolean {
@@ -292,12 +315,19 @@ export class Session {
     if (range === null) {
       return false;
     }
-    this.surface.setProcessingRange(range);
+    const result = this.surface.setProcessingRange(range);
+    if (result !== null) {
+      this.handleSurfaceDesynchronization(result);
+      return false;
+    }
     return true;
   }
 
   clearSessionProcessingMark(): void {
-    this.surface?.setProcessingRange(null);
+    const result = this.surface?.setProcessingRange(null);
+    if (result !== undefined && result !== null) {
+      this.handleSurfaceDesynchronization(result);
+    }
   }
 
   dispose(): void {
@@ -365,10 +395,17 @@ export class Session {
         precedingSpeakerIndex: projection.precedingSpeakerIndex,
         projectedText: projection.insertedText,
       });
-      this.surface?.setProvisional(revision.utteranceId, !revision.isFinal);
+      if (!this.updateProvisionalState(revision.utteranceId, !revision.isFinal)) {
+        return;
+      }
       this.recordRawSessionAppend(revision, projection);
       this.renderer.commitAppend(projection);
       this.applyRawPostprocessCallout(revision);
+      return;
+    }
+
+    if (result.reason.kind === 'surface_desynchronized') {
+      this.handleSurfaceDesynchronization(result.reason);
       return;
     }
 
@@ -417,6 +454,10 @@ export class Session {
     const result = this.surface?.appendProjection(`${revision.utteranceId}:llm_raw`, projection);
 
     if (result?.kind === 'denied') {
+      if (result.reason.kind === 'surface_desynchronized') {
+        this.handleSurfaceDesynchronization(result.reason);
+        return;
+      }
       this.dependencies.logger?.debug(
         'session',
         `raw LLM postprocess callout append denied (${callout.length} chars): ${result.reason.kind}`,
@@ -466,8 +507,15 @@ export class Session {
         precedingSpeakerIndex: state.precedingSpeakerIndex,
         projectedText,
       });
-      this.surface?.setProvisional(revision.utteranceId, !revision.isFinal);
+      if (!this.updateProvisionalState(revision.utteranceId, !revision.isFinal)) {
+        return;
+      }
       this.recordRawSessionReplace(revision);
+      return;
+    }
+
+    if (result.reason.kind === 'surface_desynchronized') {
+      this.handleSurfaceDesynchronization(result.reason);
       return;
     }
 
@@ -476,7 +524,9 @@ export class Session {
     } else {
       this.projectionByUtterance.set(revision.utteranceId, { kind: 'denied' });
     }
-    this.surface?.setProvisional(revision.utteranceId, false);
+    if (!this.updateProvisionalState(revision.utteranceId, false)) {
+      return;
+    }
     this.dependencies.logger?.debug('session', `projection replace denied: ${result.reason.kind}`);
   }
 
@@ -547,8 +597,32 @@ export class Session {
 
   private handleModify(file: TAbstractFile): void {
     if (file === this.dependencies.lockedFile) {
-      this.surface?.validateExternalModification();
+      const result = this.surface?.validateExternalModification();
+      if (result !== undefined && result !== null) {
+        this.handleSurfaceDesynchronization(result);
+      }
     }
+  }
+
+  private handleSurfaceDesynchronization(failure: SurfaceDesynchronization): void {
+    if (this.surfaceDesynchronized) {
+      return;
+    }
+
+    this.surfaceDesynchronized = true;
+    this.surface?.dispose();
+    this.surface = null;
+    this.dependencies.callbacks.onSurfaceDesynchronized(failure);
+  }
+
+  private updateProvisionalState(utteranceId: UtteranceId, provisional: boolean): boolean {
+    const failure = this.surface?.setProvisional(utteranceId, provisional);
+    if (failure === undefined || failure === null) {
+      return true;
+    }
+
+    this.handleSurfaceDesynchronization(failure);
+    return false;
   }
 
   private handleRename(file: TAbstractFile, oldPath: string): void {
@@ -635,8 +709,12 @@ export class Session {
   }
 }
 
-function createNoteSurface(view: EditorView, placement: NotePlacementOptions): NoteSurface {
-  return new NoteSurface(view, placement);
+function createNoteSurface(
+  view: EditorView,
+  placement: NotePlacementOptions,
+  onSurfaceDesynchronized: (failure: SurfaceDesynchronization) => void,
+): NoteSurface {
+  return new NoteSurface(view, placement, onSurfaceDesynchronized);
 }
 
 function resolveActiveEditorTarget(

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -4,7 +4,7 @@ import {
   type DictationControllerState,
   DictationSessionController,
 } from '../src/dictation/dictation-session-controller';
-import type { NotePlacementOptions } from '../src/editor/note-surface';
+import type { NotePlacementOptions, SurfaceDesynchronization } from '../src/editor/note-surface';
 import { type LlmCleanupFailure, ProviderError } from '../src/llm/provider';
 import type { LlmRouter, LlmRouterCleanupResult } from '../src/llm/router';
 import type { SessionAcceptResult } from '../src/session/session';
@@ -728,6 +728,267 @@ describe('DictationSessionController', () => {
     });
   });
 
+  it('contains a fatal note-surface desynchronization once and drops later transcripts', async () => {
+    const captureStream = new FakeCaptureStream();
+    const logger = new FakeLogger();
+    const notice = vi.fn();
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const cleanup = vi.fn(
+      async (): Promise<LlmRouterCleanupResult> => ({
+        model: 'm',
+        providerId: 'ollama',
+        text: 'must not run',
+      }),
+    );
+    let onSurfaceDesynchronized: ((failure: SurfaceDesynchronization) => void) | undefined;
+    const controller = createController({
+      captureStream,
+      createSession: (session, options) => {
+        sessions.push(session);
+        onSurfaceDesynchronized = options.callbacks.onSurfaceDesynchronized;
+      },
+      getSettings: () =>
+        createSettings({
+          llmFeaturesEnabled: true,
+          llmPostprocessMode: 'per_utterance',
+          llmPostprocessSkipMinWords: 0,
+          selectedModel: createExternalModelSelection(),
+        }),
+      logger,
+      llmRouter: createFakeLlmRouter({ cleanup }),
+      notice,
+      sidecarConnection,
+    });
+    const failure: SurfaceDesynchronization = {
+      documentLength: 4280,
+      kind: 'surface_desynchronized',
+      trackedPosition: 4314,
+    };
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+
+    onSurfaceDesynchronized?.(failure);
+    onSurfaceDesynchronized?.(failure);
+    sidecarConnection.emit(transcriptReady(sessionId, 'must be dropped'));
+
+    await vi.waitFor(() => {
+      expect(sidecarConnection.cancelSession).toHaveBeenCalledOnce();
+    });
+    expect(sidecarConnection.cancelSession).toHaveBeenCalledWith(sessionId);
+    expect(captureStream.stop).toHaveBeenCalledOnce();
+    expect(logger.error).toHaveBeenCalledOnce();
+    expect(logger.error).toHaveBeenCalledWith(
+      'session',
+      'dictation note surface desynchronized',
+      failure,
+    );
+    expect(notice).toHaveBeenCalledOnce();
+    expect(notice).toHaveBeenCalledWith(
+      'Dictation stopped because the note changed in a way Local Dictation could not safely track. Start dictation again to continue.',
+    );
+    await vi.waitFor(() => {
+      expect(sessions[0]?.acceptTranscript).not.toHaveBeenCalled();
+    });
+    expect(cleanup).not.toHaveBeenCalled();
+  });
+
+  it('sends one sidecar cancel when fatal containment races another cancellation source', async () => {
+    const captureStream = new FakeCaptureStream();
+    const sidecarConnection = new FakeSidecarConnection();
+    let onLockedNoteClosed: (() => void) | undefined;
+    let onSurfaceDesynchronized: ((failure: SurfaceDesynchronization) => void) | undefined;
+    let resolveCaptureStop: (() => void) | undefined;
+    captureStream.stop.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCaptureStop = resolve;
+        }),
+    );
+    const controller = createController({
+      captureStream,
+      createSession: (_session, options) => {
+        onLockedNoteClosed = options.callbacks.onLockedNoteClosed;
+        onSurfaceDesynchronized = options.callbacks.onSurfaceDesynchronized;
+      },
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+
+    onSurfaceDesynchronized?.({
+      documentLength: 4280,
+      kind: 'surface_desynchronized',
+      trackedPosition: 4314,
+    });
+    onLockedNoteClosed?.();
+
+    await vi.waitFor(() => {
+      expect(captureStream.stop).toHaveBeenCalledOnce();
+    });
+    expect(sidecarConnection.cancelSession).not.toHaveBeenCalled();
+
+    resolveCaptureStop?.();
+    await vi.waitFor(() => {
+      expect(sidecarConnection.cancelSession).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('reports a pending fatal desynchronization after the sidecar has already stopped', async () => {
+    const logger = new FakeLogger();
+    const notice = vi.fn();
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    let onSurfaceDesynchronized: ((failure: SurfaceDesynchronization) => void) | undefined;
+    const failure: SurfaceDesynchronization = {
+      documentLength: 4280,
+      kind: 'surface_desynchronized',
+      trackedPosition: 4314,
+    };
+    const controller = createController({
+      createSession: (session, options) => {
+        sessions.push(session);
+        onSurfaceDesynchronized = options.callbacks.onSurfaceDesynchronized;
+        session.acceptTranscript.mockImplementation(() => {
+          onSurfaceDesynchronized?.(failure);
+          return { kind: 'accepted' };
+        });
+      },
+      logger,
+      notice,
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    sidecarConnection.emit(transcriptReady(sessionId, 'final utterance'));
+    sidecarConnection.emit({ reason: 'user_stop', sessionId, type: 'session_stopped' });
+
+    await vi.waitFor(() => {
+      expect(sessions[0]?.dispose).toHaveBeenCalledOnce();
+    });
+    expect(sidecarConnection.cancelSession).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledOnce();
+    expect(logger.error).toHaveBeenCalledWith(
+      'session',
+      'dictation note surface desynchronized',
+      failure,
+    );
+    expect(notice).toHaveBeenCalledOnce();
+    expect(notice).toHaveBeenCalledWith(
+      'Dictation stopped because the note changed in a way Local Dictation could not safely track. Start dictation again to continue.',
+    );
+  });
+
+  it('aborts pending provider work when a fatal surface failure arrives after stop', async () => {
+    const notice = vi.fn();
+    const sidecarConnection = new FakeSidecarConnection();
+    let cleanupSignal: AbortSignal | undefined;
+    let resolveCleanup: ((result: LlmRouterCleanupResult) => void) | undefined;
+    const cleanup = vi.fn(
+      ({ abortSignal }: { abortSignal?: AbortSignal }) =>
+        new Promise<LlmRouterCleanupResult>((resolve) => {
+          cleanupSignal = abortSignal;
+          resolveCleanup = resolve;
+        }),
+    );
+    let onSurfaceDesynchronized: ((failure: SurfaceDesynchronization) => void) | undefined;
+    const sessions: FakeSession[] = [];
+    const controller = createController({
+      createSession: (session, options) => {
+        sessions.push(session);
+        onSurfaceDesynchronized = options.callbacks.onSurfaceDesynchronized;
+      },
+      getSettings: () =>
+        createSettings({
+          llmFeaturesEnabled: true,
+          llmPostprocessMode: 'per_utterance',
+          llmPostprocessSkipMinWords: 0,
+          selectedModel: createExternalModelSelection(),
+        }),
+      llmRouter: createFakeLlmRouter({ cleanup }),
+      notice,
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    sidecarConnection.emit(transcriptReady(sessionId, 'pending cleanup'));
+    await vi.waitFor(() => {
+      expect(cleanup).toHaveBeenCalledOnce();
+    });
+    sidecarConnection.emit({ reason: 'user_stop', sessionId, type: 'session_stopped' });
+    onSurfaceDesynchronized?.({
+      documentLength: 4280,
+      kind: 'surface_desynchronized',
+      trackedPosition: 4314,
+    });
+
+    expect(cleanupSignal?.aborted).toBe(true);
+    expect(sidecarConnection.cancelSession).not.toHaveBeenCalled();
+    expect(notice).toHaveBeenCalledOnce();
+
+    resolveCleanup?.({ model: 'm', providerId: 'ollama', text: 'ignored' });
+    await vi.waitFor(() => {
+      expect(sessions[0]?.dispose).toHaveBeenCalledOnce();
+    });
+    expect(sessions[0]?.acceptTranscript).not.toHaveBeenCalled();
+  });
+
+  it('contains an unexpected projection exception with accurate single-shot notice copy', async () => {
+    const captureStream = new FakeCaptureStream();
+    const logger = new FakeLogger();
+    const notice = vi.fn();
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const controller = createController({
+      captureStream,
+      createSession: (session) => {
+        sessions.push(session);
+        session.acceptTranscript.mockImplementation(() => {
+          throw new RangeError('Invalid change range 4314 to 4314 (in doc of length 4280)');
+        });
+      },
+      logger,
+      notice,
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    sidecarConnection.emit(
+      transcriptReady(sessionId, 'first', {
+        isFinal: false,
+        utteranceId: 'partial-1',
+        utteranceIndex: 0,
+      }),
+    );
+    sidecarConnection.emit(
+      transcriptReady(sessionId, 'second', {
+        isFinal: false,
+        utteranceId: 'partial-2',
+        utteranceIndex: 1,
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(sidecarConnection.cancelSession).toHaveBeenCalledOnce();
+    });
+    expect(captureStream.stop).toHaveBeenCalledOnce();
+    expect(logger.error).toHaveBeenCalledOnce();
+    expect(logger.error).toHaveBeenCalledWith(
+      'session',
+      'failed to process transcript',
+      expect.any(RangeError),
+    );
+    expect(notice).toHaveBeenCalledOnce();
+    expect(notice).toHaveBeenCalledWith(
+      'Dictation stopped because Local Dictation could not safely write to the note. Start dictation again to continue.',
+    );
+    expect(sessions[0]?.acceptTranscript).toHaveBeenCalledOnce();
+  });
+
   it('keeps raw transcript and reports a typed per-utterance cleanup failure', async () => {
     const sidecarConnection = new FakeSidecarConnection();
     const sessions: FakeSession[] = [];
@@ -1097,6 +1358,263 @@ describe('DictationSessionController', () => {
         }),
       );
     });
+  });
+
+  it('does not start batch provider work after a pending accept reports a fatal surface failure', async () => {
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const cleanup = vi.fn(
+      async (): Promise<LlmRouterCleanupResult> => ({
+        model: 'm',
+        providerId: 'ollama',
+        text: 'must not run',
+      }),
+    );
+    let onSurfaceDesynchronized: ((failure: SurfaceDesynchronization) => void) | undefined;
+    const controller = createController({
+      createSession: (session, options) => {
+        sessions.push(session);
+        onSurfaceDesynchronized = options.callbacks.onSurfaceDesynchronized;
+        session.acceptTranscript.mockImplementation((revision: TranscriptRevision) => {
+          session.currentSessionText = revision.text;
+          onSurfaceDesynchronized?.({
+            documentLength: 4280,
+            kind: 'surface_desynchronized',
+            trackedPosition: 4314,
+          });
+          return { kind: 'accepted' };
+        });
+      },
+      getSettings: () =>
+        createSettings({
+          llmFeaturesEnabled: true,
+          llmPostprocessMode: 'batch',
+          selectedModel: createExternalModelSelection(),
+        }),
+      llmRouter: createFakeLlmRouter({ cleanup }),
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+
+    sidecarConnection.emit(transcriptReady(sessionId, 'final utterance'));
+    sidecarConnection.emit({ reason: 'user_stop', sessionId, type: 'session_stopped' });
+
+    await vi.waitFor(() => {
+      expect(sessions[0]?.dispose).toHaveBeenCalledOnce();
+    });
+    expect(cleanup).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['hiding the anchor', 'anchor'],
+    ['marking the range', 'processing'],
+  ] as const)('does not start batch provider work after a fatal failure while %s', async (_description, mutation) => {
+    const logger = new FakeLogger();
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const cleanup = vi.fn(
+      async (): Promise<LlmRouterCleanupResult> => ({
+        model: 'm',
+        providerId: 'ollama',
+        text: 'must not run',
+      }),
+    );
+    let onSurfaceDesynchronized: ((failure: SurfaceDesynchronization) => void) | undefined;
+    const controller = createController({
+      createSession: (session, options) => {
+        sessions.push(session);
+        onSurfaceDesynchronized = options.callbacks.onSurfaceDesynchronized;
+      },
+      getSettings: () =>
+        createSettings({
+          llmFeaturesEnabled: true,
+          llmPostprocessMode: 'batch',
+          selectedModel: createExternalModelSelection(),
+        }),
+      llmRouter: createFakeLlmRouter({ cleanup }),
+      logger,
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    sidecarConnection.emit(transcriptReady(sessionId, 'raw transcript'));
+    await vi.waitFor(() => {
+      expect(sessions[0]?.acceptTranscript).toHaveBeenCalledOnce();
+    });
+    await controller.stopDictation();
+
+    const session = sessions[0];
+    if (session === undefined) {
+      throw new Error('expected session fixture');
+    }
+    const reportFatalFailure = () => {
+      onSurfaceDesynchronized?.({
+        documentLength: 4280,
+        kind: 'surface_desynchronized',
+        trackedPosition: 4314,
+      });
+    };
+    if (mutation === 'anchor') {
+      session.setAnchorMode.mockImplementationOnce(reportFatalFailure);
+    } else {
+      session.markSessionRangeAsProcessing.mockImplementationOnce(() => {
+        reportFatalFailure();
+        return false;
+      });
+    }
+
+    sidecarConnection.emit({ reason: 'user_stop', sessionId, type: 'session_stopped' });
+
+    await vi.waitFor(() => {
+      expect(session.dispose).toHaveBeenCalledOnce();
+    });
+    expect(cleanup).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      'llm',
+      expect.stringContaining('session range no longer available'),
+    );
+  });
+
+  it('does not apply a batch result after clearing its processing mark reports a fatal failure', async () => {
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const onLlmCleanupSuccess = vi.fn();
+    let onSurfaceDesynchronized: ((failure: SurfaceDesynchronization) => void) | undefined;
+    const controller = createController({
+      createSession: (session, options) => {
+        sessions.push(session);
+        onSurfaceDesynchronized = options.callbacks.onSurfaceDesynchronized;
+      },
+      getSettings: () =>
+        createSettings({
+          llmFeaturesEnabled: true,
+          llmPostprocessMode: 'batch',
+          selectedModel: createExternalModelSelection(),
+        }),
+      llmRouter: createFakeLlmRouter({
+        cleanup: vi.fn(
+          async (): Promise<LlmRouterCleanupResult> => ({
+            model: 'm',
+            providerId: 'ollama',
+            text: 'Clean batch.',
+          }),
+        ),
+      }),
+      onLlmCleanupSuccess,
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    sidecarConnection.emit(transcriptReady(sessionId, 'raw transcript'));
+    await vi.waitFor(() => {
+      expect(sessions[0]?.acceptTranscript).toHaveBeenCalledOnce();
+    });
+    await controller.stopDictation();
+
+    const session = sessions[0];
+    if (session === undefined) {
+      throw new Error('expected session fixture');
+    }
+    session.clearSessionProcessingMark.mockImplementationOnce(() => {
+      onSurfaceDesynchronized?.({
+        documentLength: 4280,
+        kind: 'surface_desynchronized',
+        trackedPosition: 4314,
+      });
+    });
+    sidecarConnection.emit({ reason: 'user_stop', sessionId, type: 'session_stopped' });
+
+    await vi.waitFor(() => {
+      expect(session.dispose).toHaveBeenCalledOnce();
+    });
+    expect(session.replaceSessionRangeWithCleaned).not.toHaveBeenCalled();
+    expect(onLlmCleanupSuccess).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      'replacement',
+      undefined,
+      'batch cleanup replacement skipped; session range no longer available',
+    ],
+    [
+      'additive',
+      'builtin:tldr',
+      'additive batch insert skipped; session range no longer available',
+    ],
+  ] as const)('suppresses misleading %s batch logs and success after result application reports fatal', async (_description, activePresetRef, misleadingWarning) => {
+    const logger = new FakeLogger();
+    const notice = vi.fn();
+    const onLlmCleanupSuccess = vi.fn();
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    let onSurfaceDesynchronized: ((failure: SurfaceDesynchronization) => void) | undefined;
+    const controller = createController({
+      createSession: (session, options) => {
+        sessions.push(session);
+        onSurfaceDesynchronized = options.callbacks.onSurfaceDesynchronized;
+      },
+      getSettings: () =>
+        createSettings({
+          llmFeaturesEnabled: true,
+          ...(activePresetRef === undefined
+            ? {}
+            : { llmPostprocessActivePresetRef: activePresetRef }),
+          llmPostprocessMode: 'batch',
+          selectedModel: createExternalModelSelection(),
+        }),
+      llmRouter: createFakeLlmRouter({
+        cleanup: vi.fn(
+          async (): Promise<LlmRouterCleanupResult> => ({
+            model: 'm',
+            providerId: 'ollama',
+            text: 'Clean batch.',
+          }),
+        ),
+      }),
+      logger,
+      notice,
+      onLlmCleanupSuccess,
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    sidecarConnection.emit(transcriptReady(sessionId, 'raw transcript'));
+    await vi.waitFor(() => {
+      expect(sessions[0]?.acceptTranscript).toHaveBeenCalledOnce();
+    });
+    await controller.stopDictation();
+
+    const session = sessions[0];
+    if (session === undefined) {
+      throw new Error('expected session fixture');
+    }
+    const reportFatalFailure = () => {
+      onSurfaceDesynchronized?.({
+        documentLength: 4280,
+        kind: 'surface_desynchronized',
+        trackedPosition: 4314,
+      });
+      return false;
+    };
+    if (activePresetRef === undefined) {
+      session.replaceSessionRangeWithCleaned.mockImplementationOnce(reportFatalFailure);
+    } else {
+      session.insertAdjacentToSessionRange.mockImplementationOnce(reportFatalFailure);
+    }
+    sidecarConnection.emit({ reason: 'user_stop', sessionId, type: 'session_stopped' });
+
+    await vi.waitFor(() => {
+      expect(session.dispose).toHaveBeenCalledOnce();
+    });
+    expect(logger.warn).not.toHaveBeenCalledWith('llm', misleadingWarning);
+    expect(onLlmCleanupSuccess).not.toHaveBeenCalled();
+    expect(notice).toHaveBeenCalledOnce();
   });
 
   it('keeps raw transcript when a batch cleanup fails and reports it', async () => {
@@ -1550,6 +2068,7 @@ interface CreateSessionOptions {
   callbacks: {
     onLockedNoteClosed: () => void;
     onLockedNoteDeleted: () => void;
+    onSurfaceDesynchronized: (failure: SurfaceDesynchronization) => void;
   };
   placement: NotePlacementOptions;
   rendererOptions: TranscriptRenderOptions;

--- a/test/note-surface.test.ts
+++ b/test/note-surface.test.ts
@@ -6,23 +6,37 @@ import {
   type TransactionSpec,
 } from '@codemirror/state';
 import type { EditorView, ViewUpdate } from '@codemirror/view';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   dictationAnchorExtension,
   dictationAnchorStateField,
+  setAnchorEffect,
+  setAnchorModeEffect,
 } from '../src/editor/dictation-anchor-extension';
 import { NoteSurface } from '../src/editor/note-surface';
 import {
   provisionalTranscriptDecorationsField,
   provisionalTranscriptExtension,
+  provisionalTranscriptStateField,
+  setProvisionalTranscriptEffect,
 } from '../src/editor/provisional-transcript-extension';
+import {
+  sessionProcessingExtension,
+  sessionProcessingStateField,
+  setSessionProcessingEffect,
+} from '../src/editor/session-processing-extension';
 import type { DictationAnchor } from '../src/settings/plugin-settings';
-import { TranscriptRenderer, type TranscriptRenderOptions } from '../src/transcript/renderer';
+import {
+  type TranscriptInsertProjection,
+  TranscriptRenderer,
+  type TranscriptRenderOptions,
+} from '../src/transcript/renderer';
 import { renderOptions, timestamps } from './helpers/render-options';
 
 class FakeEditorView {
   public lastUpdate: ViewUpdate | null = null;
   public state: EditorState;
+  private readonly updateListeners: Array<(update: ViewUpdate) => void> = [];
 
   constructor(doc: string, selectionHead: number, extensions: Extension = []) {
     this.state = EditorState.create({
@@ -33,27 +47,49 @@ class FakeEditorView {
   }
 
   dispatch(spec: TransactionSpec): void {
-    const transaction = this.state.update(spec);
+    const startState = this.state;
+    const transaction = startState.update(spec);
     this.state = transaction.state;
     this.lastUpdate = {
       changes: transaction.changes,
       docChanged: transaction.docChanged,
+      startState,
       transactions: [transaction],
       view: this,
     } as unknown as ViewUpdate;
+    for (const listener of this.updateListeners) {
+      listener(this.lastUpdate);
+    }
+  }
+
+  addUpdateListener(listener: (update: ViewUpdate) => void): void {
+    this.updateListeners.push(listener);
   }
 
   apply(spec: TransactionSpec): ViewUpdate {
-    const transaction = this.state.update(spec);
+    const startState = this.state;
+    const transaction = startState.update(spec);
     this.state = transaction.state;
 
     this.lastUpdate = {
       changes: transaction.changes,
       docChanged: transaction.docChanged,
+      startState,
       transactions: [transaction],
       view: this,
     } as unknown as ViewUpdate;
     return this.lastUpdate;
+  }
+
+  replaceStateWithoutViewUpdate(doc: string): void {
+    this.state = EditorState.create({
+      doc,
+      selection: EditorSelection.cursor(doc.length),
+    });
+  }
+
+  replaceEditorStateWithoutViewUpdate(state: EditorState): void {
+    this.state = state;
   }
 }
 
@@ -62,14 +98,24 @@ function createSurface({
   doc = '',
   extensions = [],
   selectionHead = 0,
+  onSurfaceDesynchronized,
 }: {
   anchor?: DictationAnchor;
   doc?: string;
   extensions?: Extension;
   selectionHead?: number;
+  onSurfaceDesynchronized?: (failure: {
+    documentLength: number;
+    kind: 'surface_desynchronized';
+    trackedPosition: number;
+  }) => void;
 } = {}): { surface: NoteSurface; view: FakeEditorView } {
   const view = new FakeEditorView(doc, selectionHead, extensions);
-  const surface = new NoteSurface(view as unknown as EditorView, { anchor });
+  const surface = new NoteSurface(
+    view as unknown as EditorView,
+    { anchor },
+    onSurfaceDesynchronized,
+  );
 
   return { surface, view };
 }
@@ -90,6 +136,19 @@ function append(
   input: { pauseMsBeforeUtterance?: number | null; utteranceStartMsInSession?: number } = {},
 ): ReturnType<NoteSurface['appendProjection']> {
   return appendWithRenderer(surface, new TranscriptRenderer(options), utteranceId, text, input);
+}
+
+function literalProjection(text: string): TranscriptInsertProjection {
+  return {
+    emittedSpeakerIndex: null,
+    emittedTimestamp: null,
+    insertedText: text,
+    precedingSpeakerIndex: null,
+    projectedText: text,
+    replacementPrefix: '',
+    textEndOffset: text.length,
+    textStartOffset: 0,
+  };
 }
 
 function appendWithRenderer(
@@ -122,6 +181,150 @@ function doc(view: FakeEditorView): string {
 }
 
 describe('NoteSurface', () => {
+  it('reports a fatal desynchronization without changing an externally replaced note', () => {
+    const initialDocument = 'x'.repeat(4280);
+    const externalReplacement = 'r'.repeat(4280);
+    const { surface, view } = createSurface({
+      doc: initialDocument,
+      selectionHead: initialDocument.length,
+    });
+    const priorTranscript = 'y'.repeat(34);
+
+    expect(surface.appendProjection('u1', literalProjection(priorTranscript)).kind).toBe(
+      'appended',
+    );
+    expect(doc(view).length).toBe(4314);
+
+    view.replaceStateWithoutViewUpdate(externalReplacement);
+
+    const failure = surface.validateExternalModification();
+    expect(failure).toEqual({
+      documentLength: 4280,
+      kind: 'surface_desynchronized',
+      trackedPosition: 4314,
+    });
+    expect(surface.appendProjection('u2', literalProjection('next'))).toEqual({
+      kind: 'denied',
+      reason: failure,
+      utteranceId: 'u2',
+    });
+    expect(doc(view)).toBe(externalReplacement);
+  });
+
+  it('keeps the writing tail valid when a mapped edit shrinks the note', () => {
+    const initialDocument = 'x'.repeat(4280);
+    const { surface, view } = createSurface({
+      doc: initialDocument,
+      selectionHead: initialDocument.length,
+    });
+
+    expect(surface.appendProjection('u1', literalProjection('y'.repeat(34))).kind).toBe('appended');
+    surface.observeTransaction(view.apply({ changes: { from: 4280, to: 4314, insert: '' } }));
+
+    expect(surface.appendProjection('u2', literalProjection('z')).kind).toBe('appended');
+    expect(doc(view)).toBe(`${initialDocument}z`);
+  });
+
+  it('reports an unmapped replacement before mapping the next editor transaction', () => {
+    const initialDocument = 'x'.repeat(4280);
+    const externalReplacement = 'r'.repeat(4280);
+    const onSurfaceDesynchronized = vi.fn();
+    const { surface, view } = createSurface({
+      doc: initialDocument,
+      onSurfaceDesynchronized,
+      selectionHead: initialDocument.length,
+    });
+    expect(surface.appendProjection('u1', literalProjection('y'.repeat(34))).kind).toBe('appended');
+    view.replaceStateWithoutViewUpdate(externalReplacement);
+    const update = view.apply({ changes: { from: 0, insert: '!' } });
+    let failure: ReturnType<NoteSurface['validateExternalModification']> = null;
+
+    expect(() => {
+      failure = surface.observeTransaction(update);
+    }).not.toThrow();
+    expect(failure).toEqual({
+      documentLength: 4280,
+      kind: 'surface_desynchronized',
+      trackedPosition: 4314,
+    });
+    expect(onSurfaceDesynchronized).toHaveBeenCalledOnce();
+    expect(onSurfaceDesynchronized).toHaveBeenCalledWith(failure);
+    expect(doc(view)).toBe(`!${externalReplacement}`);
+  });
+
+  it('keeps appending after a live partial is replaced by a shorter final', () => {
+    const initialDocument = 'x'.repeat(4246);
+    const { surface, view } = createSurface({
+      doc: initialDocument,
+      selectionHead: initialDocument.length,
+    });
+    const partial = 'p'.repeat(68);
+    const final = 'f'.repeat(34);
+
+    expect(surface.appendProjection('u1', literalProjection(partial)).kind).toBe('appended');
+    expect(surface.replaceAnchor('u1', final, partial, false).kind).toBe('replaced');
+    expect(surface.appendProjection('u2', literalProjection('z')).kind).toBe('appended');
+
+    expect(doc(view)).toBe(`${initialDocument}${final}z`);
+  });
+
+  it.each([
+    ['anchor mode', (surface: NoteSurface) => surface.setAnchorMode('visible')],
+    ['processing range', (surface: NoteSurface) => surface.setProcessingRange({ from: 0, to: 1 })],
+    ['provisional range', (surface: NoteSurface) => surface.setProvisional('u1', true)],
+    ['pending prefix trim', (surface: NoteSurface) => surface.trimPendingInitialPrefix()],
+    ['dispose', (surface: NoteSurface) => surface.dispose()],
+  ] as const)('blocks %s mutation after an unmapped replacement', (_label, mutate) => {
+    const initialDocument = 'x'.repeat(4280);
+    const externalReplacement = 'r'.repeat(4280);
+    const { surface, view } = createSurface({
+      doc: initialDocument,
+      selectionHead: initialDocument.length,
+    });
+    expect(surface.appendProjection('u1', literalProjection('y'.repeat(34))).kind).toBe('appended');
+    view.replaceStateWithoutViewUpdate(externalReplacement);
+
+    expect(mutate(surface)).toEqual({
+      documentLength: 4280,
+      kind: 'surface_desynchronized',
+      trackedPosition: 4314,
+    });
+    expect(doc(view)).toBe(externalReplacement);
+  });
+
+  it('clears editor decorations when a desynchronized surface is disposed', () => {
+    const extensions = [
+      dictationAnchorExtension(),
+      provisionalTranscriptExtension(),
+      sessionProcessingExtension(),
+    ];
+    const initialDocument = 'x'.repeat(4280);
+    const externalReplacement = 'r'.repeat(4280);
+    const { surface, view } = createSurface({
+      doc: initialDocument,
+      extensions,
+      selectionHead: initialDocument.length,
+    });
+    expect(surface.appendProjection('u1', literalProjection('y'.repeat(34))).kind).toBe('appended');
+    let replacementState = EditorState.create({ doc: externalReplacement, extensions });
+    replacementState = replacementState.update({
+      effects: [
+        setAnchorEffect.of(100),
+        setAnchorModeEffect.of('visible'),
+        setProvisionalTranscriptEffect.of({ from: 0, to: 1, utteranceId: 'u1' }),
+        setSessionProcessingEffect.of({ from: 0, to: 1 }),
+      ],
+    }).state;
+    view.replaceEditorStateWithoutViewUpdate(replacementState);
+    const failure = surface.validateExternalModification();
+
+    expect(surface.dispose()).toEqual(failure);
+    expect(view.state.field(dictationAnchorStateField)).toEqual({ mode: 'hidden', pos: null });
+    expect(view.state.field(provisionalTranscriptStateField).size).toBe(0);
+    expect(view.state.field(sessionProcessingStateField)).toBeNull();
+    expect(doc(view)).toBe(externalReplacement);
+  });
+
   it('keeps same-cursor sessions ordered when the later session writes first', () => {
     const view = new FakeEditorView('', 0);
     const earlier = new NoteSurface(view as unknown as EditorView, { anchor: 'at_cursor' });
@@ -140,6 +343,31 @@ describe('NoteSurface', () => {
     later.observeTransaction(view.lastUpdate);
 
     expect(doc(view)).toBe('AB');
+  });
+
+  it('keeps same-cursor overlaps healthy when listeners observe an older append in creation order', () => {
+    const view = new FakeEditorView('', 0);
+    const earlierFailure = vi.fn();
+    const laterFailure = vi.fn();
+    const earlier = new NoteSurface(
+      view as unknown as EditorView,
+      { anchor: 'at_cursor' },
+      earlierFailure,
+    );
+    const later = new NoteSurface(
+      view as unknown as EditorView,
+      { anchor: 'at_cursor' },
+      laterFailure,
+    );
+    view.addUpdateListener((update) => earlier.observeTransaction(update));
+    view.addUpdateListener((update) => later.observeTransaction(update));
+
+    expect(append(earlier, 'earlier', 'A').kind).toBe('appended');
+    expect(append(later, 'later', 'B').kind).toBe('appended');
+
+    expect(doc(view)).toBe('A B');
+    expect(earlierFailure).not.toHaveBeenCalled();
+    expect(laterFailure).not.toHaveBeenCalled();
   });
 
   it('extends the writing-region tail past user text typed at the initial anchor before any utterance', () => {

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -10,6 +10,7 @@ import type {
   ReplaceResult,
   RewriteRange,
   RewriteResult,
+  SurfaceDesynchronization,
 } from '../src/editor/note-surface';
 import { Session } from '../src/session/session';
 import type {
@@ -41,15 +42,19 @@ class FakeSurface {
   public readonly readNoteText = vi.fn(
     (_maxChars: number): { text: string; truncated: boolean } | null => null,
   );
-  public readonly setAnchorMode = vi.fn();
+  public readonly setAnchorMode = vi.fn(
+    (_mode: 'hidden' | 'visible'): SurfaceDesynchronization | null => null,
+  );
   public readonly setProcessingRange = vi.fn(
-    (_range: { from: number; to: number } | null): void => undefined,
+    (_range: { from: number; to: number } | null): SurfaceDesynchronization | null => null,
   );
   public readonly setProvisional = vi.fn(
-    (_utteranceId: string, _provisional: boolean): void => undefined,
+    (_utteranceId: string, _provisional: boolean): SurfaceDesynchronization | null => null,
   );
-  public readonly validateExternalModification = vi.fn();
+  public readonly validateExternalModification = vi.fn((): SurfaceDesynchronization | null => null);
   public documentText = '';
+  public onSurfaceDesynchronized: ((failure: SurfaceDesynchronization) => void) | null = null;
+  public readonly appendResultByUtterance = new Map<string, AppendResult>();
   public nextAppendResult: AppendResult | null = null;
   public nextReplaceResult: ReplaceResult | null = null;
   public nextRewriteResult: RewriteResult | null = null;
@@ -65,17 +70,18 @@ class FakeSurface {
     this.appendCalls.push({ projection, utteranceId });
 
     const from = this.documentText.length;
-    const result = this.nextAppendResult ?? {
-      kind: 'appended',
-      span: {
-        end: from + projection.projectedText.length,
-        projectedText: projection.insertedText,
-        start: from,
-        textEnd: from + projection.textEndOffset,
-        textStart: from + projection.textStartOffset,
-        utteranceId,
-      },
-    };
+    const result = this.appendResultByUtterance.get(utteranceId) ??
+      this.nextAppendResult ?? {
+        kind: 'appended',
+        span: {
+          end: from + projection.projectedText.length,
+          projectedText: projection.insertedText,
+          start: from,
+          textEnd: from + projection.textEndOffset,
+          textStart: from + projection.textStartOffset,
+          utteranceId,
+        },
+      };
 
     if (result.kind === 'appended') {
       this.documentText = `${this.documentText}${projection.projectedText}`;
@@ -445,6 +451,118 @@ describe('Session', () => {
     });
   });
 
+  it('reports a fatal surface desynchronization once and stops projecting transcripts', () => {
+    const { callbacks, lockedFile, session, surface, vault } = createSessionHarness();
+    const failure: SurfaceDesynchronization = {
+      documentLength: 4280,
+      kind: 'surface_desynchronized',
+      trackedPosition: 4314,
+    };
+    surface.validateExternalModification.mockReturnValue(failure);
+
+    vault.trigger('modify', lockedFile);
+    vault.trigger('modify', lockedFile);
+    session.acceptTranscript(transcript({ text: 'must not be inserted', utteranceId: 'u1' }));
+
+    expect(callbacks.onSurfaceDesynchronized).toHaveBeenCalledOnce();
+    expect(callbacks.onSurfaceDesynchronized).toHaveBeenCalledWith(failure);
+    expect(surface.dispose).toHaveBeenCalledOnce();
+    expect(surface.appendCalls).toHaveLength(0);
+  });
+
+  it('forwards editor-update surface desynchronization through the lifecycle once', () => {
+    const { callbacks, surface } = createSessionHarness();
+    const failure: SurfaceDesynchronization = {
+      documentLength: 4280,
+      kind: 'surface_desynchronized',
+      trackedPosition: 4314,
+    };
+
+    surface.onSurfaceDesynchronized?.(failure);
+    surface.onSurfaceDesynchronized?.(failure);
+
+    expect(callbacks.onSurfaceDesynchronized).toHaveBeenCalledOnce();
+    expect(callbacks.onSurfaceDesynchronized).toHaveBeenCalledWith(failure);
+    expect(surface.dispose).toHaveBeenCalledOnce();
+  });
+
+  it('propagates a mutation-boundary desynchronization through the lifecycle once', () => {
+    const { callbacks, session, surface } = createSessionHarness();
+    const failure: SurfaceDesynchronization = {
+      documentLength: 4280,
+      kind: 'surface_desynchronized',
+      trackedPosition: 4314,
+    };
+    surface.nextAppendResult = {
+      kind: 'denied',
+      reason: failure,
+      utteranceId: 'u1',
+    };
+
+    session.acceptTranscript(transcript({ text: 'first', utteranceId: 'u1' }));
+    session.acceptTranscript(transcript({ text: 'second', utteranceId: 'u2' }));
+
+    expect(callbacks.onSurfaceDesynchronized).toHaveBeenCalledOnce();
+    expect(callbacks.onSurfaceDesynchronized).toHaveBeenCalledWith(failure);
+    expect(surface.dispose).toHaveBeenCalledOnce();
+    expect(surface.appendCalls).toHaveLength(1);
+  });
+
+  it('propagates a raw-callout append desynchronization through the lifecycle', () => {
+    const { callbacks, session, surface } = createSessionHarness();
+    const failure: SurfaceDesynchronization = {
+      documentLength: 4280,
+      kind: 'surface_desynchronized',
+      trackedPosition: 4314,
+    };
+    surface.appendResultByUtterance.set('u1:llm_raw', {
+      kind: 'denied',
+      reason: failure,
+      utteranceId: 'u1:llm_raw',
+    });
+
+    session.acceptTranscript(
+      transcript({
+        llmPostprocessRawText: 'raw words',
+        text: 'Cleaned words.',
+        utteranceId: 'u1',
+      }),
+    );
+
+    expect(callbacks.onSurfaceDesynchronized).toHaveBeenCalledOnce();
+    expect(callbacks.onSurfaceDesynchronized).toHaveBeenCalledWith(failure);
+    expect(surface.dispose).toHaveBeenCalledOnce();
+    expect(surface.documentText).toBe('Cleaned words.');
+  });
+
+  it('propagates desynchronization while clearing a denied replacement provisional', () => {
+    const { callbacks, session, surface } = createSessionHarness();
+    const failure: SurfaceDesynchronization = {
+      documentLength: 4280,
+      kind: 'surface_desynchronized',
+      trackedPosition: 4314,
+    };
+    session.acceptTranscript(
+      transcript({ isFinal: false, revision: 0, text: 'partial', utteranceId: 'u1' }),
+    );
+    surface.nextReplaceResult = {
+      kind: 'denied',
+      reason: { kind: 'user_edited' },
+      utteranceId: 'u1',
+    };
+    surface.setProvisional.mockReturnValueOnce(failure);
+
+    session.acceptTranscript(
+      transcript({ isFinal: true, revision: 1, text: 'final', utteranceId: 'u1' }),
+    );
+    session.acceptTranscript(transcript({ text: 'must not append', utteranceId: 'u2' }));
+
+    expect(callbacks.onSurfaceDesynchronized).toHaveBeenCalledOnce();
+    expect(callbacks.onSurfaceDesynchronized).toHaveBeenCalledWith(failure);
+    expect(surface.dispose).toHaveBeenCalledOnce();
+    expect(surface.appendCalls).toHaveLength(1);
+  });
+
   it('proxies readNoteGlossary to the active surface', () => {
     const { session, surface } = createSessionHarness();
     surface.readNoteGlossary.mockReturnValueOnce({
@@ -655,6 +773,7 @@ function createSessionHarness(options: { rendererOptions?: TranscriptRenderOptio
   callbacks: {
     onLockedNoteClosed: ReturnType<typeof vi.fn>;
     onLockedNoteDeleted: ReturnType<typeof vi.fn>;
+    onSurfaceDesynchronized: ReturnType<typeof vi.fn>;
   };
   lockedFile: TFile;
   session: Session;
@@ -669,6 +788,7 @@ function createSessionHarness(options: { rendererOptions?: TranscriptRenderOptio
   const callbacks = {
     onLockedNoteClosed: vi.fn(),
     onLockedNoteDeleted: vi.fn(),
+    onSurfaceDesynchronized: vi.fn(),
   };
   const app = { vault, workspace } as unknown as Pick<App, 'vault' | 'workspace'>;
   const placement: NotePlacementOptions = { anchor: 'at_cursor' };
@@ -676,7 +796,10 @@ function createSessionHarness(options: { rendererOptions?: TranscriptRenderOptio
     app,
     callbacks,
     lockedFile,
-    noteSurfaceFactory: () => surface,
+    noteSurfaceFactory: (_view, _placement, onSurfaceDesynchronized) => {
+      surface.onSurfaceDesynchronized = onSurfaceDesynchronized;
+      return surface;
+    },
     placement,
     rendererOptions: options.rendererOptions ?? renderOptions(),
     sessionId: 'session-1',


### PR DESCRIPTION
Closes #213.

## Summary

The supplied console capture showed seven consecutive CodeMirror failures after a note surface retained position 4314 while the editor document had been replaced with a 4280-character state. Recording continued, but later utterances could not be inserted.

This change establishes tracked editor coordinates as an invariant at the `NoteSurface` boundary. An unmappable replacement becomes one typed terminal outcome: preserve the note, stop the affected session once, cancel remaining provider/sidecar work, and tell the user to restart dictation. It never clamps or guesses a new insertion point.

## Decisions

- Validate every position-bearing editor mutation before dispatch and return a typed `surface_desynchronized` result containing only safe positional metadata.
- Validate external modifications proactively and validate again at mutation boundaries to close races.
- Preflight only positions owned by the current surface against a `ViewUpdate` start-state length; keep sibling-aware writing-tail validation at actual mutation boundaries where the combined insertion position is used.
- Detect stale coordinates before any CodeMirror position mapping, preventing the mapper itself from throwing.
- Let `NoteSurface` synchronously notify its owning `Session` when a view-update-originated failure has no direct caller to receive the typed result.
- Preserve the externally replaced note byte-for-byte; clear only Local Dictation's anchor/provisional/processing decorations during containment.
- Propagate fatal outcomes through all append, replace, rewrite, raw-callout, provisional, anchor, and processing-range paths.
- Use one controller terminal flag for single-shot logging/feedback and for dropping later/new transcript events before logging, provider work, or insertion.
- Catch unexpected synchronous projection exceptions at the acceptance boundary so concurrent revisions cannot write before an outer promise catch runs.
- Abort pending per-utterance and batch provider work when fatal containment begins, including failures observed after `session_stopped`.
- Make sidecar cancellation single-flight per session; concurrent close/error/user/fatal cancellation sources reuse one in-flight operation and send one cancel command.
- Re-check the fatal terminal state after pending transcript drain and every synchronous batch-cleanup mutation, before/after provider work, before success/failure callbacks, and before ordinary range-unavailable logs.
- Keep normal mapped edits, shorter partial-to-final replacements, overlapping sessions, stopped-phase final draining, and ordinary user-edited latching unchanged.
- Keep navigation protection separate in #216.

## Verification

- Original minimized reproduction: 4280-character note, 34-character append, unobserved replacement back to 4280, external validation/ordinary editor update, then another append. It returns one typed terminal result, never dispatches an invalid range, and preserves replacement content.
- Final focused note-surface/session/controller suite after the overlap correction: 3 files / 125 tests passed.
- Real listener-order overlap regression: reproduced the false fatal before the correction, then passed with both same-cursor sessions healthy.
- Seven concurrency/batch/cancellation regressions went red before their fixes and green afterward.
- Full `npm run check:frontend` before the final narrow overlap correction: 50 files / 652 tests passed; typecheck, Biome, Obsidian ESLint, and production build passed.
- Final targeted Biome check and `git diff --check` passed.

Independent review found and drove fixes for:

- stopped-phase fatal reporting;
- raw-callout and denied-provisional propagation;
- pre-map view-update failure;
- concurrent partial accepts and post-failure provider work;
- batch cleanup continuing after fatal state;
- non-idempotent concurrent cancellation;
- a false fatal when sequential overlapping-surface listeners mixed a sibling's mapped position with the current update's start-state length.

## Review status

The final Standards audit of `499b6bf` found the overlapping-surface listener-order issue above. It is fixed in `ba7cf02` with an owned-position transaction preflight, and its regression is green.

An exact-`ba7cf02` final Spec audit could not be launched because stale completed-agent thread accounting consumed the available review slot. Earlier independent Spec audits covered issue #213 and drove the batch-terminal and single-flight cancellation corrections. This remains a draft pending CI and maintainer review.

## Scope

This PR contains a correctness failure. It does not pin tabs, recover/guess an anchor after an unmapped replacement, redesign general logging/notices, or change recognition/transcript formatting.
