### PR TITLE
Add last utterance recovery command

### DIFF
--- a/src/commands/register-commands.ts
+++ b/src/commands/register-commands.ts
@@ -1,14 +1,17 @@
-import type { Plugin } from 'obsidian';
+import type { Editor, Plugin } from 'obsidian';
 
 const START_DICTATION_COMMAND_ID = 'start-dictation-session';
 const STOP_DICTATION_COMMAND_ID = 'stop-dictation-session';
 const CANCEL_DICTATION_COMMAND_ID = 'cancel-dictation-session';
 const TOGGLE_DICTATION_COMMAND_ID = 'toggle-dictation-session';
+const REINSERT_LAST_UTTERANCE_COMMAND_ID = 'reinsert-last-utterance';
 
 interface CommandDependencies {
   cancelDictation: () => Promise<void>;
   checkSidecarHealth: () => Promise<void>;
   plugin: Plugin;
+  canReinsertLastUtterance: () => boolean;
+  reinsertLastUtterance: (editor: Editor) => void;
   restartSidecar: () => Promise<void>;
   startDictation: () => Promise<void>;
   stopDictation: () => Promise<void>;
@@ -45,6 +48,20 @@ export function registerCommands(dependencies: CommandDependencies): void {
     name: 'Cancel dictation',
     callback: async () => {
       await dependencies.cancelDictation();
+    },
+  });
+
+  dependencies.plugin.addCommand({
+    id: REINSERT_LAST_UTTERANCE_COMMAND_ID,
+    name: 'Reinsert last utterance',
+    editorCheckCallback: (checking, editor) => {
+      if (!dependencies.canReinsertLastUtterance()) {
+        return false;
+      }
+      if (!checking) {
+        dependencies.reinsertLastUtterance(editor);
+      }
+      return true;
     },
   });
 

--- a/src/commands/register-commands.ts
+++ b/src/commands/register-commands.ts
@@ -5,12 +5,14 @@ const STOP_DICTATION_COMMAND_ID = 'stop-dictation-session';
 const CANCEL_DICTATION_COMMAND_ID = 'cancel-dictation-session';
 const TOGGLE_DICTATION_COMMAND_ID = 'toggle-dictation-session';
 const REINSERT_LAST_UTTERANCE_COMMAND_ID = 'reinsert-last-utterance';
