### PR TITLE
fix(audio): stop cleanly when microphone disconnects

### DIFF
--- a/src/audio/audio-capture-stream.ts
+++ b/src/audio/audio-capture-stream.ts
@@ -12,6 +12,10 @@ interface AudioCaptureStreamOptions {
   // to the OS default. Lets the wiring layer (main.ts) surface a Notice without
   // pulling Obsidian UI imports into this module.
   onDeviceFallback?: () => void;
+  // A track can end while its MediaStream still exists (for example, when a
+  // USB microphone is unplugged). Include the session id so a late event from
+  // an old track cannot stop a newer capture.
+  onUnexpectedEnd?: (sessionId: string) => void;
 }
 
 export interface AudioCaptureStartOptions {
@@ -26,6 +30,10 @@ export class AudioCaptureStream {
   private muteNode: GainNode | null = null;
   private recorderNode: AudioWorkletNode | null = null;
   private sourceNode: MediaStreamAudioSourceNode | null = null;
+  private trackEndListener: {
+    listener: () => void;
+    tracks: MediaStreamTrack[];
+  } | null = null;
 
   constructor(private readonly options: AudioCaptureStreamOptions) {}
 
@@ -91,6 +99,7 @@ export class AudioCaptureStream {
       this.muteNode = muteNode;
       this.recorderNode = recorderNode;
       this.sourceNode = sourceNode;
+      this.observeUnexpectedTrackEnd(mediaStream, sessionId);
       this.options.logger?.debug('audio', 'capture started');
     } catch (error) {
       this.options.logger?.error('audio', 'failed to initialize streaming audio capture', error);
@@ -162,6 +171,7 @@ export class AudioCaptureStream {
     const recorderNode = this.recorderNode;
     const sourceNode = this.sourceNode;
 
+    this.clearTrackEndListener();
     this.audioContext = null;
     this.frameListener = null;
     this.mediaStream = null;
@@ -191,6 +201,41 @@ export class AudioCaptureStream {
 
     if (audioContext !== null) {
       await closeAudioContext(audioContext);
+    }
+  }
+
+  private observeUnexpectedTrackEnd(mediaStream: MediaStream, sessionId: string): void {
+    const tracks = mediaStream.getAudioTracks();
+    let reported = false;
+    const listener = (): void => {
+      if (reported || this.mediaStream !== mediaStream) {
+        return;
+      }
+      reported = true;
+      this.options.logger?.warn('audio', 'microphone track ended unexpectedly');
+      this.options.onUnexpectedEnd?.(sessionId);
+    };
+
+    for (const track of tracks) {
+      track.addEventListener('ended', listener);
+    }
+    this.trackEndListener = { listener, tracks };
+
+    // Cover a device that disappeared after getUserMedia resolved but before
+    // the audio graph and event listeners finished initializing.
+    if (tracks.some((track) => track.readyState === 'ended')) {
+      listener();
+    }
+  }
+
+  private clearTrackEndListener(): void {
+    const registration = this.trackEndListener;
+    this.trackEndListener = null;
+    if (registration === null) {
+      return;
+    }
+    for (const track of registration.tracks) {
+      track.removeEventListener('ended', registration.listener);
     }
   }
 }

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -164,6 +164,11 @@ const FEEDBACK_FAILURES = {
     key: 'transcript-record-failed',
     message: 'Could not record the transcript.',
   },
+  microphoneDisconnected: {
+    key: 'microphone-capture-ended',
+    message:
+      'Microphone disconnected. Dictation stopped and will finish processing audio already captured. Reconnect the microphone, then start dictation again.',
+  },
   sidecar: {
     key: 'sidecar-session-error',
     message: 'The speech engine reported an error.',
@@ -448,6 +453,28 @@ export class DictationSessionController {
       this.disposeLocalSession(sessionId);
       this.handleError(FEEDBACK_FAILURES.stopDictation, error, entry);
     }
+  }
+
+  async handleAudioCaptureEnded(sessionId: string): Promise<void> {
+    const entry = this.sessions.get(sessionId);
+    if (entry === undefined || entry.phase !== 'active' || this.activeSessionId !== sessionId) {
+      return;
+    }
+
+    this.dependencies.logger?.warn(
+      'audio',
+      `microphone capture ended unexpectedly for session ${sessionId}`,
+    );
+    this.reportTerminalFeedback(entry, {
+      cause: { reason: 'microphone_disconnected', sessionId },
+      intent: 'warning',
+      key: FEEDBACK_FAILURES.microphoneDisconnected.key,
+      message: FEEDBACK_FAILURES.microphoneDisconnected.message,
+    });
+
+    // Stop rather than cancel so the sidecar drains and emits transcripts for
+    // audio already accepted before the device disappeared.
+    await this.stopDictation();
   }
 
   private async cleanupFailedStart(sessionId: string, error: unknown): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,6 +112,9 @@ export default class LocalSttPlugin extends Plugin {
           message: 'Saved microphone unavailable. Using the default input device.',
         });
       },
+      onUnexpectedEnd: (sessionId) => {
+        void this.dictationController?.handleAudioCaptureEnded(sessionId);
+      },
     });
     this.modelInstallManager = new ModelInstallManager({
       getSettings: () => this.settings,

--- a/test/audio-capture-stream.test.ts
+++ b/test/audio-capture-stream.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/audio/pcm-recorder-worklet-source', () => ({
+  PCM_RECORDER_WORKLET_SOURCE: 'registerProcessor("pcm-recorder", class {});',
+}));
+
+import { AudioCaptureStream } from '../src/audio/audio-capture-stream';
+
+class FakeMediaStreamTrack {
+  private readonly endedListeners = new Set<EventListenerOrEventListenerObject>();
+  public readyState: MediaStreamTrackState = 'live';
+  public readonly stop = vi.fn(() => {
+    this.readyState = 'ended';
+    this.emitEnded();
+  });
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject | null): void {
+    if (type === 'ended' && listener !== null) {
+      this.endedListeners.add(listener);
+    }
+  }
+
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject | null): void {
+    if (type === 'ended' && listener !== null) {
+      this.endedListeners.delete(listener);
+    }
+  }
+
+  endUnexpectedly(): void {
+    this.readyState = 'ended';
+    this.emitEnded();
+  }
+
+  listenerCount(): number {
+    return this.endedListeners.size;
+  }
+
+  private emitEnded(): void {
+    const event = new Event('ended');
+    for (const listener of this.endedListeners) {
+      if (typeof listener === 'function') {
+        listener(event);
+      } else {
+        listener.handleEvent(event);
+      }
+    }
+  }
+}
+
+class FakeMediaStream {
+  constructor(private readonly track: FakeMediaStreamTrack) {}
+
+  getAudioTracks(): MediaStreamTrack[] {
+    return [this.track as unknown as MediaStreamTrack];
+  }
+
+  getTracks(): MediaStreamTrack[] {
+    return this.getAudioTracks();
+  }
+}
+
+class FakeAudioNode {
+  readonly connect = vi.fn();
+  readonly disconnect = vi.fn();
+}
+
+class FakeAudioContext {
+  readonly audioWorklet = { addModule: vi.fn(async (_url: string) => {}) };
+  readonly destination = new FakeAudioNode();
+  readonly close = vi.fn(async () => {
+    this.state = 'closed';
+  });
+  readonly createGain = vi.fn(() => ({
+    ...new FakeAudioNode(),
+    gain: { value: 1 },
+  }));
+  readonly createMediaStreamSource = vi.fn((_stream: MediaStream) => new FakeAudioNode());
+  readonly resume = vi.fn(async () => {});
+  state: AudioContextState = 'running';
+}
+
+class FakeAudioWorkletNode extends FakeAudioNode {
+  readonly port = { onmessage: null as ((event: MessageEvent<ArrayBuffer>) => void) | null };
+}
+
+describe('AudioCaptureStream', () => {
+  beforeEach(() => {
+    vi.stubGlobal('AudioContext', FakeAudioContext);
+    vi.stubGlobal('AudioWorkletNode', FakeAudioWorkletNode);
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:recorder-worklet');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('reports an unexpected microphone track end once for the owning session', async () => {
+    const track = new FakeMediaStreamTrack();
+    const mediaStream = new FakeMediaStream(track);
+    const getUserMedia = vi.fn(async () => mediaStream as unknown as MediaStream);
+    vi.stubGlobal('navigator', { mediaDevices: { getUserMedia } });
+    const onUnexpectedEnd = vi.fn();
+    const capture = new AudioCaptureStream({ onUnexpectedEnd });
+
+    await capture.start({ sessionId: 'session-a' }, vi.fn());
+    track.endUnexpectedly();
+    track.endUnexpectedly();
+
+    expect(onUnexpectedEnd).toHaveBeenCalledOnce();
+    expect(onUnexpectedEnd).toHaveBeenCalledWith('session-a');
+    expect(track.listenerCount()).toBe(1);
+  });
+
+  it('removes the old track listener before teardown and rapid restart', async () => {
+    const firstTrack = new FakeMediaStreamTrack();
+    const secondTrack = new FakeMediaStreamTrack();
+    const getUserMedia = vi
+      .fn()
+      .mockResolvedValueOnce(new FakeMediaStream(firstTrack) as unknown as MediaStream)
+      .mockResolvedValueOnce(new FakeMediaStream(secondTrack) as unknown as MediaStream);
+    vi.stubGlobal('navigator', { mediaDevices: { getUserMedia } });
+    const onUnexpectedEnd = vi.fn();
+    const capture = new AudioCaptureStream({ onUnexpectedEnd });
+
+    await capture.start({ sessionId: 'session-a' }, vi.fn());
+    await capture.stop();
+    await capture.start({ sessionId: 'session-b' }, vi.fn());
+    firstTrack.endUnexpectedly();
+
+    expect(firstTrack.listenerCount()).toBe(0);
+    expect(secondTrack.listenerCount()).toBe(1);
+    expect(onUnexpectedEnd).not.toHaveBeenCalled();
+
+    secondTrack.endUnexpectedly();
+    expect(onUnexpectedEnd).toHaveBeenCalledOnce();
+    expect(onUnexpectedEnd).toHaveBeenCalledWith('session-b');
+  });
+});

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -2104,6 +2104,72 @@ describe('DictationSessionController', () => {
     expect(controller.getState()).toBe('idle');
   });
 
