### PR TITLE
Keep dictated note open during navigation

### DIFF
--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -94,6 +94,9 @@ interface ActiveSessionSnapshot {
 }
 
 type SessionPhase = 'starting' | 'active' | 'stopping' | 'cancelling' | 'stopped';
+// Stable across sidecar lifecycle acknowledgements: graceful terminal feedback
+// may still drain accepted work, while cancellation permanently rejects writes.
+type SessionTermination = 'open' | 'feedback-claimed' | 'cancelled';
 
 interface ManagedSession {
   anchorTimerId: number | null;
@@ -101,13 +104,16 @@ interface ManagedSession {
   // in final-event order. Partials bypass it and project immediately.
   cleanupChain: Promise<void>;
   cleanupAbortControllers: Set<AbortController>;
-  fatalTranscriptFailureReported: boolean;
   llmFailureLogged: boolean;
   pendingTranscriptWork: Set<Promise<void>>;
   phase: SessionPhase;
   session: ControllerSession;
   snapshot: ActiveSessionSnapshot;
-  terminalFeedbackReported: boolean;
+  termination: SessionTermination;
+}
+
+function rejectsTranscriptWork(entry: ManagedSession): boolean {
+  return entry.termination === 'cancelled';
 }
 
 interface DictationSessionControllerDependencies {
@@ -342,13 +348,12 @@ export class DictationSessionController {
       anchorTimerId: null,
       cleanupChain: Promise.resolve(),
       cleanupAbortControllers: new Set(),
-      fatalTranscriptFailureReported: false,
       llmFailureLogged: false,
       pendingTranscriptWork: new Set(),
       phase: 'starting',
       session,
       snapshot,
-      terminalFeedbackReported: false,
+      termination: 'open',
     };
     this.sessions.set(sessionId, entry);
     this.activeSessionId = sessionId;
@@ -461,12 +466,12 @@ export class DictationSessionController {
       return;
     }
 
+    this.handleError(FEEDBACK_FAILURES.startDictation, error, entry);
     if (entry.phase === 'starting') {
       this.disposeLocalSession(sessionId);
     } else {
       await this.cancelSession(sessionId);
     }
-    this.handleError(FEEDBACK_FAILURES.startDictation, error, entry);
   }
 
   private async assertMicrophoneInputAvailable(): Promise<void> {
@@ -497,6 +502,7 @@ export class DictationSessionController {
     // Establish the terminal state before capture teardown yields. Every caller
     // then joins the same promise, so concurrent failure sources cannot send
     // duplicate cancellation commands to the sidecar.
+    entry.termination = 'cancelled';
     entry.phase = 'cancelling';
     this.abortProviderCleanups(entry);
     const cancellation = Promise.resolve().then(() => this.completeSessionCancellation(sessionId));
@@ -753,7 +759,7 @@ export class DictationSessionController {
 
   private async handleTranscriptReady(event: TranscriptReadyEvent): Promise<void> {
     const entry = this.sessions.get(event.sessionId);
-    if (entry === undefined || entry.fatalTranscriptFailureReported) {
+    if (entry === undefined || rejectsTranscriptWork(entry)) {
       return;
     }
 
@@ -827,7 +833,7 @@ export class DictationSessionController {
       revision === null ||
       !this.sessions.has(sessionId) ||
       entry.phase === 'cancelling' ||
-      entry.fatalTranscriptFailureReported
+      rejectsTranscriptWork(entry)
     ) {
       return;
     }
@@ -838,7 +844,7 @@ export class DictationSessionController {
       this.cancelOnFatalTranscriptFailure(sessionId, FEEDBACK_FAILURES.transcriptWrite, error);
       return;
     }
-    if (entry.fatalTranscriptFailureReported) {
+    if (rejectsTranscriptWork(entry)) {
       return;
     }
     if (result.kind === 'rejected') {
@@ -1006,7 +1012,9 @@ export class DictationSessionController {
       'session',
       `session ${event.sessionId} stopped (reason: ${event.reason})`,
     );
-    entry.phase = 'stopped';
+    if (!rejectsTranscriptWork(entry)) {
+      entry.phase = 'stopped';
+    }
 
     if (event.sessionId === this.activeSessionId) {
       this.activeSessionId = null;
@@ -1223,7 +1231,7 @@ export class DictationSessionController {
     if (this.sessions.get(sessionId) !== entry) {
       return true;
     }
-    if (!entry.fatalTranscriptFailureReported) {
+    if (!rejectsTranscriptWork(entry)) {
       return false;
     }
 
@@ -1364,11 +1372,10 @@ export class DictationSessionController {
     details: unknown,
   ): void {
     const entry = this.sessions.get(sessionId);
-    if (entry === undefined || entry.fatalTranscriptFailureReported) {
+    if (entry === undefined || rejectsTranscriptWork(entry)) {
       return;
     }
 
-    entry.fatalTranscriptFailureReported = true;
     this.abortProviderCleanups(entry);
     this.reportTerminalFeedback(entry, {
       cause: details,
@@ -1376,6 +1383,7 @@ export class DictationSessionController {
       key: failure.key,
       message: failure.message,
     });
+    entry.termination = 'cancelled';
 
     if (entry.phase === 'cancelling' || entry.phase === 'stopped') {
       return;
@@ -1388,11 +1396,11 @@ export class DictationSessionController {
   }
 
   private reportTerminalFeedback(entry: ManagedSession, request: FeedbackRequest): boolean {
-    if (entry.terminalFeedbackReported) {
+    if (entry.termination !== 'open') {
       return false;
     }
 
-    entry.terminalFeedbackReported = true;
+    entry.termination = 'feedback-claimed';
     this.dependencies.feedback.show(request);
     return true;
   }

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -441,7 +441,7 @@ export class DictationSessionController {
       this.dependencies.sidecarConnection.requestStopSession(sessionId);
     } catch (error) {
       this.disposeLocalSession(sessionId);
-      this.handleError(FEEDBACK_FAILURES.stopDictation, error);
+      this.handleError(FEEDBACK_FAILURES.stopDictation, error, entry);
     }
   }
 
@@ -466,7 +466,7 @@ export class DictationSessionController {
     } else {
       await this.cancelSession(sessionId);
     }
-    this.handleError(FEEDBACK_FAILURES.startDictation, error);
+    this.handleError(FEEDBACK_FAILURES.startDictation, error, entry);
   }
 
   private async assertMicrophoneInputAvailable(): Promise<void> {
@@ -672,6 +672,9 @@ export class DictationSessionController {
     if (entry === undefined) {
       return;
     }
+    if (entry.phase === 'cancelling') {
+      return;
+    }
 
     this.applySessionStateToAnchor(entry, event.state);
 
@@ -839,7 +842,7 @@ export class DictationSessionController {
       return;
     }
     if (result.kind === 'rejected') {
-      this.handleError(FEEDBACK_FAILURES.recordTranscript, new Error(result.reason));
+      this.handleError(FEEDBACK_FAILURES.recordTranscript, new Error(result.reason), entry);
       await this.cancelSession(sessionId);
     }
   }
@@ -1256,7 +1259,12 @@ export class DictationSessionController {
 
     if (event.sessionId === this.activeSessionId) {
       this.applyUiState('error');
-      this.dependencies.feedback.show({ intent: 'error', message: detail });
+      this.reportTerminalFeedback(entry, {
+        cause: { code: event.code, details: event.details, sessionId: event.sessionId },
+        intent: 'error',
+        key: FEEDBACK_FAILURES.sidecar.key,
+        message: detail,
+      });
     } else {
       this.dependencies.logger?.warn('session', detail);
     }
@@ -1282,10 +1290,14 @@ export class DictationSessionController {
     if (entry === undefined) {
       return;
     }
+    if (entry.phase === 'cancelling') {
+      return;
+    }
 
     const detail = event.details ? `${event.message} (${event.details})` : event.message;
     if (sessionId === this.activeSessionId) {
-      this.dependencies.feedback.show({
+      this.reportTerminalFeedback(entry, {
+        cause: { code: event.code, details: event.details, sessionId },
         intent: 'warning',
         key: 'utterance-queue-overload',
         message: detail,
@@ -1382,15 +1394,22 @@ export class DictationSessionController {
     this.dependencies.feedback.show(request);
   }
 
-  private handleError(failure: FeedbackFailure, error: unknown): void {
+  private handleError(failure: FeedbackFailure, error: unknown, entry?: ManagedSession): void {
     this.applyUiState('error');
+    const report = (request: FeedbackRequest): void => {
+      if (entry === undefined) {
+        this.dependencies.feedback.show(request);
+        return;
+      }
+      this.reportTerminalFeedback(entry, request);
+    };
 
     // Microphone-capture failures get specific, actionable copy that stands on
     // its own; prefixing it with the generic start-failure message just buries
     // the instructions. The Settings mic picker shows the same copy for parity.
     const microphoneMessage = formatMicrophoneCaptureErrorMessage(error);
     if (microphoneMessage !== null) {
-      this.dependencies.feedback.show({
+      report({
         cause: error,
         intent: 'action-required',
         key: 'microphone-permission',
@@ -1401,7 +1420,7 @@ export class DictationSessionController {
 
     const systemAudioMessage = formatSystemAudioSidecarErrorMessage(error);
     if (systemAudioMessage !== null) {
-      this.dependencies.feedback.show({
+      report({
         cause: error,
         intent: 'action-required',
         key: 'system-audio-permission',
@@ -1410,7 +1429,7 @@ export class DictationSessionController {
       return;
     }
 
-    this.dependencies.feedback.show({
+    report({
       cause: error,
       intent: 'error',
       key: failure.key,

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -107,6 +107,7 @@ interface ManagedSession {
   phase: SessionPhase;
   session: ControllerSession;
   snapshot: ActiveSessionSnapshot;
+  targetLossReported: boolean;
 }
 
 interface DictationSessionControllerDependencies {
@@ -173,6 +174,16 @@ const FEEDBACK_FAILURES = {
   stopDictation: {
     key: 'dictation-stop-failed',
     message: 'Could not stop dictation.',
+  },
+  targetNoteClosed: {
+    key: 'dictation-target-closed',
+    message:
+      'Dictation stopped because its target note was closed or replaced. Start dictation again to continue.',
+  },
+  targetNoteDeleted: {
+    key: 'dictation-target-deleted',
+    message:
+      'Dictation stopped because its target note was deleted. Restore or recreate the note, then start dictation again.',
   },
   transcriptWrite: {
     key: 'transcript-write-failed',
@@ -337,6 +348,7 @@ export class DictationSessionController {
       phase: 'starting',
       session,
       snapshot,
+      targetLossReported: false,
     };
     this.sessions.set(sessionId, entry);
     this.activeSessionId = sessionId;
@@ -1314,11 +1326,22 @@ export class DictationSessionController {
   }
 
   private cancelOnLockedNoteEvent(sessionId: string, reason: 'closed' | 'deleted'): void {
-    if (!this.sessions.has(sessionId)) {
+    const entry = this.sessions.get(sessionId);
+    if (entry === undefined || entry.targetLossReported) {
       return;
     }
 
-    this.dependencies.logger?.warn('session', `locked note ${reason} for session ${sessionId}`);
+    entry.targetLossReported = true;
+    const failure =
+      reason === 'closed'
+        ? FEEDBACK_FAILURES.targetNoteClosed
+        : FEEDBACK_FAILURES.targetNoteDeleted;
+    this.dependencies.feedback.show({
+      cause: { reason, sessionId },
+      intent: 'warning',
+      key: failure.key,
+      message: failure.message,
+    });
     void this.cancelSession(sessionId);
   }
 

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -94,9 +94,9 @@ interface ActiveSessionSnapshot {
 }
 
 type SessionPhase = 'starting' | 'active' | 'stopping' | 'cancelling' | 'stopped';
-// Stable across sidecar lifecycle acknowledgements: graceful terminal feedback
-// may still drain accepted work, while cancellation permanently rejects writes.
-type SessionTermination = 'open' | 'feedback-claimed' | 'cancelled';
+// Stable across sidecar lifecycle acknowledgements. Terminal causes claim the
+// feedback slot, while cancellation also permanently rejects transcript work.
+type TerminalArbitrationState = 'open' | 'feedback-claimed' | 'cancelled';
 
 interface ManagedSession {
   anchorTimerId: number | null;
@@ -109,11 +109,11 @@ interface ManagedSession {
   phase: SessionPhase;
   session: ControllerSession;
   snapshot: ActiveSessionSnapshot;
-  termination: SessionTermination;
+  terminalArbitration: TerminalArbitrationState;
 }
 
 function rejectsTranscriptWork(entry: ManagedSession): boolean {
-  return entry.termination === 'cancelled';
+  return entry.terminalArbitration === 'cancelled';
 }
 
 interface DictationSessionControllerDependencies {
@@ -353,7 +353,7 @@ export class DictationSessionController {
       phase: 'starting',
       session,
       snapshot,
-      termination: 'open',
+      terminalArbitration: 'open',
     };
     this.sessions.set(sessionId, entry);
     this.activeSessionId = sessionId;
@@ -502,7 +502,7 @@ export class DictationSessionController {
     // Establish the terminal state before capture teardown yields. Every caller
     // then joins the same promise, so concurrent failure sources cannot send
     // duplicate cancellation commands to the sidecar.
-    entry.termination = 'cancelled';
+    entry.terminalArbitration = 'cancelled';
     entry.phase = 'cancelling';
     this.abortProviderCleanups(entry);
     const cancellation = Promise.resolve().then(() => this.completeSessionCancellation(sessionId));
@@ -1306,7 +1306,10 @@ export class DictationSessionController {
 
     const detail = event.details ? `${event.message} (${event.details})` : event.message;
     if (sessionId === this.activeSessionId) {
-      this.reportTerminalFeedback(entry, {
+      // Queue overload is a graceful stop, not a cancellation cause. Keep its
+      // warning outside terminal arbitration so a later target loss can explain
+      // why accepted work was discarded while the queue was draining.
+      this.dependencies.feedback.show({
         cause: { code: event.code, details: event.details, sessionId },
         intent: 'warning',
         key: 'utterance-queue-overload',
@@ -1383,7 +1386,7 @@ export class DictationSessionController {
       key: failure.key,
       message: failure.message,
     });
-    entry.termination = 'cancelled';
+    entry.terminalArbitration = 'cancelled';
 
     if (entry.phase === 'cancelling' || entry.phase === 'stopped') {
       return;
@@ -1396,11 +1399,11 @@ export class DictationSessionController {
   }
 
   private reportTerminalFeedback(entry: ManagedSession, request: FeedbackRequest): boolean {
-    if (entry.termination !== 'open') {
+    if (entry.terminalArbitration !== 'open') {
       return false;
     }
 
-    entry.termination = 'feedback-claimed';
+    entry.terminalArbitration = 'feedback-claimed';
     this.dependencies.feedback.show(request);
     return true;
   }

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -1258,13 +1258,15 @@ export class DictationSessionController {
     }
 
     if (event.sessionId === this.activeSessionId) {
-      this.applyUiState('error');
-      this.reportTerminalFeedback(entry, {
+      const reported = this.reportTerminalFeedback(entry, {
         cause: { code: event.code, details: event.details, sessionId: event.sessionId },
         intent: 'error',
         key: FEEDBACK_FAILURES.sidecar.key,
         message: detail,
       });
+      if (reported) {
+        this.applyUiState('error');
+      }
     } else {
       this.dependencies.logger?.warn('session', detail);
     }
@@ -1385,56 +1387,57 @@ export class DictationSessionController {
     void this.cancelSession(sessionId);
   }
 
-  private reportTerminalFeedback(entry: ManagedSession, request: FeedbackRequest): void {
+  private reportTerminalFeedback(entry: ManagedSession, request: FeedbackRequest): boolean {
     if (entry.terminalFeedbackReported) {
-      return;
+      return false;
     }
 
     entry.terminalFeedbackReported = true;
     this.dependencies.feedback.show(request);
+    return true;
   }
 
   private handleError(failure: FeedbackFailure, error: unknown, entry?: ManagedSession): void {
-    this.applyUiState('error');
-    const report = (request: FeedbackRequest): void => {
-      if (entry === undefined) {
-        this.dependencies.feedback.show(request);
-        return;
-      }
-      this.reportTerminalFeedback(entry, request);
-    };
-
     // Microphone-capture failures get specific, actionable copy that stands on
     // its own; prefixing it with the generic start-failure message just buries
     // the instructions. The Settings mic picker shows the same copy for parity.
     const microphoneMessage = formatMicrophoneCaptureErrorMessage(error);
+    let request: FeedbackRequest;
     if (microphoneMessage !== null) {
-      report({
+      request = {
         cause: error,
         intent: 'action-required',
         key: 'microphone-permission',
         message: microphoneMessage,
-      });
-      return;
+      };
+    } else {
+      const systemAudioMessage = formatSystemAudioSidecarErrorMessage(error);
+      request =
+        systemAudioMessage === null
+          ? {
+              cause: error,
+              intent: 'error',
+              key: failure.key,
+              message: failure.message,
+            }
+          : {
+              cause: error,
+              intent: 'action-required',
+              key: 'system-audio-permission',
+              message: systemAudioMessage,
+            };
     }
 
-    const systemAudioMessage = formatSystemAudioSidecarErrorMessage(error);
-    if (systemAudioMessage !== null) {
-      report({
-        cause: error,
-        intent: 'action-required',
-        key: 'system-audio-permission',
-        message: systemAudioMessage,
-      });
-      return;
+    let reported: boolean;
+    if (entry === undefined) {
+      this.dependencies.feedback.show(request);
+      reported = true;
+    } else {
+      reported = this.reportTerminalFeedback(entry, request);
     }
-
-    report({
-      cause: error,
-      intent: 'error',
-      key: failure.key,
-      message: failure.message,
-    });
+    if (reported) {
+      this.applyUiState('error');
+    }
   }
 }
 

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -24,7 +24,7 @@ import type { PluginSettings, SmartParagraphPauseSettings } from '../settings/pl
 import { formatErrorMessage } from '../shared/format-utils';
 import type { PluginLogger } from '../shared/plugin-logger';
 import { truncateLeadingText } from '../shared/text-truncation';
-import type { UserFeedback } from '../shared/user-feedback';
+import type { FeedbackRequest, UserFeedback } from '../shared/user-feedback';
 import type {
   ContextRequestEvent,
   ContextWindow,
@@ -107,7 +107,7 @@ interface ManagedSession {
   phase: SessionPhase;
   session: ControllerSession;
   snapshot: ActiveSessionSnapshot;
-  targetLossReported: boolean;
+  terminalFeedbackReported: boolean;
 }
 
 interface DictationSessionControllerDependencies {
@@ -348,7 +348,7 @@ export class DictationSessionController {
       phase: 'starting',
       session,
       snapshot,
-      targetLossReported: false,
+      terminalFeedbackReported: false,
     };
     this.sessions.set(sessionId, entry);
     this.activeSessionId = sessionId;
@@ -1327,16 +1327,15 @@ export class DictationSessionController {
 
   private cancelOnLockedNoteEvent(sessionId: string, reason: 'closed' | 'deleted'): void {
     const entry = this.sessions.get(sessionId);
-    if (entry === undefined || entry.targetLossReported) {
+    if (entry === undefined) {
       return;
     }
 
-    entry.targetLossReported = true;
     const failure =
       reason === 'closed'
         ? FEEDBACK_FAILURES.targetNoteClosed
         : FEEDBACK_FAILURES.targetNoteDeleted;
-    this.dependencies.feedback.show({
+    this.reportTerminalFeedback(entry, {
       cause: { reason, sessionId },
       intent: 'warning',
       key: failure.key,
@@ -1357,7 +1356,7 @@ export class DictationSessionController {
 
     entry.fatalTranscriptFailureReported = true;
     this.abortProviderCleanups(entry);
-    this.dependencies.feedback.show({
+    this.reportTerminalFeedback(entry, {
       cause: details,
       intent: 'error',
       key: failure.key,
@@ -1372,6 +1371,15 @@ export class DictationSessionController {
     // observes the terminal phase and cannot repeat the failure.
     entry.phase = 'cancelling';
     void this.cancelSession(sessionId);
+  }
+
+  private reportTerminalFeedback(entry: ManagedSession, request: FeedbackRequest): void {
+    if (entry.terminalFeedbackReported) {
+      return;
+    }
+
+    entry.terminalFeedbackReported = true;
+    this.dependencies.feedback.show(request);
   }
 
   private handleError(failure: FeedbackFailure, error: unknown): void {

--- a/src/editor/temporary-leaf-pin.ts
+++ b/src/editor/temporary-leaf-pin.ts
@@ -1,0 +1,95 @@
+import type { EventRef } from 'obsidian';
+
+export interface PinnableLeaf {
+  getViewState(): { pinned?: boolean };
+  offref(ref: EventRef): void;
+  on(name: 'pinned-change', callback: (pinned: boolean) => unknown): EventRef;
+  setPinned(pinned: boolean): void;
+}
+
+export interface TemporaryLeafPinLease {
+  release(): void;
+}
+
+interface SharedPinLease {
+  leaseCount: number;
+  ownsTemporaryPin: boolean;
+  pinnedChangeRef: EventRef | null;
+}
+
+/**
+ * Coordinates temporary pin ownership per leaf. A single shared record owns the
+ * pin mutation and listener even when an older session is still draining while
+ * a newer session targets the same editor leaf.
+ */
+export class TemporaryLeafPinLeaseManager {
+  private readonly leasesByLeaf = new WeakMap<PinnableLeaf, SharedPinLease>();
+
+  acquire(leaf: PinnableLeaf, isTargetLive: () => boolean): TemporaryLeafPinLease {
+    const existing = this.leasesByLeaf.get(leaf);
+    if (existing !== undefined) {
+      existing.leaseCount += 1;
+      return this.createLease(leaf, existing, isTargetLive);
+    }
+
+    const shared: SharedPinLease = {
+      leaseCount: 1,
+      ownsTemporaryPin: leaf.getViewState().pinned !== true,
+      pinnedChangeRef: null,
+    };
+    const pinnedChangeRef = leaf.on('pinned-change', (pinned) => {
+      if (!pinned) {
+        shared.ownsTemporaryPin = false;
+      }
+    });
+    shared.pinnedChangeRef = pinnedChangeRef;
+    this.leasesByLeaf.set(leaf, shared);
+
+    if (shared.ownsTemporaryPin) {
+      try {
+        leaf.setPinned(true);
+      } catch (error) {
+        leaf.offref(pinnedChangeRef);
+        this.leasesByLeaf.delete(leaf);
+        throw error;
+      }
+    }
+
+    return this.createLease(leaf, shared, isTargetLive);
+  }
+
+  private createLease(
+    leaf: PinnableLeaf,
+    shared: SharedPinLease,
+    isTargetLive: () => boolean,
+  ): TemporaryLeafPinLease {
+    let released = false;
+
+    return {
+      release: () => {
+        if (released) {
+          return;
+        }
+        released = true;
+
+        if (this.leasesByLeaf.get(leaf) !== shared) {
+          return;
+        }
+
+        shared.leaseCount -= 1;
+        if (shared.leaseCount > 0) {
+          return;
+        }
+
+        if (shared.pinnedChangeRef !== null) {
+          leaf.offref(shared.pinnedChangeRef);
+        }
+        this.leasesByLeaf.delete(leaf);
+
+        if (shared.ownsTemporaryPin && isTargetLive() && leaf.getViewState().pinned === true) {
+          leaf.setPinned(false);
+        }
+      },
+    };
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { dictationAnchorExtension } from './editor/dictation-anchor-extension';
 import { noteSurfaceUpdateListenerExtension } from './editor/note-surface';
 import { provisionalTranscriptExtension } from './editor/provisional-transcript-extension';
 import { sessionProcessingExtension } from './editor/session-processing-extension';
+import { TemporaryLeafPinLeaseManager } from './editor/temporary-leaf-pin';
 import type { LlmCleanupFailure } from './llm/provider';
 import { createLlmRouter } from './llm/router';
 import { ManageModelsModal } from './models/manage-models-modal';
@@ -67,6 +68,7 @@ export default class LocalSttPlugin extends Plugin {
   private settings: PluginSettings = DEFAULT_PLUGIN_SETTINGS;
   private sidecarConnection: SidecarConnection | null = null;
   private sidecarInstallManager: SidecarInstallManager | null = null;
+  private readonly temporaryLeafPinLeaseManager = new TemporaryLeafPinLeaseManager();
 
   override async onload(): Promise<void> {
     const loadedSettings = loadPluginSettings(await this.loadData(), this.app.secretStorage);
@@ -161,6 +163,7 @@ export default class LocalSttPlugin extends Plugin {
       createSession: ({ callbacks, placement, rendererOptions, sessionId }) =>
         Session.createFromActiveEditor(this.app, {
           callbacks,
+          leafPinManager: this.temporaryLeafPinLeaseManager,
           logger: this.logger,
           placement,
           rendererOptions,

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -14,6 +14,11 @@ import {
   type RewriteResult,
   type SurfaceDesynchronization,
 } from '../editor/note-surface';
+import type {
+  PinnableLeaf,
+  TemporaryLeafPinLease,
+  TemporaryLeafPinLeaseManager,
+} from '../editor/temporary-leaf-pin';
 import type { PluginLogger } from '../shared/plugin-logger';
 import { truncateLeadingText } from '../shared/text-truncation';
 import {
@@ -32,7 +37,7 @@ interface MarkdownFileInfoLike {
   file: TFile | null;
 }
 
-interface MarkdownLeafLike {
+interface MarkdownLeafLike extends PinnableLeaf {
   view?: MarkdownFileInfoLike;
 }
 
@@ -62,6 +67,7 @@ export interface SessionLifecycleCallbacks {
 export interface SessionDependencies {
   app: Pick<App, 'vault' | 'workspace'>;
   callbacks: SessionLifecycleCallbacks;
+  leafPinManager: Pick<TemporaryLeafPinLeaseManager, 'acquire'>;
   logger?: PluginLogger;
   lockedFile: TFile;
   noteSurfaceFactory?: (
@@ -109,6 +115,8 @@ interface RawSessionEntry {
 export class Session {
   private readonly journal: SessionJournal;
   private readonly renderer: TranscriptRenderer;
+  private readonly targetLeaf: MarkdownLeafLike | null;
+  private leafPinLease: TemporaryLeafPinLease | null = null;
   private noteDeleted = false;
   private noteOpen = true;
   private readonly projectionByUtterance = new Map<string, ProjectionState>();
@@ -122,6 +130,7 @@ export class Session {
     app: Pick<App, 'vault' | 'workspace'>,
     options: {
       callbacks: SessionLifecycleCallbacks;
+      leafPinManager: Pick<TemporaryLeafPinLeaseManager, 'acquire'>;
       logger?: PluginLogger;
       placement: NotePlacementOptions;
       rendererOptions: TranscriptRenderOptions;
@@ -143,6 +152,7 @@ export class Session {
     return new Session({
       app,
       callbacks: options.callbacks,
+      leafPinManager: options.leafPinManager,
       lockedFile: target.file,
       placement,
       rendererOptions: options.rendererOptions,
@@ -162,7 +172,9 @@ export class Session {
         this.handleSurfaceDesynchronization(failure);
       },
     );
+    this.targetLeaf = findOpenMarkdownLeafForEditor(dependencies.app, dependencies.view);
     this.registerLifecycleSubscriptions();
+    this.acquireLeafPinLease();
   }
 
   acceptTranscript(revision: TranscriptRevision): SessionAcceptResult {
@@ -335,6 +347,7 @@ export class Session {
     this.surface?.dispose();
     this.surface = null;
     this.releaseSubscriptions();
+    this.releaseLeafPinLease();
   }
 
   private projectRevision(revision: TranscriptRevision): void {
@@ -573,7 +586,7 @@ export class Session {
       return;
     }
 
-    if (this.hasOpenLockedFile()) {
+    if (this.hasLiveTargetSurface()) {
       return;
     }
 
@@ -634,9 +647,61 @@ export class Session {
     }
   }
 
-  private hasOpenLockedFile(): boolean {
+  private acquireLeafPinLease(): void {
+    if (this.targetLeaf === null) {
+      this.dependencies.logger?.debug(
+        'session',
+        'navigation protection unavailable: exact editor leaf could not be resolved',
+      );
+      return;
+    }
+
+    try {
+      this.leafPinLease = this.dependencies.leafPinManager.acquire(this.targetLeaf, () =>
+        this.isExactTargetLeafLive(),
+      );
+    } catch (error) {
+      this.dependencies.logger?.debug(
+        'session',
+        'navigation protection unavailable: temporary leaf pin could not be acquired',
+        error,
+      );
+    }
+  }
+
+  private releaseLeafPinLease(): void {
+    const lease = this.leafPinLease;
+    this.leafPinLease = null;
+
+    try {
+      lease?.release();
+    } catch (error) {
+      this.dependencies.logger?.warn(
+        'session',
+        'failed to restore the temporary dictation leaf pin',
+        error,
+      );
+    }
+  }
+
+  private hasLiveTargetSurface(): boolean {
+    if (this.targetLeaf !== null) {
+      return this.isExactTargetLeafLive();
+    }
+
     return (
       findOpenMarkdownViewForFile(this.dependencies.app, this.dependencies.lockedFile) !== null
+    );
+  }
+
+  private isExactTargetLeafLive(): boolean {
+    if (this.targetLeaf === null) {
+      return false;
+    }
+
+    return (
+      findOpenMarkdownLeafForEditor(this.dependencies.app, this.dependencies.view) ===
+      this.targetLeaf
     );
   }
 
@@ -761,6 +826,26 @@ function findOpenMarkdownViewForFile(
   }
 
   return null;
+}
+
+function findOpenMarkdownLeafForEditor(
+  app: Pick<App, 'workspace'>,
+  targetView: EditorView,
+): MarkdownLeafLike | null {
+  let match: MarkdownLeafLike | null = null;
+
+  for (const leaf of app.workspace.getLeavesOfType('markdown') as unknown as MarkdownLeafLike[]) {
+    if (leaf.view?.editor?.cm !== targetView) {
+      continue;
+    }
+
+    if (match !== null) {
+      return null;
+    }
+    match = leaf;
+  }
+
+  return match;
 }
 
 function formatRawPostprocessCallout(rawText: string): string {

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -879,6 +879,50 @@ describe('DictationSessionController', () => {
 
   it.each([
     {
+      error: (sessionId: string): SidecarEvent => ({
+        code: 'inference_failed',
+        message: 'The speech engine failed.',
+        sessionId,
+        type: 'error',
+      }),
+      source: 'sidecar error',
+    },
+    {
+      error: (sessionId: string): SidecarEvent => ({
+        code: 'utterance_queue_overload',
+        message: 'The transcription backlog reached capacity.',
+        sessionId,
+        type: 'error',
+      }),
+      source: 'queue overload',
+    },
+  ])('keeps target-loss feedback when it races a $source', async ({ error, source: _source }) => {
+    const show = vi.fn();
+    const sidecarConnection = new FakeSidecarConnection();
+    let onLockedNoteClosed: (() => void) | undefined;
+    const controller = createController({
+      createSession: (_session, options) => {
+        onLockedNoteClosed = options.callbacks.onLockedNoteClosed;
+      },
+      feedback: { show },
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+
+    onLockedNoteClosed?.();
+    sidecarConnection.emit(error(sessionId));
+
+    await vi.waitFor(() => {
+      expect(sidecarConnection.cancelSession).toHaveBeenCalledOnce();
+    });
+    expect(show).toHaveBeenCalledOnce();
+    expect(show).toHaveBeenCalledWith(expect.objectContaining({ key: 'dictation-target-closed' }));
+  });
+
+  it.each([
+    {
       callback: 'onLockedNoteClosed' as const,
       expectedKey: 'dictation-target-closed',
       expectedMessage:

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -800,8 +800,9 @@ describe('DictationSessionController', () => {
     expect(cleanup).not.toHaveBeenCalled();
   });
 
-  it('sends one sidecar cancel when fatal containment races another cancellation source', async () => {
+  it('reports and cancels once when fatal containment races target loss', async () => {
     const captureStream = new FakeCaptureStream();
+    const show = vi.fn();
     const sidecarConnection = new FakeSidecarConnection();
     let onLockedNoteClosed: (() => void) | undefined;
     let onSurfaceDesynchronized: ((failure: SurfaceDesynchronization) => void) | undefined;
@@ -818,6 +819,7 @@ describe('DictationSessionController', () => {
         onLockedNoteClosed = options.callbacks.onLockedNoteClosed;
         onSurfaceDesynchronized = options.callbacks.onSurfaceDesynchronized;
       },
+      feedback: { show },
       sidecarConnection,
     });
 
@@ -839,6 +841,40 @@ describe('DictationSessionController', () => {
     await vi.waitFor(() => {
       expect(sidecarConnection.cancelSession).toHaveBeenCalledOnce();
     });
+    expect(show).toHaveBeenCalledOnce();
+    expect(show).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'dictation-surface-desynchronized' }),
+    );
+  });
+
+  it('keeps target-loss feedback as the first cause when desynchronization follows', async () => {
+    const show = vi.fn();
+    const sidecarConnection = new FakeSidecarConnection();
+    let onLockedNoteClosed: (() => void) | undefined;
+    let onSurfaceDesynchronized: ((failure: SurfaceDesynchronization) => void) | undefined;
+    const controller = createController({
+      createSession: (_session, options) => {
+        onLockedNoteClosed = options.callbacks.onLockedNoteClosed;
+        onSurfaceDesynchronized = options.callbacks.onSurfaceDesynchronized;
+      },
+      feedback: { show },
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+
+    onLockedNoteClosed?.();
+    onSurfaceDesynchronized?.({
+      documentLength: 4280,
+      kind: 'surface_desynchronized',
+      trackedPosition: 4314,
+    });
+
+    await vi.waitFor(() => {
+      expect(sidecarConnection.cancelSession).toHaveBeenCalledOnce();
+    });
+    expect(show).toHaveBeenCalledOnce();
+    expect(show).toHaveBeenCalledWith(expect.objectContaining({ key: 'dictation-target-closed' }));
   });
 
   it.each([

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -1018,6 +1018,43 @@ describe('DictationSessionController', () => {
     expect(show).toHaveBeenCalledWith(expect.objectContaining({ key: 'dictation-target-closed' }));
   });
 
+  it('reports target loss after a prior queue-overload warning cancels the drain', async () => {
+    const show = vi.fn();
+    const sidecarConnection = new FakeSidecarConnection();
+    let onLockedNoteClosed: (() => void) | undefined;
+    const controller = createController({
+      createSession: (_session, options) => {
+        onLockedNoteClosed = options.callbacks.onLockedNoteClosed;
+      },
+      feedback: { show },
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    sidecarConnection.emit({
+      code: 'utterance_queue_overload',
+      message: 'The transcription backlog reached capacity.',
+      sessionId,
+      type: 'error',
+    });
+    await vi.waitFor(() => {
+      expect(show).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'utterance-queue-overload' }),
+      );
+    });
+
+    onLockedNoteClosed?.();
+
+    await vi.waitFor(() => {
+      expect(sidecarConnection.cancelSession).toHaveBeenCalledWith(sessionId);
+    });
+    expect(show).toHaveBeenCalledTimes(2);
+    expect(show).toHaveBeenLastCalledWith(
+      expect.objectContaining({ key: 'dictation-target-closed' }),
+    );
+  });
+
   it.each([
     {
       callback: 'onLockedNoteClosed' as const,

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -655,6 +655,60 @@ describe('DictationSessionController', () => {
     });
   });
 
+  it('drops a queued raw final after an acknowledged cancellation while earlier cleanup ignores abort', async () => {
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    let cleanupSignal: AbortSignal | undefined;
+    let resolveCleanup: ((value: LlmRouterCleanupResult) => void) | undefined;
+    const cleanup = vi.fn(
+      ({ abortSignal }: { abortSignal?: AbortSignal }) =>
+        new Promise<LlmRouterCleanupResult>((resolve) => {
+          cleanupSignal = abortSignal;
+          resolveCleanup = resolve;
+        }),
+    );
+    let onLockedNoteClosed: (() => void) | undefined;
+    const controller = createController({
+      createSession: (session, options) => {
+        sessions.push(session);
+        onLockedNoteClosed = options.callbacks.onLockedNoteClosed;
+      },
+      getSettings: () =>
+        createSettings({
+          llmFeaturesEnabled: true,
+          llmPostprocessMode: 'per_utterance',
+          llmPostprocessSkipMinWords: 2,
+          selectedModel: createExternalModelSelection(),
+        }),
+      llmRouter: createFakeLlmRouter({ cleanup }),
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+
+    sidecarConnection.emit(transcriptReady(sessionId, 'cleanup blocks'));
+    sidecarConnection.emit(transcriptReady(sessionId, 'raw'));
+    await vi.waitFor(() => {
+      expect(cleanup).toHaveBeenCalledOnce();
+    });
+
+    onLockedNoteClosed?.();
+    await vi.waitFor(() => {
+      expect(sidecarConnection.cancelSession).toHaveBeenCalledWith(sessionId);
+    });
+    expect(cleanupSignal?.aborted).toBe(true);
+    expect(sessions[0]?.acceptTranscript).not.toHaveBeenCalled();
+
+    // This provider deliberately ignores abort. Its completion releases the
+    // raw final queued behind it after session_stopped has already arrived.
+    resolveCleanup?.({ model: 'm', providerId: 'ollama', text: 'ignored cleanup' });
+    await vi.waitFor(() => {
+      expect(sessions[0]?.dispose).toHaveBeenCalledOnce();
+    });
+    expect(sessions[0]?.acceptTranscript).not.toHaveBeenCalled();
+  });
+
   it('does not accept queued utterances after cancellation, even when capture teardown rejects', async () => {
     const captureStream = new FakeCaptureStream();
     const logger = new FakeLogger();

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -877,6 +877,49 @@ describe('DictationSessionController', () => {
     expect(show).toHaveBeenCalledWith(expect.objectContaining({ key: 'dictation-target-closed' }));
   });
 
+  it('keeps the controller idle when target loss wins a pending-start failure race', async () => {
+    const show = vi.fn();
+    const sidecarConnection = new FakeSidecarConnection();
+    let onLockedNoteClosed: (() => void) | undefined;
+    let rejectStart: ((error: Error) => void) | undefined;
+    sidecarConnection.startSession.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectStart = reject;
+        }),
+    );
+    sidecarConnection.cancelSession.mockImplementationOnce(async (sessionId) => ({
+      reason: 'user_cancel',
+      sessionId,
+      type: 'session_stopped',
+    }));
+    const controller = createController({
+      createSession: (_session, options) => {
+        onLockedNoteClosed = options.callbacks.onLockedNoteClosed;
+      },
+      feedback: { show },
+      sidecarConnection,
+    });
+
+    const start = controller.startDictation();
+    await vi.waitFor(() => {
+      expect(sidecarConnection.startSession).toHaveBeenCalledOnce();
+    });
+
+    onLockedNoteClosed?.();
+    await vi.waitFor(() => {
+      expect(controller.getState()).toBe('idle');
+      expect(sidecarConnection.cancelSession).toHaveBeenCalledOnce();
+    });
+
+    rejectStart?.(new Error('sidecar start failed after cancellation'));
+    await start;
+
+    expect(controller.getState()).toBe('idle');
+    expect(show).toHaveBeenCalledOnce();
+    expect(show).toHaveBeenCalledWith(expect.objectContaining({ key: 'dictation-target-closed' }));
+  });
+
   it.each([
     {
       error: (sessionId: string): SidecarEvent => ({

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -841,6 +841,55 @@ describe('DictationSessionController', () => {
     });
   });
 
+  it.each([
+    {
+      callback: 'onLockedNoteClosed' as const,
+      expectedKey: 'dictation-target-closed',
+      expectedMessage:
+        'Dictation stopped because its target note was closed or replaced. Start dictation again to continue.',
+      reason: 'closed',
+    },
+    {
+      callback: 'onLockedNoteDeleted' as const,
+      expectedKey: 'dictation-target-deleted',
+      expectedMessage:
+        'Dictation stopped because its target note was deleted. Restore or recreate the note, then start dictation again.',
+      reason: 'deleted',
+    },
+  ])('reports one actionable explanation when the target is $reason', async (scenario) => {
+    const captureStream = new FakeCaptureStream();
+    const show = vi.fn();
+    const sidecarConnection = new FakeSidecarConnection();
+    let callbacks: CreateSessionOptions['callbacks'] | undefined;
+    const controller = createController({
+      captureStream,
+      createSession: (_session, options) => {
+        callbacks = options.callbacks;
+      },
+      feedback: { show },
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    const targetLossCallback = callbacks?.[scenario.callback];
+
+    targetLossCallback?.();
+    targetLossCallback?.();
+
+    await vi.waitFor(() => {
+      expect(sidecarConnection.cancelSession).toHaveBeenCalledOnce();
+    });
+    expect(captureStream.stop).toHaveBeenCalledOnce();
+    expect(show).toHaveBeenCalledOnce();
+    expect(show).toHaveBeenCalledWith({
+      cause: { reason: scenario.reason, sessionId },
+      intent: 'warning',
+      key: scenario.expectedKey,
+      message: scenario.expectedMessage,
+    });
+  });
+
   it('reports a pending fatal desynchronization after the sidecar has already stopped', async () => {
     const show = vi.fn();
     const sidecarConnection = new FakeSidecarConnection();

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -492,6 +492,18 @@ describe('Session', () => {
     );
   });
 
+  it('continues without pinning either leaf when exact editor resolution is ambiguous', () => {
+    const { duplicateLeaf, session, surface, targetLeaf } = createSessionHarness({
+      ambiguousTarget: true,
+    });
+
+    session.acceptTranscript(transcript({ text: 'still dictated', utteranceId: 'u1' }));
+
+    expect(targetLeaf.setPinned).not.toHaveBeenCalled();
+    expect(duplicateLeaf?.setPinned).not.toHaveBeenCalled();
+    expect(surface.appendCalls).toHaveLength(1);
+  });
+
   it('requests cancel on locked-note delete and never writes later transcripts', () => {
     const { callbacks, lockedFile, session, surface, vault } = createSessionHarness();
 
@@ -839,6 +851,7 @@ describe('Session', () => {
 
 function createSessionHarness(
   options: {
+    ambiguousTarget?: boolean;
     duplicateLockedLeaf?: boolean;
     leafPinManager?: TemporaryLeafPinLeaseManager;
     logger?: PluginLogger;
@@ -867,9 +880,13 @@ function createSessionHarness(
   if (targetLeaf === undefined) {
     throw new Error('expected target leaf fixture');
   }
-  const duplicateLeaf = options.duplicateLockedLeaf
-    ? new FakeMarkdownLeaf(lockedFile, {} as EditorView)
-    : null;
+  const duplicateLeaf =
+    options.duplicateLockedLeaf || options.ambiguousTarget
+      ? new FakeMarkdownLeaf(
+          lockedFile,
+          options.ambiguousTarget ? targetLeaf.view.editor.cm : ({} as EditorView),
+        )
+      : null;
   if (duplicateLeaf !== null) {
     workspace.leaves.unshift(duplicateLeaf);
   }

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -12,7 +12,9 @@ import type {
   RewriteResult,
   SurfaceDesynchronization,
 } from '../src/editor/note-surface';
+import { TemporaryLeafPinLeaseManager } from '../src/editor/temporary-leaf-pin';
 import { Session } from '../src/session/session';
+import type { PluginLogger } from '../src/shared/plugin-logger';
 import type {
   TranscriptInsertProjection,
   TranscriptRenderOptions,
@@ -396,7 +398,8 @@ describe('Session', () => {
   });
 
   it('keeps projecting to the locked background note when the active tab changes', () => {
-    const { callbacks, lockedFile, session, surface, workspace } = createSessionHarness();
+    const { callbacks, lockedFile, session, surface, targetLeaf, workspace } =
+      createSessionHarness();
     const otherFile = fakeFile('other.md');
 
     workspace.activeEditor = fakeActiveEditor(otherFile);
@@ -410,18 +413,83 @@ describe('Session', () => {
       utteranceId: 'u1',
     });
     expect(workspace.leaves[0]?.view?.file).toBe(lockedFile);
+    expect(targetLeaf.pinned).toBe(true);
   });
 
-  it('requests graceful stop when the locked note is no longer open', () => {
-    const { callbacks, session, surface, workspace } = createSessionHarness();
+  it('treats the exact target leaf as closed even when a duplicate shows the same file', () => {
+    const { callbacks, duplicateLeaf, session, surface, workspace } = createSessionHarness({
+      duplicateLockedLeaf: true,
+    });
 
-    workspace.leaves = [];
+    workspace.leaves = duplicateLeaf === null ? [] : [duplicateLeaf];
     workspace.trigger('layout-change');
     session.acceptTranscript(transcript({ text: 'drained journal only', utteranceId: 'u1' }));
 
     expect(callbacks.onLockedNoteClosed).toHaveBeenCalledTimes(1);
     expect(surface.dispose).toHaveBeenCalledTimes(1);
     expect(surface.appendCalls).toHaveLength(0);
+  });
+
+  it('treats replacement of the target leaf editor as terminal', () => {
+    const { callbacks, lockedFile, session, surface, targetLeaf, workspace } =
+      createSessionHarness();
+
+    targetLeaf.view = {
+      editor: { cm: {} as EditorView },
+      file: lockedFile,
+    };
+    workspace.trigger('layout-change');
+    session.acceptTranscript(transcript({ text: 'must not move', utteranceId: 'u1' }));
+
+    expect(callbacks.onLockedNoteClosed).toHaveBeenCalledOnce();
+    expect(surface.dispose).toHaveBeenCalledOnce();
+    expect(surface.appendCalls).toHaveLength(0);
+  });
+
+  it('does not stop or pin the target when an unrelated duplicate leaf closes', () => {
+    const { callbacks, duplicateLeaf, session, targetLeaf, workspace } = createSessionHarness({
+      duplicateLockedLeaf: true,
+    });
+
+    workspace.leaves = [targetLeaf];
+    workspace.trigger('layout-change');
+
+    expect(callbacks.onLockedNoteClosed).not.toHaveBeenCalled();
+    expect(targetLeaf.pinned).toBe(true);
+    expect(duplicateLeaf?.setPinned).not.toHaveBeenCalled();
+
+    session.dispose();
+
+    expect(targetLeaf.pinned).toBe(false);
+  });
+
+  it('holds the temporary pin until session disposal', () => {
+    const { session, targetLeaf } = createSessionHarness();
+
+    expect(targetLeaf.pinned).toBe(true);
+    session.acceptTranscript(transcript({ text: 'pending transcript', utteranceId: 'u1' }));
+    expect(targetLeaf.pinned).toBe(true);
+
+    session.dispose();
+
+    expect(targetLeaf.pinned).toBe(false);
+  });
+
+  it('continues without navigation protection when the exact editor leaf is unresolved', () => {
+    const logger = fakeLogger();
+    const { session, surface, targetLeaf } = createSessionHarness({
+      logger,
+      unresolvedTarget: true,
+    });
+
+    session.acceptTranscript(transcript({ text: 'still dictated', utteranceId: 'u1' }));
+
+    expect(targetLeaf.setPinned).not.toHaveBeenCalled();
+    expect(surface.appendCalls).toHaveLength(1);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'session',
+      'navigation protection unavailable: exact editor leaf could not be resolved',
+    );
   });
 
   it('requests cancel on locked-note delete and never writes later transcripts', () => {
@@ -769,15 +837,25 @@ describe('Session', () => {
   });
 });
 
-function createSessionHarness(options: { rendererOptions?: TranscriptRenderOptions } = {}): {
+function createSessionHarness(
+  options: {
+    duplicateLockedLeaf?: boolean;
+    leafPinManager?: TemporaryLeafPinLeaseManager;
+    logger?: PluginLogger;
+    rendererOptions?: TranscriptRenderOptions;
+    unresolvedTarget?: boolean;
+  } = {},
+): {
   callbacks: {
     onLockedNoteClosed: ReturnType<typeof vi.fn>;
     onLockedNoteDeleted: ReturnType<typeof vi.fn>;
     onSurfaceDesynchronized: ReturnType<typeof vi.fn>;
   };
+  duplicateLeaf: FakeMarkdownLeaf | null;
   lockedFile: TFile;
   session: Session;
   surface: FakeSurface;
+  targetLeaf: FakeMarkdownLeaf;
   vault: FakeEvents;
   workspace: FakeWorkspace;
 } {
@@ -785,6 +863,16 @@ function createSessionHarness(options: { rendererOptions?: TranscriptRenderOptio
   const surface = new FakeSurface();
   const vault = new FakeEvents();
   const workspace = new FakeWorkspace(lockedFile);
+  const targetLeaf = workspace.leaves[0];
+  if (targetLeaf === undefined) {
+    throw new Error('expected target leaf fixture');
+  }
+  const duplicateLeaf = options.duplicateLockedLeaf
+    ? new FakeMarkdownLeaf(lockedFile, {} as EditorView)
+    : null;
+  if (duplicateLeaf !== null) {
+    workspace.leaves.unshift(duplicateLeaf);
+  }
   const callbacks = {
     onLockedNoteClosed: vi.fn(),
     onLockedNoteDeleted: vi.fn(),
@@ -795,6 +883,7 @@ function createSessionHarness(options: { rendererOptions?: TranscriptRenderOptio
   const session = new Session({
     app,
     callbacks,
+    leafPinManager: options.leafPinManager ?? new TemporaryLeafPinLeaseManager(),
     lockedFile,
     noteSurfaceFactory: (_view, _placement, onSurfaceDesynchronized) => {
       surface.onSurfaceDesynchronized = onSurfaceDesynchronized;
@@ -803,10 +892,20 @@ function createSessionHarness(options: { rendererOptions?: TranscriptRenderOptio
     placement,
     rendererOptions: options.rendererOptions ?? renderOptions(),
     sessionId: 'session-1',
-    view: {} as EditorView,
+    view: options.unresolvedTarget ? ({} as EditorView) : targetLeaf.view.editor.cm,
+    ...(options.logger !== undefined ? { logger: options.logger } : {}),
   });
 
-  return { callbacks, lockedFile, session, surface, vault, workspace };
+  return {
+    callbacks,
+    duplicateLeaf,
+    lockedFile,
+    session,
+    surface,
+    targetLeaf,
+    vault,
+    workspace,
+  };
 }
 
 class FakeEvents {
@@ -842,16 +941,35 @@ class FakeEvents {
 
 class FakeWorkspace extends FakeEvents {
   public activeEditor: unknown;
-  public leaves: Array<{ view: { editor: { cm: EditorView }; file: TFile } }> = [];
+  public leaves: FakeMarkdownLeaf[] = [];
 
   constructor(file: TFile) {
     super();
-    this.activeEditor = fakeActiveEditor(file);
-    this.leaves = [this.activeEditor as { view: { editor: { cm: EditorView }; file: TFile } }];
+    const leaf = new FakeMarkdownLeaf(file, {} as EditorView);
+    this.activeEditor = leaf.view;
+    this.leaves = [leaf];
   }
 
-  getLeavesOfType(viewType: string): Array<{ view: { editor: { cm: EditorView }; file: TFile } }> {
+  getLeavesOfType(viewType: string): FakeMarkdownLeaf[] {
     return viewType === 'markdown' ? this.leaves : [];
+  }
+}
+
+class FakeMarkdownLeaf extends FakeEvents {
+  public pinned = false;
+  public view: { editor: { cm: EditorView }; file: TFile };
+  public readonly setPinned = vi.fn((pinned: boolean) => {
+    this.pinned = pinned;
+    this.trigger('pinned-change', pinned);
+  });
+
+  constructor(file: TFile, view: EditorView) {
+    super();
+    this.view = { editor: { cm: view }, file };
+  }
+
+  getViewState(): { pinned: boolean } {
+    return { pinned: this.pinned };
   }
 }
 
@@ -871,4 +989,16 @@ function fakeFile(path: string): TFile {
     path,
     vault: null,
   } as unknown as TFile;
+}
+
+function fakeLogger(): {
+  debug: ReturnType<typeof vi.fn<PluginLogger['debug']>>;
+  error: ReturnType<typeof vi.fn<PluginLogger['error']>>;
+  warn: ReturnType<typeof vi.fn<PluginLogger['warn']>>;
+} {
+  return {
+    debug: vi.fn<PluginLogger['debug']>(),
+    error: vi.fn<PluginLogger['error']>(),
+    warn: vi.fn<PluginLogger['warn']>(),
+  };
 }

--- a/test/temporary-leaf-pin.test.ts
+++ b/test/temporary-leaf-pin.test.ts
@@ -1,0 +1,135 @@
+import type { EventRef } from 'obsidian';
+import { describe, expect, it, vi } from 'vitest';
+
+import { type PinnableLeaf, TemporaryLeafPinLeaseManager } from '../src/editor/temporary-leaf-pin';
+
+describe('TemporaryLeafPinLeaseManager', () => {
+  it('temporarily pins an unpinned leaf and restores it after the target is no longer needed', () => {
+    const leaf = new FakeLeaf(false);
+    const manager = new TemporaryLeafPinLeaseManager();
+    let targetLive = true;
+
+    const lease = manager.acquire(leaf, () => targetLive);
+
+    expect(leaf.pinned).toBe(true);
+    expect(leaf.setPinned).toHaveBeenCalledTimes(1);
+    expect(leaf.listenerCount).toBe(1);
+
+    lease.release();
+    targetLive = false;
+
+    expect(leaf.setPinned).toHaveBeenNthCalledWith(2, false);
+    expect(leaf.listenerCount).toBe(0);
+  });
+
+  it('observes but never mutates a leaf that was already pinned', () => {
+    const leaf = new FakeLeaf(true);
+    const manager = new TemporaryLeafPinLeaseManager();
+
+    const lease = manager.acquire(leaf, () => true);
+    lease.release();
+
+    expect(leaf.pinned).toBe(true);
+    expect(leaf.setPinned).not.toHaveBeenCalled();
+    expect(leaf.listenerCount).toBe(0);
+  });
+
+  it('permanently relinquishes ownership when the user unpins', () => {
+    const leaf = new FakeLeaf(false);
+    const manager = new TemporaryLeafPinLeaseManager();
+    const lease = manager.acquire(leaf, () => true);
+
+    leaf.userSetPinned(false);
+    leaf.userSetPinned(true);
+    lease.release();
+
+    expect(leaf.pinned).toBe(true);
+    expect(leaf.setPinned).toHaveBeenCalledTimes(1);
+    expect(leaf.listenerCount).toBe(0);
+  });
+
+  it('restores a shared temporary pin only after the final overlapping lease releases', () => {
+    const leaf = new FakeLeaf(false);
+    const manager = new TemporaryLeafPinLeaseManager();
+    const first = manager.acquire(leaf, () => true);
+    const second = manager.acquire(leaf, () => true);
+
+    first.release();
+
+    expect(leaf.pinned).toBe(true);
+    expect(leaf.setPinned).toHaveBeenCalledTimes(1);
+
+    second.release();
+
+    expect(leaf.pinned).toBe(false);
+    expect(leaf.setPinned).toHaveBeenCalledTimes(2);
+    expect(leaf.listenerCount).toBe(0);
+  });
+
+  it('makes repeated release idempotent', () => {
+    const leaf = new FakeLeaf(false);
+    const manager = new TemporaryLeafPinLeaseManager();
+    const lease = manager.acquire(leaf, () => true);
+
+    lease.release();
+    lease.release();
+
+    expect(leaf.setPinned).toHaveBeenCalledTimes(2);
+    expect(leaf.listenerCount).toBe(0);
+  });
+
+  it('does not mutate a leaf whose exact target surface is no longer live', () => {
+    const leaf = new FakeLeaf(false);
+    const manager = new TemporaryLeafPinLeaseManager();
+    const lease = manager.acquire(leaf, () => false);
+
+    lease.release();
+
+    expect(leaf.pinned).toBe(true);
+    expect(leaf.setPinned).toHaveBeenCalledTimes(1);
+    expect(leaf.listenerCount).toBe(0);
+  });
+});
+
+class FakeLeaf implements PinnableLeaf {
+  private readonly listeners = new Map<EventRef, (pinned: boolean) => void>();
+  private nextRef = 0;
+  public pinned: boolean;
+  readonly setPinned = vi.fn((pinned: boolean) => {
+    this.pinned = pinned;
+    this.emitPinnedChange(pinned);
+  });
+
+  constructor(pinned: boolean) {
+    this.pinned = pinned;
+  }
+
+  get listenerCount(): number {
+    return this.listeners.size;
+  }
+
+  getViewState(): { pinned?: boolean } {
+    return { pinned: this.pinned };
+  }
+
+  on(_name: 'pinned-change', callback: (pinned: boolean) => unknown): EventRef {
+    const ref = { id: this.nextRef++ } as unknown as EventRef;
+    this.listeners.set(ref, callback);
+    return ref;
+  }
+
+  offref(ref: EventRef): void {
+    this.listeners.delete(ref);
+  }
+
+  userSetPinned(pinned: boolean): void {
+    this.pinned = pinned;
+    this.emitPinnedChange(pinned);
+  }
+
+  private emitPinnedChange(pinned: boolean): void {
+    for (const listener of this.listeners.values()) {
+      listener(pinned);
+    }
+  }
+}

--- a/test/temporary-leaf-pin.test.ts
+++ b/test/temporary-leaf-pin.test.ts
@@ -7,18 +7,17 @@ describe('TemporaryLeafPinLeaseManager', () => {
   it('temporarily pins an unpinned leaf and restores it after the target is no longer needed', () => {
     const leaf = new FakeLeaf(false);
     const manager = new TemporaryLeafPinLeaseManager();
-    let targetLive = true;
 
-    const lease = manager.acquire(leaf, () => targetLive);
+    const lease = manager.acquire(leaf, () => true);
 
     expect(leaf.pinned).toBe(true);
     expect(leaf.setPinned).toHaveBeenCalledTimes(1);
     expect(leaf.listenerCount).toBe(1);
 
     lease.release();
-    targetLive = false;
 
     expect(leaf.setPinned).toHaveBeenNthCalledWith(2, false);
+    expect(leaf.listenerCountsAtMutation).toEqual([1, 0]);
     expect(leaf.listenerCount).toBe(0);
   });
 
@@ -94,8 +93,10 @@ describe('TemporaryLeafPinLeaseManager', () => {
 class FakeLeaf implements PinnableLeaf {
   private readonly listeners = new Map<EventRef, (pinned: boolean) => void>();
   private nextRef = 0;
+  public readonly listenerCountsAtMutation: number[] = [];
   public pinned: boolean;
   readonly setPinned = vi.fn((pinned: boolean) => {
+    this.listenerCountsAtMutation.push(this.listeners.size);
     this.pinned = pinned;
     this.emitPinnedChange(pinned);
   });


### PR DESCRIPTION
Closes #216.

PR #217 is merged. This branch is based on the resulting `main`, so target-loss feedback has one presentation/log owner with no pending parent dependency.

## Summary

- Protect the exact Markdown leaf that owns the active CodeMirror dictation surface so ordinary navigation opens elsewhere.
- Keep protection for the full `Session` lifetime, including queued transcript work and optional batch LLM cleanup.
- Stop safely when the exact target leaf is closed, replaced, or deleted, even when another pane shows the same file.
- Continue dictation without navigation protection when an exact pinnable leaf cannot be resolved.
- Show actionable, privacy-safe feedback for explicit target loss without allowing later cancellation races to overwrite the first cancellation cause.

## Decisions

- Exact CodeMirror identity is the sole leaf-resolution key; file identity is retained only as the legacy liveness fallback when no exact leaf can be resolved.
- One plugin-scoped lease manager owns pin state, the `pinned-change` subscription, overlapping lease counts, user override, and restoration.
- A manual `pinned-change(false)` permanently relinquishes plugin ownership for that shared lease. A later user repin is never undone.
- Originally pinned leaves are observed but never mutated.
- Final release unsubscribes first and restores only a plugin-owned pin whose exact target surface is still live.
- `Session.dispose()` remains the authoritative release boundary, after transcript drain and batch cleanup.
- Target close/delete feedback is keyed and single-shot. Its cause contains only the reason and opaque session ID; it never includes note or transcript content.
- One controller-owned terminal arbiter suppresses competing cancellation causes and makes cancellation permanently reject transcript writes, including across `session_stopped` acknowledgements.
- Queue overload remains a graceful-drain warning outside cancellation arbitration, so a later target loss can explain why accepted work was discarded.
- If exact leaf resolution or pin acquisition fails, dictation continues and emits only a developer diagnostic.

## Verification

Completed on final head `a9c3b4e` over `main` (`f7af5ba`):

- Focused lifecycle suite: 3 files / 97 tests passed.
- `npm run check:frontend`: typecheck passed; Biome passed (existing schema-version info only); Obsidian ESLint passed (pre-existing settings-search warning only); 54 files / 698 tests passed; production bundle built.
- `git diff --check origin/main...HEAD` passed.
- Isolated real-Obsidian smoke test on the exact final bundle passed:
  - ordinary file navigation opened a second leaf while the dictated leaf remained pinned;
  - teardown restored an originally unpinned target after the session drain;
  - manual unpin followed by user repin remained pinned after teardown;
  - transcript targeting remained on the original note and no runtime notices were emitted.
- Independent Standards review: no findings.
- Independent Spec review against #216: no findings.

## Review status

Implementation, final-head automated gates, independent review, and the runtime acceptance gate are complete. Ready for review.
