### PR TITLE
Let setup start a real dictation session

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -324,7 +324,9 @@ export default class LocalSttPlugin extends Plugin {
     const modal = new SetupWizardModal({
       app: this.app,
       feedback: this.feedback,
+      hasDictationTarget: () => Session.hasDictationTarget(this.app),
       hasSelectedModel: () => this.settings.selectedModel !== null,
+      isDictationBusy: () => this.requireDictationController().isBusy(),
       isSidecarInstalled: () => this.isSidecarInstalled(),
       logger: this.logger,
       modelInstallManager: this.requireModelInstallManager(),
@@ -347,6 +349,7 @@ export default class LocalSttPlugin extends Plugin {
       sidecarConnection: this.requireSidecarConnection(),
       sidecarInstallManager: this.requireSidecarInstallManager(),
       sidecarStartupTimeoutMs: this.settings.sidecarStartupTimeoutSeconds * 1000,
+      startDictation: () => this.requireDictationController().startDictation(),
     });
     modal.open();
   }

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -126,6 +126,10 @@ export class Session {
   private surface: NoteSurfaceLike | null;
   private surfaceDesynchronized = false;
 
+  static hasDictationTarget(app: Pick<App, 'workspace'>): boolean {
+    return resolveDictationTarget(app) !== null;
+  }
+
   static createFromActiveEditor(
     app: Pick<App, 'vault' | 'workspace'>,
     options: {
@@ -137,9 +141,7 @@ export class Session {
       sessionId: string;
     },
   ): Session {
-    const active = resolveActiveEditorTarget(app);
-    const fallback = active === null ? resolveFallbackEditorTarget(app) : null;
-    const target = active ?? fallback;
+    const target = resolveDictationTarget(app);
 
     if (target === null) {
       throw new Error('No active Markdown editor is available.');
@@ -147,7 +149,9 @@ export class Session {
 
     // No cursor available — append to end of the open note rather than blocking on a popup.
     const placement: NotePlacementOptions =
-      fallback !== null ? { ...options.placement, anchor: 'end_of_note' } : options.placement;
+      target.kind === 'fallback'
+        ? { ...options.placement, anchor: 'end_of_note' }
+        : options.placement;
 
     return new Session({
       app,
@@ -780,6 +784,20 @@ function createNoteSurface(
   onSurfaceDesynchronized: (failure: SurfaceDesynchronization) => void,
 ): NoteSurface {
   return new NoteSurface(view, placement, onSurfaceDesynchronized);
+}
+
+type DictationTarget =
+  | { file: TFile; kind: 'active'; view: EditorView }
+  | { file: TFile; kind: 'fallback'; view: EditorView };
+
+function resolveDictationTarget(app: Pick<App, 'workspace'>): DictationTarget | null {
+  const active = resolveActiveEditorTarget(app);
+  if (active !== null) {
+    return { ...active, kind: 'active' };
+  }
+
+  const fallback = resolveFallbackEditorTarget(app);
+  return fallback === null ? null : { ...fallback, kind: 'fallback' };
 }
 
 function resolveActiveEditorTarget(

--- a/src/setup/setup-ready-actions.ts
+++ b/src/setup/setup-ready-actions.ts
@@ -1,0 +1,74 @@
+import type { UserFeedback } from '../shared/user-feedback';
+
+interface SetupReadyActionDependencies {
+  closeWizard: () => void;
+  feedback: Pick<UserFeedback, 'show'>;
+  hasDictationTarget: () => boolean;
+  isDictationBusy: () => boolean;
+  onCompleted: () => Promise<void>;
+  startDictation: () => Promise<void>;
+}
+
+export class SetupReadyActions {
+  private pending = false;
+
+  constructor(private readonly dependencies: SetupReadyActionDependencies) {}
+
+  async done(): Promise<void> {
+    await this.complete(false);
+  }
+
+  async tryDictationNow(): Promise<void> {
+    if (this.pending) {
+      return;
+    }
+
+    if (this.dependencies.isDictationBusy()) {
+      this.dependencies.feedback.show({
+        intent: 'warning',
+        key: 'setup-wizard-prerequisite',
+        message: 'Wait for the current dictation to finish, then try again.',
+      });
+      return;
+    }
+
+    if (!this.dependencies.hasDictationTarget()) {
+      this.dependencies.feedback.show({
+        intent: 'warning',
+        key: 'setup-wizard-prerequisite',
+        message: 'Open a Markdown note in editing mode, then try dictation again.',
+      });
+      return;
+    }
+
+    await this.complete(true);
+  }
+
+  private async complete(startDictation: boolean): Promise<void> {
+    if (this.pending) {
+      return;
+    }
+
+    this.pending = true;
+    try {
+      try {
+        await this.dependencies.onCompleted();
+      } catch (cause) {
+        this.dependencies.feedback.show({
+          cause,
+          intent: 'error',
+          key: 'setup-wizard-completion',
+          message: "Couldn't finish setup. Try again.",
+        });
+        return;
+      }
+
+      this.dependencies.closeWizard();
+      if (startDictation) {
+        await this.dependencies.startDictation();
+      }
+    } finally {
+      this.pending = false;
+    }
+  }
+}

--- a/src/setup/setup-wizard-modal.ts
+++ b/src/setup/setup-wizard-modal.ts
@@ -6,13 +6,16 @@ import type { PluginLogger } from '../shared/plugin-logger';
 import type { UserFeedback } from '../shared/user-feedback';
 import type { SidecarConnection } from '../sidecar/sidecar-connection';
 import type { SidecarInstallManager } from '../sidecar/sidecar-install-manager';
+import { SetupReadyActions } from './setup-ready-actions';
 import { getInstallCopy } from './sidecar-install-copy';
 import { SidecarInstallModal } from './sidecar-install-modal';
 
 interface WizardDependencies {
   app: App;
   feedback: Pick<UserFeedback, 'show'>;
+  hasDictationTarget: () => boolean;
   hasSelectedModel: () => boolean;
+  isDictationBusy: () => boolean;
   isSidecarInstalled: () => Promise<boolean>;
   logger?: PluginLogger;
   modelInstallManager: ModelInstallManager;
@@ -23,6 +26,7 @@ interface WizardDependencies {
   sidecarConnection: Pick<SidecarConnection, 'restart'>;
   sidecarInstallManager: SidecarInstallManager;
   sidecarStartupTimeoutMs: number;
+  startDictation: () => Promise<void>;
 }
 
 type WizardStepId = 'sidecar' | 'model' | 'ready';
@@ -34,9 +38,18 @@ export class SetupWizardModal extends Modal {
   private sidecarReady = false;
   private modelReady = false;
   private modelManagerUnsub: (() => void) | null = null;
+  private readonly readyActions: SetupReadyActions;
 
   constructor(private readonly deps: WizardDependencies) {
     super(deps.app);
+    this.readyActions = new SetupReadyActions({
+      closeWizard: () => this.close(),
+      feedback: deps.feedback,
+      hasDictationTarget: deps.hasDictationTarget,
+      isDictationBusy: deps.isDictationBusy,
+      onCompleted: deps.onCompleted,
+      startDictation: deps.startDictation,
+    });
   }
 
   override onOpen(): void {
@@ -252,6 +265,9 @@ export class SetupWizardModal extends Modal {
       cls: 'local-stt-wizard-step__title',
       text: "You're ready to dictate",
     });
+    body.createEl('p', {
+      text: "Try it in the Markdown note that's open now. Speak a few words, then use the ribbon mic or your hotkey to stop.",
+    });
 
     const cardRibbon = body.createDiv({ cls: 'local-stt-wizard-card' });
     const ribbonIcon = cardRibbon.createSpan({ cls: 'local-stt-wizard-card__icon' });
@@ -276,12 +292,16 @@ export class SetupWizardModal extends Modal {
 
     const actions = this.contentEl.createDiv({ cls: 'local-stt-wizard-actions' });
     actions.createEl('button', { text: 'Back' }).addEventListener('click', () => this.goBack());
-    const done = actions.createEl('button', { cls: 'mod-cta', text: 'Done' });
+    const done = actions.createEl('button', { text: 'Done' });
     done.addEventListener('click', () => {
-      void (async () => {
-        await this.deps.onCompleted();
-        this.close();
-      })();
+      void this.readyActions.done();
+    });
+    const tryDictation = actions.createEl('button', {
+      cls: 'mod-cta',
+      text: 'Try dictation now',
+    });
+    tryDictation.addEventListener('click', () => {
+      void this.readyActions.tryDictationNow();
     });
   }
 

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -184,9 +184,7 @@ describe('Session', () => {
         workspace: {
           activeEditor: null,
           getActiveFile: () => fallbackFile,
-          getLeavesOfType: () => [
-            { view: { editor: { cm: fallbackView }, file: fallbackFile } },
-          ],
+          getLeavesOfType: () => [{ view: { editor: { cm: fallbackView }, file: fallbackFile } }],
         },
       } as unknown as Pick<App, 'workspace'>),
     ).toBe(true);

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -164,6 +164,43 @@ class FakeSurface {
 }
 
 describe('Session', () => {
+  it('reports whether ordinary dictation can resolve a writable Markdown target', () => {
+    const activeFile = fakeFile('active.md');
+    const activeView = {} as EditorView;
+    const fallbackFile = fakeFile('fallback.md');
+    const fallbackView = {} as EditorView;
+
+    expect(
+      Session.hasDictationTarget({
+        workspace: {
+          activeEditor: { editor: { cm: activeView }, file: activeFile },
+          getActiveFile: () => activeFile,
+          getLeavesOfType: () => [],
+        },
+      } as unknown as Pick<App, 'workspace'>),
+    ).toBe(true);
+    expect(
+      Session.hasDictationTarget({
+        workspace: {
+          activeEditor: null,
+          getActiveFile: () => fallbackFile,
+          getLeavesOfType: () => [
+            { view: { editor: { cm: fallbackView }, file: fallbackFile } },
+          ],
+        },
+      } as unknown as Pick<App, 'workspace'>),
+    ).toBe(true);
+    expect(
+      Session.hasDictationTarget({
+        workspace: {
+          activeEditor: null,
+          getActiveFile: () => fallbackFile,
+          getLeavesOfType: () => [],
+        },
+      } as unknown as Pick<App, 'workspace'>),
+    ).toBe(false);
+  });
+
   it('replaces a partial in place when its final revision arrives', () => {
     const { session, surface } = createSessionHarness();
 

--- a/test/setup-ready-actions.test.ts
+++ b/test/setup-ready-actions.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { SetupReadyActions } from '../src/setup/setup-ready-actions';
+
+function createHarness(
+  overrides: Partial<ConstructorParameters<typeof SetupReadyActions>[0]> = {},
+): {
+  actions: SetupReadyActions;
+  closeWizard: ReturnType<typeof vi.fn>;
+  events: string[];
+  feedback: { show: ReturnType<typeof vi.fn> };
+  onCompleted: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  startDictation: ReturnType<typeof vi.fn<() => Promise<void>>>;
+} {
+  const events: string[] = [];
+  const closeWizard = vi.fn(() => events.push('closed'));
+  const feedback = { show: vi.fn() };
+  const onCompleted = vi.fn(async () => {
+    events.push('completed');
+  });
+  const startDictation = vi.fn(async () => {
+    events.push('started');
+  });
+
+  return {
+    actions: new SetupReadyActions({
+      closeWizard,
+      feedback,
+      hasDictationTarget: () => true,
+      isDictationBusy: () => false,
+      onCompleted,
+      startDictation,
+      ...overrides,
+    }),
+    closeWizard,
+    events,
+    feedback,
+    onCompleted,
+    startDictation,
+  };
+}
+
+describe('setup ready actions', () => {
+  it('completes setup, closes the wizard, then starts one ordinary dictation session', async () => {
+    const harness = createHarness();
+
+    await harness.actions.tryDictationNow();
+
+    expect(harness.events).toEqual(['completed', 'closed', 'started']);
+    expect(harness.startDictation).toHaveBeenCalledOnce();
+  });
+
+  it('keeps Done as a completion-only path', async () => {
+    const harness = createHarness();
+
+    await harness.actions.done();
+
+    expect(harness.events).toEqual(['completed', 'closed']);
+    expect(harness.startDictation).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      expectedMessage: 'Wait for the current dictation to finish, then try again.',
+      hasDictationTarget: true,
+      isDictationBusy: true,
+    },
+    {
+      expectedMessage: 'Open a Markdown note in editing mode, then try dictation again.',
+      hasDictationTarget: false,
+      isDictationBusy: false,
+    },
+  ])('keeps the wizard open when the dictation prerequisite is unavailable', async ({
+    expectedMessage,
+    hasDictationTarget,
+    isDictationBusy,
+  }) => {
+    const harness = createHarness({
+      hasDictationTarget: () => hasDictationTarget,
+      isDictationBusy: () => isDictationBusy,
+    });
+
+    await harness.actions.tryDictationNow();
+
+    expect(harness.feedback.show).toHaveBeenCalledWith({
+      intent: 'warning',
+      key: 'setup-wizard-prerequisite',
+      message: expectedMessage,
+    });
+    expect(harness.onCompleted).not.toHaveBeenCalled();
+    expect(harness.closeWizard).not.toHaveBeenCalled();
+    expect(harness.startDictation).not.toHaveBeenCalled();
+  });
+
+  it('keeps the wizard open and does not start when setup completion fails', async () => {
+    const cause = new Error('settings write failed');
+    const harness = createHarness({ onCompleted: vi.fn().mockRejectedValue(cause) });
+
+    await harness.actions.tryDictationNow();
+
+    expect(harness.feedback.show).toHaveBeenCalledWith({
+      cause,
+      intent: 'error',
+      key: 'setup-wizard-completion',
+      message: "Couldn't finish setup. Try again.",
+    });
+    expect(harness.closeWizard).not.toHaveBeenCalled();
+    expect(harness.startDictation).not.toHaveBeenCalled();
+  });
+
+  it('coalesces concurrent ready actions into one completion and one session start', async () => {
+    let completeSetup: (() => void) | undefined;
+    const onCompleted = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          completeSetup = resolve;
+        }),
+    );
+    const harness = createHarness({ onCompleted });
+
+    const first = harness.actions.tryDictationNow();
+    const second = harness.actions.tryDictationNow();
+    completeSetup?.();
+    await Promise.all([first, second]);
+
+    expect(onCompleted).toHaveBeenCalledOnce();
+    expect(harness.startDictation).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Closes #220.

> [!IMPORTANT]
> This PR is stacked on #223. Merge #223, then retarget this PR to `main` before merging it. The stack keeps the setup target resolver aligned with #216 exact dictated-leaf protection.

## Summary

- Add a primary **Try dictation now** action to the setup wizard ready step while preserving **Done**.
- Complete setup, close the wizard, then start one ordinary production dictation session.
- Keep the wizard open and explain busy-session or missing-Markdown-note prerequisites.
- Resolve readiness through the exact editor-target path used by ordinary dictation.

## Decisions

- Delegate capture, permissions, model/sidecar validation, session UI, transcript insertion, cancellation, and errors to `DictationSessionController`; no onboarding-only capture pipeline.
- Use the same `Session` target resolver as ordinary dictation, including its open-note fallback behavior, so preflight and production start cannot drift.
- Preserve #216 exact CodeMirror leaf ownership after target selection; setup does not introduce a second leaf/file resolver.
- Treat **Try dictation now** as a guarded orchestration action and coalesce concurrent clicks into one completion and one start.
- Persist setup before closing the modal, then close before calling the production controller.
- Route missing-note, busy-session, and completion-failure feedback through #217 keyed `UserFeedback` service.
- Keep **Done** completion-only and make **Try dictation now** the sole primary CTA.
- Do not auto-stop; ready-step copy tells the user to stop with the ordinary ribbon mic or hotkey.

## Verification

- Exact PR head `cb61644` over #223 head `a9c3b4e`: `npm run check:frontend` passed — typecheck, Biome (schema-version info only), Obsidian ESLint (one pre-existing settings-search warning), 55 files / 705 tests, and production bundle.
- `git diff --check origin/feat/issue-216-protect-dictation-leaf...HEAD` passed.
- Fresh live CI on `cb61644` is green: frontend quality and all three sidecar quality jobs.

Not run:

- Manual Obsidian microphone smoke test; this environment does not provide an interactive Obsidian session or microphone capture.

## Review status

Ready for review and cleanly mergeable into its current stacked base. Independent Standards and Spec reviews found no substantive findings. To merge through the repository workflow, merge #223, retarget this PR to `main`, and confirm the resulting required frontend CI check.