+  it('gracefully finalizes buffered speech when the active microphone disconnects', async () => {
+    const captureStream = new FakeCaptureStream();
+    const show = vi.fn();
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const controller = createController({
+      captureStream,
+      createSession: (session) => {
+        sessions.push(session);
+      },
+      feedback: { show },
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+
+    await controller.handleAudioCaptureEnded(sessionId);
+
+    expect(captureStream.stop).toHaveBeenCalledTimes(1);
+    expect(sidecarConnection.requestStopSession).toHaveBeenCalledWith(sessionId);
+    expect(sidecarConnection.cancelSession).not.toHaveBeenCalled();
+    expect(show).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: 'warning',
+        key: 'microphone-capture-ended',
+        message: expect.stringContaining('Reconnect the microphone'),
+      }),
+    );
+    expect(controller.getState()).toBe('idle');
+
+    sidecarConnection.emit(transcriptReady(sessionId, 'speech captured before disconnect'));
+    await vi.waitFor(() => {
+      expect(sessions[0]?.acceptTranscript).toHaveBeenCalledWith(
+        expect.objectContaining({ text: 'speech captured before disconnect' }),
+      );
+    });
+    sidecarConnection.emit({ reason: 'user_stop', sessionId, type: 'session_stopped' });
+    await vi.waitFor(() => {
+      expect(sessions[0]?.dispose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('ignores a stale microphone-ended event after a new session starts', async () => {
+    const captureStream = new FakeCaptureStream();
+    const show = vi.fn();
+    const sidecarConnection = new FakeSidecarConnection();
+    const controller = createController({ captureStream, feedback: { show }, sidecarConnection });
+
+    await controller.startDictation();
+    const firstSessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    await controller.handleAudioCaptureEnded(firstSessionId);
+    await controller.startDictation();
+    const secondSessionId = sidecarConnection.startSession.mock.calls[1]?.[0].sessionId ?? '';
+
+    await controller.handleAudioCaptureEnded(firstSessionId);
+
+    expect(secondSessionId).not.toBe(firstSessionId);
+    expect(sidecarConnection.requestStopSession).toHaveBeenCalledTimes(1);
+    expect(sidecarConnection.requestStopSession).toHaveBeenCalledWith(firstSessionId);
+    expect(captureStream.stop).toHaveBeenCalledTimes(1);
+    expect(captureStream.sessionId).toBe(secondSessionId);
+    expect(show).toHaveBeenCalledTimes(1);
+    expect(controller.getState()).toBe('listening');
+  });
+
   it('still stops the sidecar session and returns to idle when capture teardown rejects on stop', async () => {
     const captureStream = new FakeCaptureStream();
     const logger = new FakeLogger();


### PR DESCRIPTION
## Summary

- Stop an active dictation session when its microphone track ends unexpectedly instead of leaving the UI listening to a silent stream.
- Gracefully stop the sidecar so audio already captured before the disconnect can still finalize into the note.

## Key changes

- Plugin: observe `MediaStreamTrack` `ended` events and remove owned listeners before capture teardown.
- Plugin: route device loss by session ID, ignore stale events after rapid restart, and show actionable reconnect feedback.
- Tests: cover one-shot track-end reporting, listener teardown, rapid restart isolation, buffered transcript drain, and stale controller events.

## Notes

No settings-schema, wire-protocol, or native-sidecar changes.

## Test plan

- [x] `npm run check` (TS typecheck + lint + vitest + esbuild)
- [x] `cargo test` (+ `cargo clippy` if Rust changed) via `npm run check`
- [ ] Manual: unplug a physical USB microphone during dictation (not available in this environment)