+const CLEAR_LAST_UTTERANCE_COMMAND_ID = 'clear-last-utterance';
 
 interface CommandDependencies {
   cancelDictation: () => Promise<void>;
+  clearLastUtterance: () => void;
   checkSidecarHealth: () => Promise<void>;
   plugin: Plugin;
-  canReinsertLastUtterance: () => boolean;
+  hasLastUtterance: () => boolean;
   reinsertLastUtterance: (editor: Editor) => void;
   restartSidecar: () => Promise<void>;
   startDictation: () => Promise<void>;
@@ -55,11 +57,25 @@ export function registerCommands(dependencies: CommandDependencies): void {
     id: REINSERT_LAST_UTTERANCE_COMMAND_ID,
     name: 'Reinsert last utterance',
     editorCheckCallback: (checking, editor) => {
-      if (!dependencies.canReinsertLastUtterance()) {
+      if (!dependencies.hasLastUtterance()) {
         return false;
       }
       if (!checking) {
         dependencies.reinsertLastUtterance(editor);
+      }
+      return true;
+    },
+  });
+
+  dependencies.plugin.addCommand({
+    id: CLEAR_LAST_UTTERANCE_COMMAND_ID,
+    name: 'Clear last utterance',
+    checkCallback: (checking) => {
+      if (!dependencies.hasLastUtterance()) {
+        return false;
+      }
+      if (!checking) {
+        dependencies.clearLastUtterance();
       }
       return true;
     },

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -135,6 +135,7 @@ interface DictationSessionControllerDependencies {
   logger?: PluginLogger;
   onLlmCleanupFailure?: (failure: LlmCleanupFailure) => void;
   onLlmCleanupSuccess?: () => void;
+  onFinalizedUtteranceAccepted?: (text: string) => void;
   onModelMissing?: () => void;
   onSidecarMissing?: () => void;
   countAudioInputDevices?: () => Promise<number | null>;
@@ -877,6 +878,10 @@ export class DictationSessionController {
     if (result.kind === 'rejected') {
       this.handleError(FEEDBACK_FAILURES.recordTranscript, new Error(result.reason), entry);
       await this.cancelSession(sessionId);
+      return;
+    }
+    if (result.kind === 'accepted' && revision.isFinal && revision.text.trim().length > 0) {
+      this.dependencies.onFinalizedUtteranceAccepted?.(revision.text);
     }
   }
 

--- a/src/dictation/last-utterance-recovery.ts
+++ b/src/dictation/last-utterance-recovery.ts
@@ -2,25 +2,39 @@ import type { Editor, EditorPosition } from 'obsidian';
 
 import type { UserFeedback } from '../shared/user-feedback';
 
+const UNICODE_WORD_AT_START = /^[\p{L}\p{M}\p{N}\p{Pc}]/u;
+const UNICODE_WORD_AT_END = /[\p{L}\p{M}\p{N}\p{Pc}]$/u;
+
 export type UtteranceRecoveryEditor = Pick<
   Editor,
   'getCursor' | 'getLine' | 'replaceRange' | 'setCursor'
 >;
 
 export class LastUtteranceRecovery {
+  private enabled = true;
   private text: string | null = null;
 
   constructor(private readonly feedback: Pick<UserFeedback, 'show'>) {}
 
   hasUtterance(): boolean {
-    return this.text !== null;
+    return this.enabled && this.text !== null;
   }
 
   clear(): void {
     this.text = null;
   }
 
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+    if (!enabled) {
+      this.clear();
+    }
+  }
+
   recordFinalizedUtterance(text: string): void {
+    if (!this.enabled) {
+      return;
+    }
     const normalized = text.trim();
     if (normalized.length > 0) {
       this.text = normalized;
@@ -62,32 +76,16 @@ export class LastUtteranceRecovery {
 }
 
 function formatInsertion(text: string, line: string, cursorCh: number): string {
-  const characterBefore = cursorCh > 0 ? line.charAt(cursorCh - 1) : '';
-  const characterAfter = line.charAt(cursorCh);
-  const prefix = needsSpaceBefore(characterBefore, text.charAt(0)) ? ' ' : '';
-  const suffix = needsSpaceAfter(text.charAt(text.length - 1), characterAfter) ? ' ' : '';
+  const textBeforeCursor = line.slice(0, cursorCh);
+  const textAfterCursor = line.slice(cursorCh);
+  const prefix = needsWordBoundarySpace(textBeforeCursor, text) ? ' ' : '';
+  const suffix = needsWordBoundarySpace(text, textAfterCursor) ? ' ' : '';
 
   return `${prefix}${text}${suffix}`;
 }
 
-function needsSpaceBefore(characterBefore: string, firstInsertedCharacter: string): boolean {
-  if (characterBefore.length === 0 || /\s/u.test(characterBefore)) {
-    return false;
-  }
-  if ('([{'.includes(characterBefore) || '.,!?;:)]}'.includes(firstInsertedCharacter)) {
-    return false;
-  }
-  return true;
-}
-
-function needsSpaceAfter(lastInsertedCharacter: string, characterAfter: string): boolean {
-  if (characterAfter.length === 0 || /\s/u.test(characterAfter)) {
-    return false;
-  }
-  if ('([{'.includes(lastInsertedCharacter) || '.,!?;:)]}'.includes(characterAfter)) {
-    return false;
-  }
-  return true;
+function needsWordBoundarySpace(before: string, after: string): boolean {
+  return UNICODE_WORD_AT_END.test(before) && UNICODE_WORD_AT_START.test(after);
 }
 
 function advancePosition(position: EditorPosition, insertion: string): EditorPosition {

--- a/src/dictation/last-utterance-recovery.ts
+++ b/src/dictation/last-utterance-recovery.ts
@@ -1,0 +1,103 @@
+import type { Editor, EditorPosition } from 'obsidian';
+
+import type { UserFeedback } from '../shared/user-feedback';
+
+export type UtteranceRecoveryEditor = Pick<
+  Editor,
+  'getCursor' | 'getLine' | 'replaceRange' | 'setCursor'
+>;
+
+export class LastUtteranceRecovery {
+  private text: string | null = null;
+
+  constructor(private readonly feedback: Pick<UserFeedback, 'show'>) {}
+
+  hasUtterance(): boolean {
+    return this.text !== null;
+  }
+
+  clear(): void {
+    this.text = null;
+  }
+
+  recordFinalizedUtterance(text: string): void {
+    const normalized = text.trim();
+    if (normalized.length > 0) {
+      this.text = normalized;
+    }
+  }
+
+  reinsert(editor: UtteranceRecoveryEditor): boolean {
+    if (this.text === null) {
+      this.feedback.show({
+        intent: 'information',
+        key: 'last-utterance-unavailable',
+        message: 'No finalized utterance is available to reinsert.',
+      });
+      return false;
+    }
+
+    try {
+      const cursor = editor.getCursor('head');
+      const line = editor.getLine(cursor.line);
+      const insertion = formatInsertion(this.text, line, cursor.ch);
+      editor.replaceRange(insertion, cursor);
+      editor.setCursor(advancePosition(cursor, insertion));
+      this.feedback.show({
+        intent: 'success',
+        key: 'last-utterance-reinserted',
+        message: 'Reinserted the last finalized utterance.',
+      });
+      return true;
+    } catch (error) {
+      this.feedback.show({
+        cause: error,
+        intent: 'error',
+        key: 'last-utterance-reinsert-failed',
+        message: 'Could not reinsert the last finalized utterance.',
+      });
+      return false;
+    }
+  }
+}
+
+function formatInsertion(text: string, line: string, cursorCh: number): string {
+  const characterBefore = cursorCh > 0 ? line.charAt(cursorCh - 1) : '';
+  const characterAfter = line.charAt(cursorCh);
+  const prefix = needsSpaceBefore(characterBefore, text.charAt(0)) ? ' ' : '';
+  const suffix = needsSpaceAfter(text.charAt(text.length - 1), characterAfter) ? ' ' : '';
+
+  return `${prefix}${text}${suffix}`;
+}
+
+function needsSpaceBefore(characterBefore: string, firstInsertedCharacter: string): boolean {
+  if (characterBefore.length === 0 || /\s/u.test(characterBefore)) {
+    return false;
+  }
+  if ('([{'.includes(characterBefore) || '.,!?;:)]}'.includes(firstInsertedCharacter)) {
+    return false;
+  }
+  return true;
+}
+
+function needsSpaceAfter(lastInsertedCharacter: string, characterAfter: string): boolean {
+  if (characterAfter.length === 0 || /\s/u.test(characterAfter)) {
+    return false;
+  }
+  if ('([{'.includes(lastInsertedCharacter) || '.,!?;:)]}'.includes(characterAfter)) {
+    return false;
+  }
+  return true;
+}
+
+function advancePosition(position: EditorPosition, insertion: string): EditorPosition {
+  const lines = insertion.split('\n');
+  if (lines.length === 1) {
+    return { ch: position.ch + insertion.length, line: position.line };
+  }
+
+  return {
+    ch: lines.at(-1)?.length ?? 0,
+    line: position.line + lines.length - 1,
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { AudioCaptureStream } from './audio/audio-capture-stream';
 import { SidecarAudioLevelMeter } from './audio/sidecar-audio-level-meter';
 import { registerCommands } from './commands/register-commands';
 import { DictationSessionController } from './dictation/dictation-session-controller';
+import { LastUtteranceRecovery } from './dictation/last-utterance-recovery';
 import { dictationAnchorExtension } from './editor/dictation-anchor-extension';
 import { noteSurfaceUpdateListenerExtension } from './editor/note-surface';
 import { provisionalTranscriptExtension } from './editor/provisional-transcript-extension';
@@ -62,6 +63,7 @@ export default class LocalSttPlugin extends Plugin {
     presenter: createObsidianFeedbackPresenter(),
   });
   private llmCleanupFailure: LlmCleanupFailure | null = null;
+  private readonly lastUtteranceRecovery = new LastUtteranceRecovery(this.feedback);
   private readonly llmCleanupFailureSubscribers = new Set<() => void>();
   private modelInstallManager: ModelInstallManager | null = null;
   private presetStateStore: LlmPresetStateStore | null = null;
@@ -196,6 +198,9 @@ export default class LocalSttPlugin extends Plugin {
           this.notifyLlmCleanupFailureSubscribers();
         }
       },
+      onFinalizedUtteranceAccepted: (text) => {
+        this.lastUtteranceRecovery.recordFinalizedUtterance(text);
+      },
       onModelMissing: () => {
         void this.openModelPicker();
       },
@@ -237,8 +242,12 @@ export default class LocalSttPlugin extends Plugin {
 
     registerCommands({
       cancelDictation: async () => this.requireDictationController().cancelDictation(),
+      canReinsertLastUtterance: () => this.lastUtteranceRecovery.hasUtterance(),
       checkSidecarHealth: async () => this.checkSidecarHealth(),
       plugin: this,
+      reinsertLastUtterance: (editor) => {
+        this.lastUtteranceRecovery.reinsert(editor);
+      },
       restartSidecar: async () => this.restartSidecar(),
       startDictation: async () => this.requireDictationController().startDictation(),
       stopDictation: async () => this.requireDictationController().stopDictation(),
@@ -393,6 +402,8 @@ export default class LocalSttPlugin extends Plugin {
   }
 
   private async disposeAll(): Promise<void> {
+    this.lastUtteranceRecovery.clear();
+
     try {
       this.modelInstallManager?.dispose();
     } catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,6 +76,7 @@ export default class LocalSttPlugin extends Plugin {
   override async onload(): Promise<void> {
     const loadedSettings = loadPluginSettings(await this.loadData(), this.app.secretStorage);
     this.settings = loadedSettings.settings;
+    this.lastUtteranceRecovery.setEnabled(this.settings.retainLastUtterance);
     if (loadedSettings.shouldPersist) {
       await this.saveData(this.settings);
     }
@@ -242,8 +243,16 @@ export default class LocalSttPlugin extends Plugin {
 
     registerCommands({
       cancelDictation: async () => this.requireDictationController().cancelDictation(),
-      canReinsertLastUtterance: () => this.lastUtteranceRecovery.hasUtterance(),
+      clearLastUtterance: () => {
+        this.lastUtteranceRecovery.clear();
+        this.feedback.show({
+          intent: 'success',
+          key: 'last-utterance-cleared',
+          message: 'Cleared the last retained utterance.',
+        });
+      },
       checkSidecarHealth: async () => this.checkSidecarHealth(),
+      hasLastUtterance: () => this.lastUtteranceRecovery.hasUtterance(),
       plugin: this,
       reinsertLastUtterance: (editor) => {
         this.lastUtteranceRecovery.reinsert(editor);
@@ -504,6 +513,7 @@ export default class LocalSttPlugin extends Plugin {
   ): Promise<void> {
     const previousSettings = this.settings;
     this.settings = resolvePluginSettings(nextSettings);
+    this.lastUtteranceRecovery.setEnabled(this.settings.retainLastUtterance);
     if (options.persist) {
       await this.saveData(this.settings);
     }

--- a/src/settings/plugin-settings.ts
+++ b/src/settings/plugin-settings.ts
@@ -128,6 +128,7 @@ export interface PluginSettings {
   llmRouting: LlmRouting;
   localTranscriptSidebarBootstrapped: boolean;
   modelStorePathOverride: string;
+  retainLastUtterance: boolean;
   schemaVersion: 2;
   selectedModel: SelectedModel | null;
   // Last-known-good capabilities for `selectedModel`, captured on a successful
@@ -182,6 +183,7 @@ export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
   llmRouting: 'local',
   localTranscriptSidebarBootstrapped: false,
   modelStorePathOverride: '',
+  retainLastUtterance: true,
   schemaVersion: 2,
   selectedModel: null,
   selectedModelCapabilitiesSnapshot: null,
@@ -302,6 +304,10 @@ export function resolvePluginSettings(data: unknown): PluginSettings {
     modelStorePathOverride: readString(
       raw.modelStorePathOverride,
       DEFAULT_PLUGIN_SETTINGS.modelStorePathOverride,
+    ),
+    retainLastUtterance: readBoolean(
+      raw.retainLastUtterance,
+      DEFAULT_PLUGIN_SETTINGS.retainLastUtterance,
     ),
     // Bump `schemaVersion` and add a migration step when renaming a key or changing default semantics.
     schemaVersion: 2,

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -244,6 +244,12 @@ export class LocalSttSettingTab extends PluginSettingTab {
     updateDiarizationDesc();
     this.disposeDiarizationDesc = manager.subscribe(updateDiarizationDesc);
 
+    addToggleSetting(outputCard, this.access, {
+      name: 'Keep last utterance for recovery',
+      desc: 'Keep the latest finalized utterance in memory for the Reinsert last utterance command. The text is never saved to disk and is cleared when disabled or the plugin unloads.',
+      key: 'retainLastUtterance',
+    });
+
     const timestampsCard = createSettingGroup(containerEl, 'Timestamps');
     this.renderTimestampSettings(timestampsCard, settings);
 

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -417,6 +417,50 @@ describe('DictationSessionController', () => {
     });
   });
 
+  it('offers only accepted non-empty final revisions for last-utterance recovery', async () => {
+    const onFinalizedUtteranceAccepted = vi.fn();
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const controller = createController({
+      createSession: (session) => {
+        sessions.push(session);
+      },
+      onFinalizedUtteranceAccepted,
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    const session = sessions[0];
+    if (session === undefined) {
+      throw new Error('expected session fixture');
+    }
+
+    sidecarConnection.emit(transcriptReady(sessionId, 'partial', { isFinal: false }));
+    await vi.waitFor(() => {
+      expect(session.acceptTranscript).toHaveBeenCalledTimes(1);
+    });
+    expect(onFinalizedUtteranceAccepted).not.toHaveBeenCalled();
+
+    sidecarConnection.emit(transcriptReady(sessionId, ''));
+    await vi.waitFor(() => {
+      expect(session.acceptTranscript).toHaveBeenCalledTimes(2);
+    });
+    expect(onFinalizedUtteranceAccepted).not.toHaveBeenCalled();
+
+    sidecarConnection.emit(transcriptReady(sessionId, 'recover this'));
+    await vi.waitFor(() => {
+      expect(onFinalizedUtteranceAccepted).toHaveBeenCalledWith('recover this');
+    });
+
+    session.acceptTranscript.mockReturnValueOnce({ kind: 'duplicate' });
+    sidecarConnection.emit(transcriptReady(sessionId, 'do not replace recovery'));
+    await vi.waitFor(() => {
+      expect(session.acceptTranscript).toHaveBeenCalledTimes(4);
+    });
+    expect(onFinalizedUtteranceAccepted).toHaveBeenCalledTimes(1);
+  });
+
   it('silently enforces the five-session active plus draining cap', async () => {
     const sidecarConnection = new FakeSidecarConnection();
     const controller = createController({ sidecarConnection });
@@ -2354,6 +2398,7 @@ function createController({
   sidecarConnection = new FakeSidecarConnection(),
   onLlmCleanupFailure,
   onLlmCleanupSuccess,
+  onFinalizedUtteranceAccepted,
 }: {
   audioLevelMeter?: FakeAudioLevelMeter;
   captureStream?: FakeCaptureStream;
@@ -2365,6 +2410,7 @@ function createController({
   feedback?: Pick<UserFeedback, 'show'>;
   onLlmCleanupFailure?: (failure: LlmCleanupFailure) => void;
   onLlmCleanupSuccess?: () => void;
+  onFinalizedUtteranceAccepted?: (text: string) => void;
   sidecarConnection?: FakeSidecarConnection;
 } = {}): DictationSessionController {
   return new DictationSessionController({
@@ -2382,6 +2428,7 @@ function createController({
     logger,
     ...(onLlmCleanupFailure !== undefined ? { onLlmCleanupFailure } : {}),
     ...(onLlmCleanupSuccess !== undefined ? { onLlmCleanupSuccess } : {}),
+    ...(onFinalizedUtteranceAccepted !== undefined ? { onFinalizedUtteranceAccepted } : {}),
     onModelMissing: vi.fn(),
     onSidecarMissing: vi.fn(),
     setRibbonQueueTier: vi.fn((_tier: QueueBackpressureTier) => {}),

--- a/test/last-utterance-recovery.test.ts
+++ b/test/last-utterance-recovery.test.ts
@@ -1,0 +1,116 @@
+import type { EditorPosition } from 'obsidian';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  LastUtteranceRecovery,
+  type UtteranceRecoveryEditor,
+} from '../src/dictation/last-utterance-recovery';
+
+describe('LastUtteranceRecovery', () => {
+  it('keeps recovery unavailable until a non-empty finalized utterance is recorded', () => {
+    const { feedback, recovery } = createRecoveryHarness();
+
+    recovery.recordFinalizedUtterance('   ');
+
+    expect(recovery.hasUtterance()).toBe(false);
+    expect(recovery.reinsert(createEditorHarness('').editor)).toBe(false);
+    expect(feedback.show).toHaveBeenCalledWith({
+      intent: 'information',
+      key: 'last-utterance-unavailable',
+      message: 'No finalized utterance is available to reinsert.',
+    });
+  });
+
+  it('clears the in-memory utterance explicitly', () => {
+    const { recovery } = createRecoveryHarness();
+    recovery.recordFinalizedUtterance('temporary text');
+
+    recovery.clear();
+
+    expect(recovery.hasUtterance()).toBe(false);
+  });
+
+  it('inserts at the cursor without replacing a selection and separates adjacent words', () => {
+    const { feedback, recovery } = createRecoveryHarness();
+    const editor = createEditorHarness('beforeafter', { ch: 6, line: 0 });
+    recovery.recordFinalizedUtterance(' restored text ');
+
+    expect(recovery.reinsert(editor.editor)).toBe(true);
+
+    expect(editor.getCursor).toHaveBeenCalledWith('head');
+    expect(editor.replaceRange).toHaveBeenCalledWith(' restored text ', { ch: 6, line: 0 });
+    expect(editor.replaceRange.mock.calls[0]).toHaveLength(2);
+    expect(editor.setCursor).toHaveBeenCalledWith({ ch: 21, line: 0 });
+    expect(feedback.show).toHaveBeenCalledWith({
+      intent: 'success',
+      key: 'last-utterance-reinserted',
+      message: 'Reinserted the last finalized utterance.',
+    });
+  });
+
+  it('does not add a trailing space before closing punctuation', () => {
+    const { recovery } = createRecoveryHarness();
+    const editor = createEditorHarness('()', { ch: 1, line: 0 });
+    recovery.recordFinalizedUtterance('aside');
+
+    recovery.reinsert(editor.editor);
+
+    expect(editor.replaceRange).toHaveBeenCalledWith('aside', { ch: 1, line: 0 });
+  });
+
+  it('places the cursor after a recovered multiline utterance', () => {
+    const { recovery } = createRecoveryHarness();
+    const editor = createEditorHarness('prefix ', { ch: 7, line: 3 });
+    recovery.recordFinalizedUtterance('first line\nsecond line');
+
+    recovery.reinsert(editor.editor);
+
+    expect(editor.replaceRange).toHaveBeenCalledWith('first line\nsecond line', {
+      ch: 7,
+      line: 3,
+    });
+    expect(editor.setCursor).toHaveBeenCalledWith({ ch: 11, line: 4 });
+  });
+
+  it('reports editor failures without clearing the recovery buffer', () => {
+    const error = new Error('editor unavailable');
+    const { feedback, recovery } = createRecoveryHarness();
+    const editor = createEditorHarness('');
+    editor.replaceRange.mockImplementation(() => {
+      throw error;
+    });
+    recovery.recordFinalizedUtterance('recover me');
+
+    expect(recovery.reinsert(editor.editor)).toBe(false);
+    expect(recovery.hasUtterance()).toBe(true);
+    expect(feedback.show).toHaveBeenCalledWith({
+      cause: error,
+      intent: 'error',
+      key: 'last-utterance-reinsert-failed',
+      message: 'Could not reinsert the last finalized utterance.',
+    });
+  });
+});
+
+function createRecoveryHarness(): {
+  feedback: { show: ReturnType<typeof vi.fn> };
+  recovery: LastUtteranceRecovery;
+} {
+  const feedback = { show: vi.fn() };
+  return { feedback, recovery: new LastUtteranceRecovery(feedback) };
+}
+
+function createEditorHarness(line: string, cursor: EditorPosition = { ch: 0, line: 0 }) {
+  const getCursor = vi.fn(() => cursor);
+  const getLine = vi.fn(() => line);
+  const replaceRange = vi.fn();
+  const setCursor = vi.fn();
+  const editor = {
+    getCursor,
+    getLine,
+    replaceRange,
+    setCursor,
+  } as unknown as UtteranceRecoveryEditor;
+
+  return { editor, getCursor, getLine, replaceRange, setCursor };
+}

--- a/test/last-utterance-recovery.test.ts
+++ b/test/last-utterance-recovery.test.ts
@@ -30,6 +30,22 @@ describe('LastUtteranceRecovery', () => {
     expect(recovery.hasUtterance()).toBe(false);
   });
 
+  it('clears immediately when disabled and ignores text until re-enabled', () => {
+    const { recovery } = createRecoveryHarness();
+    recovery.recordFinalizedUtterance('temporary text');
+
+    recovery.setEnabled(false);
+    recovery.recordFinalizedUtterance('must not be retained');
+
+    expect(recovery.hasUtterance()).toBe(false);
+
+    recovery.setEnabled(true);
+    expect(recovery.hasUtterance()).toBe(false);
+
+    recovery.recordFinalizedUtterance('new recovery text');
+    expect(recovery.hasUtterance()).toBe(true);
+  });
+
   it('inserts at the cursor without replacing a selection and separates adjacent words', () => {
     const { feedback, recovery } = createRecoveryHarness();
     const editor = createEditorHarness('beforeafter', { ch: 6, line: 0 });
@@ -56,6 +72,31 @@ describe('LastUtteranceRecovery', () => {
     recovery.reinsert(editor.editor);
 
     expect(editor.replaceRange).toHaveBeenCalledWith('aside', { ch: 1, line: 0 });
+  });
+
+  it.each([
+    ['emphasis', '****', 2, '**restored**'],
+    ['inline code', '``', 1, '`restored`'],
+    ['quotes', '""', 1, '"restored"'],
+  ])('does not synthesize spaces inside Markdown %s', (_label, line, ch, expectedLine) => {
+    const { recovery } = createRecoveryHarness();
+    const editor = createEditorHarness(line, { ch, line: 0 });
+    recovery.recordFinalizedUtterance('restored');
+
+    recovery.reinsert(editor.editor);
+
+    const insertion = editor.replaceRange.mock.calls[0]?.[0] ?? '';
+    expect(`${line.slice(0, ch)}${insertion}${line.slice(ch)}`).toBe(expectedLine);
+  });
+
+  it('separates adjacent Unicode word characters', () => {
+    const { recovery } = createRecoveryHarness();
+    const editor = createEditorHarness('𐐀界', { ch: 2, line: 0 });
+    recovery.recordFinalizedUtterance('é');
+
+    recovery.reinsert(editor.editor);
+
+    expect(editor.replaceRange).toHaveBeenCalledWith(' é ', { ch: 2, line: 0 });
   });
 
   it('places the cursor after a recovered multiline utterance', () => {

--- a/test/plugin-settings.test.ts
+++ b/test/plugin-settings.test.ts
@@ -53,6 +53,12 @@ describe('resolvePluginSettings', () => {
     expect(resolvePluginSettings({ diarizationEnabled: 'yes' }).diarizationEnabled).toBe(false);
   });
 
+  it('retains the last utterance by default and honors only a persisted boolean opt-out', () => {
+    expect(DEFAULT_PLUGIN_SETTINGS.retainLastUtterance).toBe(true);
+    expect(resolvePluginSettings({ retainLastUtterance: false }).retainLastUtterance).toBe(false);
+    expect(resolvePluginSettings({ retainLastUtterance: 'no' }).retainLastUtterance).toBe(true);
+  });
+
   it('migrates legacy speaker label setting to diarization', () => {
     expect(resolvePluginSettings({ speakerLabelsEnabled: true }).diarizationEnabled).toBe(true);
     expect(

--- a/test/register-commands.test.ts
+++ b/test/register-commands.test.ts
@@ -1,0 +1,42 @@
+import type { Command, Editor, Plugin } from 'obsidian';
+import { describe, expect, it, vi } from 'vitest';
+
+import { registerCommands } from '../src/commands/register-commands';
+
+describe('registerCommands', () => {
+  it('exposes reinsert last utterance only when recovery is available', () => {
+    const commands: Command[] = [];
+    const plugin = {
+      addCommand: vi.fn((command: Command) => {
+        commands.push(command);
+      }),
+    } as unknown as Plugin;
+    let available = false;
+    const reinsertLastUtterance = vi.fn((_editor: Editor) => {});
+    registerCommands({
+      cancelDictation: vi.fn(async () => {}),
+      canReinsertLastUtterance: () => available,
+      checkSidecarHealth: vi.fn(async () => {}),
+      plugin,
+      reinsertLastUtterance,
+      restartSidecar: vi.fn(async () => {}),
+      startDictation: vi.fn(async () => {}),
+      stopDictation: vi.fn(async () => {}),
+      toggleDictation: vi.fn(async () => {}),
+    });
+    const command = commands.find(({ id }) => id === 'reinsert-last-utterance');
+    const editor = {} as Editor;
+
+    expect(command?.name).toBe('Reinsert last utterance');
+    expect(command?.editorCheckCallback?.(true, editor, {} as never)).toBe(false);
+    expect(reinsertLastUtterance).not.toHaveBeenCalled();
+
+    available = true;
+    expect(command?.editorCheckCallback?.(true, editor, {} as never)).toBe(true);
+    expect(reinsertLastUtterance).not.toHaveBeenCalled();
+
+    expect(command?.editorCheckCallback?.(false, editor, {} as never)).toBe(true);
+    expect(reinsertLastUtterance).toHaveBeenCalledOnce();
+    expect(reinsertLastUtterance).toHaveBeenCalledWith(editor);
+  });
+});

--- a/test/register-commands.test.ts
+++ b/test/register-commands.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { registerCommands } from '../src/commands/register-commands';
 
 describe('registerCommands', () => {
-  it('exposes reinsert last utterance only when recovery is available', () => {
+  it('exposes recovery commands only while a retained utterance is available', () => {
     const commands: Command[] = [];
     const plugin = {
       addCommand: vi.fn((command: Command) => {
@@ -12,11 +12,15 @@ describe('registerCommands', () => {
       }),
     } as unknown as Plugin;
     let available = false;
+    const clearLastUtterance = vi.fn(() => {
+      available = false;
+    });
     const reinsertLastUtterance = vi.fn((_editor: Editor) => {});
     registerCommands({
       cancelDictation: vi.fn(async () => {}),
-      canReinsertLastUtterance: () => available,
+      clearLastUtterance,
       checkSidecarHealth: vi.fn(async () => {}),
+      hasLastUtterance: () => available,
       plugin,
       reinsertLastUtterance,
       restartSidecar: vi.fn(async () => {}),
@@ -24,19 +28,30 @@ describe('registerCommands', () => {
       stopDictation: vi.fn(async () => {}),
       toggleDictation: vi.fn(async () => {}),
     });
-    const command = commands.find(({ id }) => id === 'reinsert-last-utterance');
+    const reinsertCommand = commands.find(({ id }) => id === 'reinsert-last-utterance');
+    const clearCommand = commands.find(({ id }) => id === 'clear-last-utterance');
     const editor = {} as Editor;
 
-    expect(command?.name).toBe('Reinsert last utterance');
-    expect(command?.editorCheckCallback?.(true, editor, {} as never)).toBe(false);
+    expect(reinsertCommand?.name).toBe('Reinsert last utterance');
+    expect(clearCommand?.name).toBe('Clear last utterance');
+    expect(reinsertCommand?.editorCheckCallback?.(true, editor, {} as never)).toBe(false);
+    expect(clearCommand?.checkCallback?.(true)).toBe(false);
     expect(reinsertLastUtterance).not.toHaveBeenCalled();
+    expect(clearLastUtterance).not.toHaveBeenCalled();
 
     available = true;
-    expect(command?.editorCheckCallback?.(true, editor, {} as never)).toBe(true);
+    expect(reinsertCommand?.editorCheckCallback?.(true, editor, {} as never)).toBe(true);
+    expect(clearCommand?.checkCallback?.(true)).toBe(true);
     expect(reinsertLastUtterance).not.toHaveBeenCalled();
+    expect(clearLastUtterance).not.toHaveBeenCalled();
 
-    expect(command?.editorCheckCallback?.(false, editor, {} as never)).toBe(true);
+    expect(reinsertCommand?.editorCheckCallback?.(false, editor, {} as never)).toBe(true);
     expect(reinsertLastUtterance).toHaveBeenCalledOnce();
     expect(reinsertLastUtterance).toHaveBeenCalledWith(editor);
+
+    expect(clearCommand?.checkCallback?.(false)).toBe(true);
+    expect(clearLastUtterance).toHaveBeenCalledOnce();
+    expect(reinsertCommand?.editorCheckCallback?.(true, editor, {} as never)).toBe(false);
+    expect(clearCommand?.checkCallback?.(true)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Adds an editor command to reinsert the most recently accepted finalized utterance at the current cursor.
- Keeps one recovery payload in memory only, with a default-on setting that can disable and immediately clear retention.
- Adds an explicit command to clear the retained utterance without unloading the plugin.
- Relates to #228.

## Key changes

- **Plugin:** Captures only accepted, non-empty final revisions after per-utterance cleanup; partial, duplicate, stale, rejected, and cancelled work cannot replace the recovery payload.
- **Editor:** Inserts at a zero-width range so an active selection is not overwritten, synthesizes spaces only at Unicode word-to-word boundaries, and restores the caret after single- or multi-line text.
- **Commands:** Exposes `Reinsert last utterance` and `Clear last utterance` only while a retained payload is available.
- **Settings:** Provides `Keep last utterance for recovery`; disabling it clears memory immediately and prevents future recording until re-enabled.
- **Tests:** Covers controller eligibility, command lifecycle, opt-out persistence, cursor placement, multiline recovery, Unicode spacing, Markdown delimiters, explicit clearing, and editor failure handling.

## Privacy and lifecycle

The payload is local and in-memory only. It is never persisted, logged, or included in diagnostics. It is cleared on explicit command, when retention is disabled, and when the plugin unloads. Audio handling is unchanged.

## Test plan

- [x] `npm run check:frontend` (typecheck, Biome, Obsidian ESLint, 740 Vitest tests, production frontend build)
- [x] Exact-head GitHub CI and CodeQL
- [ ] Manual Obsidian editor/undo pass not run; editor behavior is covered with behavioral command and insertion tests.
