### PR TITLE
Add local personal correction rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ All transcription models in the current catalog run locally and support English.
 - **Meeting capture.** Include system audio from meetings, calls, or videos alongside your microphone on Windows, Linux, and macOS 14.2 or later.
 - **Speaker labels.** Optional on-device diarization assigns session-stable speaker labels. Speaker embeddings stay in memory and are discarded after the session.
 - **Timestamps.** Add elapsed or wall-clock timestamps at configurable intervals.
+- **Personal corrections.** Fix recurring names, technical terms, and recognition mistakes with ordered local replacement rules.
 - **Local model choices.** Choose Whisper, Cohere Transcribe, or Moonshine models and download them from Settings.
 - **Optional text transformation.** Clean up, summarize, extract action items, or apply a custom prompt through local Ollama or remote OpenRouter models.
 - **Explicit remote controls.** Keep transformations local, allow OpenRouter only for oversized transcripts, or disable remote and LLM features entirely.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -351,9 +351,22 @@ utterance-level VAD evidence. If nothing is dropped it records
 Final transcripts then pass through **personal corrections** when the session
 has enabled rules. Rules are literal, ordered, and independently configure case
 and whole-word matching. Each rule consumes the prior rule's output, so ordering
-is explicit. The stage preserves segment timing and reports only rule and
-replacement counts in its payload; transcript and rule content are not copied
-into diagnostics.
+is explicit. Matching uses the same canonical text users see: trimmed non-empty
+segments joined with one space. A match may therefore cross adjacent segments
+belonging to the same speaker, but never crosses a speaker boundary.
+Leading or trailing whitespace in either side of a rule is rejected because
+canonical segment joining cannot preserve it reliably.
+
+Corrections preserve every segment record, timestamp, and speaker assignment.
+For a cross-segment match, the replacement is stored in the first affected
+segment and consumed text is cleared from subsequent affected segments. A
+suffix remains in its original segment whenever that produces the same
+canonical text; otherwise it moves beside the replacement to avoid introducing
+an artificial space before punctuation or a word continuation. This keeps
+unrelated timing boundaries available to later diarization, at the cost of
+assigning replacement text that spans boundaries to the first affected
+segment's time range. The stage reports only rule and replacement counts in its
+payload; transcript and rule content are not copied into diagnostics.
 
 `StageId::Punctuation` remains reserved and has no registered processor yet.
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -25,7 +25,7 @@ flowchart LR
     subgraph Sidecar ["Native sidecar (Rust)"]
         VAD["VAD · speech boundaries"]
         INF["Inference · engine registry"]
-        STAGE["Post-engine stages<br/>(hallucination filter)"]
+        STAGE["Post-engine stages<br/>(hallucination filter + personal corrections)"]
         DIA["Diarization<br/>(optional)"]
         VAD --> INF --> STAGE --> DIA
     end
@@ -339,7 +339,7 @@ utterance duration. A panicking stage is caught and recorded as
 (`Ok` / `Skipped` / `Failed` with revision and payload), and the full history
 ships in `transcript_ready.stageResults[]`.
 
-**Registered today:** the **hallucination filter** — a conservative filter that
+**Registered first:** the **hallucination filter** — a conservative filter that
 drops whole hallucinated segments while preserving timing. Hard text artifacts
 (empty text, punctuation-only output, known non-speech tags, caption/source
 attributions) can drop on text alone; soft artifacts (courtesy endings, CTAs,
@@ -348,8 +348,14 @@ combines Whisper/Cohere decoder diagnostics with per-segment voiced fraction and
 utterance-level VAD evidence. If nothing is dropped it records
 `Skipped { reason: "no_hallucinations" }`.
 
-`StageId::Punctuation` and `StageId::UserRules` exist as reserved identifiers but
-have no registered processor yet.
+Final transcripts then pass through **personal corrections** when the session
+has enabled rules. Rules are literal, ordered, and independently configure case
+and whole-word matching. Each rule consumes the prior rule's output, so ordering
+is explicit. The stage preserves segment timing and reports only rule and
+replacement counts in its payload; transcript and rule content are not copied
+into diagnostics.
+
+`StageId::Punctuation` remains reserved and has no registered processor yet.
 
 ---
 

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -864,6 +864,7 @@ dependencies = [
  "objc2-foundation",
  "ort",
  "realfft",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -21,6 +21,7 @@ ndarray = "0.17"
 half = { version = "2", optional = true, features = ["num-traits"] }
 ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "download-binaries", "copy-dylibs", "ndarray", "preload-dylibs", "tls-rustls"] }
 realfft = { version = "3.5" }
+regex = "1.12"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/native/src/app.rs
+++ b/native/src/app.rs
@@ -17,8 +17,9 @@ use crate::model_store::{
 };
 use crate::protocol::{
     AccelerationPreference, AudioFrame, Command, CompiledAdapterInfo, CompiledRuntimeInfo,
-    ContextWindow, Event, HealthStatus, ListeningMode, ModelInstallState, ModelProbeStatus,
-    QueueBackpressureTier, SelectedModel, SessionState, SessionStopReason, system_info_string,
+    ContextWindow, Event, HealthStatus, ListeningMode, MAX_USER_RULES, ModelInstallState,
+    ModelProbeStatus, QueueBackpressureTier, SelectedModel, SessionState, SessionStopReason,
+    system_info_string,
 };
 use crate::session::{
     FinalizedUtterance, ListeningSession, SessionAction, SessionBaseState, SessionConfig,
@@ -459,7 +460,27 @@ impl AppState {
                 session_start_unix_ms,
                 session_id,
                 speaking_style,
+                user_rules,
             } => {
+                let invalid_user_rules = if user_rules.len() > MAX_USER_RULES {
+                    Some(format!(
+                        "received {} correction rules; maximum is {MAX_USER_RULES}",
+                        user_rules.len()
+                    ))
+                } else {
+                    user_rules.iter().find_map(|rule| rule.validate().err())
+                };
+                if let Some(details) = invalid_user_rules {
+                    events.push(Event::Error {
+                        code: "invalid_user_rules".to_string(),
+                        details: Some(details),
+                        message: "Personal correction rules are invalid. Review them in Settings and try again."
+                            .to_string(),
+                        session_id: Some(session_id),
+                    });
+                    return (ControlFlow::Continue, events);
+                }
+
                 if self.active_sessions.len() >= MAX_ACTIVE_SESSIONS {
                     events.push(Event::Error {
                         code: "session_capacity_exceeded".to_string(),
@@ -544,6 +565,7 @@ impl AppState {
                                 session_start_unix_ms,
                                 session_id: session_id.clone(),
                                 stage_enablement: StageEnablement::default(),
+                                user_rules,
                             }))
                             .is_err()
                         {
@@ -1659,6 +1681,7 @@ mod tests {
         AccelerationPreference, AudioFrame, Command, ContextWindow, ContextWindowSource, Event,
         HealthStatus, ListeningMode, ModelProbeStatus, PCM_BYTES_PER_FRAME, QueueBackpressureTier,
         SelectedModel, SessionState, SessionStopReason, StageId, StageOutcome, StageStatus,
+        UserRule,
     };
     use crate::session::{FinalizedUtterance, ListeningSession, SessionInitError, SpeakingStyle};
     use crate::system_audio::{AudioFrameSink, SystemAudioCapture, SystemAudioError};
@@ -2337,6 +2360,32 @@ mod tests {
             }
             other => panic!("expected invalid ModelProbeResult, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn start_session_rejects_invalid_user_rules_before_allocating_a_session() {
+        let model_file_path = create_model_file();
+        let mut command = start_session_command("session-invalid-rules", &model_file_path);
+        let Command::StartSession { user_rules, .. } = &mut command else {
+            panic!("expected start session command");
+        };
+        user_rules.push(UserRule {
+            case_sensitive: false,
+            replacement: "replacement".to_string(),
+            source: "   ".to_string(),
+            whole_word: true,
+        });
+        let mut app = test_app();
+
+        let (_, events) = app.handle_command(command);
+
+        assert!(matches!(
+            events.as_slice(),
+            [Event::Error { code, session_id, .. }]
+                if code == "invalid_user_rules"
+                    && session_id.as_deref() == Some("session-invalid-rules")
+        ));
+        assert!(!app.active_sessions.contains_key("session-invalid-rules"));
     }
 
     #[test]
@@ -3405,6 +3454,7 @@ mod tests {
             session_start_unix_ms: 1_700_000_000_000,
             session_id: session_id.to_string(),
             speaking_style: SpeakingStyle::Balanced,
+            user_rules: Vec::new(),
         }
     }
 

--- a/native/src/app.rs
+++ b/native/src/app.rs
@@ -17,9 +17,9 @@ use crate::model_store::{
 };
 use crate::protocol::{
     AccelerationPreference, AudioFrame, Command, CompiledAdapterInfo, CompiledRuntimeInfo,
-    ContextWindow, Event, HealthStatus, ListeningMode, MAX_USER_RULES, ModelInstallState,
-    ModelProbeStatus, QueueBackpressureTier, SelectedModel, SessionState, SessionStopReason,
-    system_info_string,
+    ContextWindow, Event, HealthStatus, ListeningMode, ModelInstallState, ModelProbeStatus,
+    QueueBackpressureTier, SelectedModel, SessionState, SessionStopReason, system_info_string,
+    validate_user_rules,
 };
 use crate::session::{
     FinalizedUtterance, ListeningSession, SessionAction, SessionBaseState, SessionConfig,
@@ -462,15 +462,7 @@ impl AppState {
                 speaking_style,
                 user_rules,
             } => {
-                let invalid_user_rules = if user_rules.len() > MAX_USER_RULES {
-                    Some(format!(
-                        "received {} correction rules; maximum is {MAX_USER_RULES}",
-                        user_rules.len()
-                    ))
-                } else {
-                    user_rules.iter().find_map(|rule| rule.validate().err())
-                };
-                if let Some(details) = invalid_user_rules {
+                if let Err(details) = validate_user_rules(&user_rules) {
                     events.push(Event::Error {
                         code: "invalid_user_rules".to_string(),
                         details: Some(details),

--- a/native/src/protocol.rs
+++ b/native/src/protocol.rs
@@ -182,6 +182,41 @@ pub enum StageId {
     UserRules,
 }
 
+pub const MAX_USER_RULES: usize = 100;
+pub const MAX_USER_RULE_SOURCE_CHARS: usize = 120;
+pub const MAX_USER_RULE_REPLACEMENT_CHARS: usize = 300;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UserRule {
+    pub case_sensitive: bool,
+    pub replacement: String,
+    pub source: String,
+    pub whole_word: bool,
+}
+
+impl UserRule {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.source.trim().is_empty() {
+            return Err("correction rule source must not be blank".to_string());
+        }
+        if self.source.chars().count() > MAX_USER_RULE_SOURCE_CHARS {
+            return Err(format!(
+                "correction rule source exceeds {MAX_USER_RULE_SOURCE_CHARS} characters"
+            ));
+        }
+        if self.replacement.chars().count() > MAX_USER_RULE_REPLACEMENT_CHARS {
+            return Err(format!(
+                "correction rule replacement exceeds {MAX_USER_RULE_REPLACEMENT_CHARS} characters"
+            ));
+        }
+        if self.source == self.replacement {
+            return Err("correction rule source and replacement must differ".to_string());
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum StageStatus {
@@ -283,6 +318,8 @@ pub enum Command {
         session_id: String,
         #[serde(default)]
         speaking_style: SpeakingStyle,
+        #[serde(default)]
+        user_rules: Vec<UserRule>,
     },
     ContextResponse {
         correlation_id: Uuid,
@@ -629,8 +666,8 @@ mod tests {
         AUDIO_FRAME_KIND, AccelerationPreference, AudioFrame, Command, Event, EventEnvelope,
         FRAME_HEADER_LENGTH, IncomingFrame, JSON_FRAME_KIND, ListeningMode, MAX_FRAME_PAYLOAD,
         ModelInstallState, ModelProbeStatus, PCM_BYTES_PER_FRAME, QueueBackpressureTier,
-        SelectedModel, SessionStopReason, SpeakingStyle, encode_audio_frame_envelope, read_frame,
-        write_event_frame, write_frame,
+        SelectedModel, SessionStopReason, SpeakingStyle, UserRule, encode_audio_frame_envelope,
+        read_frame, write_event_frame, write_frame,
     };
     use crate::engine::capabilities::{ModelFamilyId, RuntimeId};
     use uuid::Uuid;
@@ -676,7 +713,51 @@ mod tests {
                 session_start_unix_ms: 1_700_000_000_000,
                 session_id: "session-1".to_string(),
                 speaking_style: SpeakingStyle::Balanced,
+                user_rules: Vec::new(),
             })
+        );
+    }
+
+    #[test]
+    fn start_session_round_trip_preserves_user_rules() {
+        let payload = serde_json::to_vec(&serde_json::json!({
+            "type": "start_session",
+            "sessionId": "session-rules",
+            "mode": "always_on",
+            "modelSelection": {
+                "kind": "external_file",
+                "runtimeId": "whisper_cpp",
+                "familyId": "whisper",
+                "filePath": "/tmp/model.bin"
+            },
+            "language": "en",
+            "sessionStartUnixMs": 1_700_000_000_000_u64,
+            "userRules": [{
+                "caseSensitive": false,
+                "replacement": "Kubernetes",
+                "source": "kuber netes",
+                "wholeWord": true
+            }]
+        }))
+        .expect("payload should serialize");
+        let mut framed = Vec::new();
+        write_frame(&mut framed, JSON_FRAME_KIND, &payload).expect("frame should write");
+
+        let parsed = read_frame(&mut framed.as_slice())
+            .expect("frame should parse")
+            .expect("frame should exist");
+        let IncomingFrame::Command(Command::StartSession { user_rules, .. }) = parsed else {
+            panic!("expected start session");
+        };
+
+        assert_eq!(
+            user_rules,
+            vec![UserRule {
+                case_sensitive: false,
+                replacement: "Kubernetes".to_string(),
+                source: "kuber netes".to_string(),
+                whole_word: true,
+            }]
         );
     }
 

--- a/native/src/protocol.rs
+++ b/native/src/protocol.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::io::{ErrorKind, Read, Write};
 
 use anyhow::{Context, Result, anyhow, bail, ensure};
@@ -200,6 +201,14 @@ impl UserRule {
         if self.source.trim().is_empty() {
             return Err("correction rule source must not be blank".to_string());
         }
+        if self.source != self.source.trim() {
+            return Err("correction rule source must not begin or end with whitespace".to_string());
+        }
+        if self.replacement != self.replacement.trim() {
+            return Err(
+                "correction rule replacement must not begin or end with whitespace".to_string(),
+            );
+        }
         if self.source.chars().count() > MAX_USER_RULE_SOURCE_CHARS {
             return Err(format!(
                 "correction rule source exceeds {MAX_USER_RULE_SOURCE_CHARS} characters"
@@ -215,6 +224,30 @@ impl UserRule {
         }
         Ok(())
     }
+}
+
+pub fn validate_user_rules(rules: &[UserRule]) -> Result<(), String> {
+    if rules.len() > MAX_USER_RULES {
+        return Err(format!(
+            "received {} correction rules; maximum is {MAX_USER_RULES}",
+            rules.len()
+        ));
+    }
+
+    let mut matchers = HashSet::with_capacity(rules.len());
+    for rule in rules {
+        rule.validate()?;
+        let source = if rule.case_sensitive {
+            rule.source.clone()
+        } else {
+            rule.source.to_lowercase()
+        };
+        if !matchers.insert((source, rule.case_sensitive, rule.whole_word)) {
+            return Err("correction rules contain duplicate matching semantics".to_string());
+        }
+    }
+
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -667,7 +700,7 @@ mod tests {
         FRAME_HEADER_LENGTH, IncomingFrame, JSON_FRAME_KIND, ListeningMode, MAX_FRAME_PAYLOAD,
         ModelInstallState, ModelProbeStatus, PCM_BYTES_PER_FRAME, QueueBackpressureTier,
         SelectedModel, SessionStopReason, SpeakingStyle, UserRule, encode_audio_frame_envelope,
-        read_frame, write_event_frame, write_frame,
+        read_frame, validate_user_rules, write_event_frame, write_frame,
     };
     use crate::engine::capabilities::{ModelFamilyId, RuntimeId};
     use uuid::Uuid;
@@ -758,6 +791,29 @@ mod tests {
                 source: "kuber netes".to_string(),
                 whole_word: true,
             }]
+        );
+    }
+
+    #[test]
+    fn user_rule_validation_rejects_duplicate_matchers() {
+        let rules = [
+            UserRule {
+                case_sensitive: false,
+                replacement: "Kubernetes".to_string(),
+                source: "kuber netes".to_string(),
+                whole_word: true,
+            },
+            UserRule {
+                case_sensitive: false,
+                replacement: "K8s".to_string(),
+                source: "KUBER NETES".to_string(),
+                whole_word: true,
+            },
+        ];
+
+        assert_eq!(
+            validate_user_rules(&rules),
+            Err("correction rules contain duplicate matching semantics".to_string())
         );
     }
 

--- a/native/src/stages/mod.rs
+++ b/native/src/stages/mod.rs
@@ -4,10 +4,11 @@ use std::time::Instant;
 use crate::audio_metadata::VoiceActivityEvidence;
 use crate::engine::capabilities::ModelFamilyCapabilities;
 use crate::panic_util::format_panic_message;
-use crate::protocol::{StageId, StageOutcome, StageStatus, TranscriptSegment};
+use crate::protocol::{StageId, StageOutcome, StageStatus, TranscriptSegment, UserRule};
 use crate::transcription::{SegmentDiagnostics, Transcript};
 
 mod hallucination_filter;
+mod user_rules;
 
 /// Boolean opt-out for stages that always have a runtime config to consume.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -67,8 +68,13 @@ pub trait StageProcessor: Send + Sync {
 
 /// Build the registered post-engine processor chain in canonical order. The
 /// engine stage outcome is appended separately by `assemble_transcript`.
-pub fn post_engine_processors() -> Vec<Box<dyn StageProcessor>> {
-    vec![Box::new(hallucination_filter::HallucinationFilterStage)]
+pub fn post_engine_processors(user_rules: &[UserRule]) -> Vec<Box<dyn StageProcessor>> {
+    let mut processors: Vec<Box<dyn StageProcessor>> =
+        vec![Box::new(hallucination_filter::HallucinationFilterStage)];
+    if !user_rules.is_empty() {
+        processors.push(Box::new(user_rules::UserRulesStage::new(user_rules)));
+    }
+    processors
 }
 
 pub fn run_post_engine(
@@ -320,6 +326,27 @@ mod tests {
         fn process(&self, _transcript: &Transcript, _ctx: &StageContext<'_>) -> StageProcess {
             panic!("synthetic stage panic");
         }
+    }
+
+    #[test]
+    fn canonical_chain_places_user_rules_after_hallucination_filter() {
+        let rules = [UserRule {
+            case_sensitive: false,
+            replacement: "Kubernetes".to_string(),
+            source: "kuber netes".to_string(),
+            whole_word: true,
+        }];
+
+        let stage_ids: Vec<StageId> = post_engine_processors(&rules)
+            .iter()
+            .map(|processor| processor.id())
+            .collect();
+
+        assert_eq!(
+            stage_ids,
+            vec![StageId::HallucinationFilter, StageId::UserRules]
+        );
+        assert_eq!(post_engine_processors(&[]).len(), 1);
     }
 
     fn run(transcript: &mut Transcript, processors: Vec<Box<dyn StageProcessor>>) {

--- a/native/src/stages/user_rules.rs
+++ b/native/src/stages/user_rules.rs
@@ -2,9 +2,9 @@ use std::collections::HashSet;
 
 use regex::{Regex, RegexBuilder};
 
-use crate::protocol::{StageId, UserRule};
+use crate::protocol::{StageId, TranscriptSegment, UserRule};
 use crate::stages::{StageContext, StageProcess, StageProcessor};
-use crate::transcription::Transcript;
+use crate::transcription::{Transcript, join_segment_text};
 
 struct CompiledRule {
     matcher: Regex,
@@ -37,28 +37,202 @@ impl CompiledRule {
         }
     }
 
-    fn apply(&self, input: &str) -> (String, usize) {
-        let mut output = String::with_capacity(input.len());
-        let mut copied_until = 0;
-        let mut replacement_count = 0;
+    fn apply(&self, segments: &mut [TranscriptSegment]) -> Result<usize, String> {
+        let view = CanonicalSegmentView::new(segments);
+        let matches: Vec<MappedMatch> = self
+            .matcher
+            .find_iter(&view.text)
+            .filter(|matched| {
+                !self.whole_word || has_word_boundaries(&view.text, matched.start(), matched.end())
+            })
+            .map(|matched| {
+                Ok(MappedMatch {
+                    end: view.end_location(matched.end()).ok_or_else(|| {
+                        "correction match end could not be mapped to a segment".to_string()
+                    })?,
+                    range_end: matched.end(),
+                    range_start: matched.start(),
+                    start: view.start_location(matched.start()).ok_or_else(|| {
+                        "correction match start could not be mapped to a segment".to_string()
+                    })?,
+                })
+            })
+            .collect::<Result<_, String>>()?;
 
-        for matched in self.matcher.find_iter(input) {
-            if self.whole_word && !has_word_boundaries(input, matched.start(), matched.end()) {
+        if matches.is_empty() {
+            return Ok(0);
+        }
+
+        let mut expected = view.text;
+        for matched in matches.iter().rev() {
+            expected.replace_range(matched.range_start..matched.range_end, &self.replacement);
+            apply_mapped_replacement(segments, *matched, &self.replacement);
+        }
+
+        if join_segment_text(segments) != expected.trim() {
+            return Err(
+                "correction result could not be mapped without changing segment timing".to_string(),
+            );
+        }
+
+        Ok(matches.len())
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SegmentLocation {
+    byte_offset: usize,
+    segment_index: usize,
+}
+
+#[derive(Clone, Copy)]
+struct MappedMatch {
+    end: SegmentLocation,
+    range_end: usize,
+    range_start: usize,
+    start: SegmentLocation,
+}
+
+struct CanonicalSegment {
+    canonical_end: usize,
+    canonical_start: usize,
+    segment_index: usize,
+    source_end: usize,
+    source_start: usize,
+}
+
+struct CanonicalSegmentView {
+    segments: Vec<CanonicalSegment>,
+    text: String,
+}
+
+impl CanonicalSegmentView {
+    fn new(segments: &[TranscriptSegment]) -> Self {
+        let mut text = String::new();
+        let mut mapped_segments = Vec::with_capacity(segments.len());
+
+        for (segment_index, segment) in segments.iter().enumerate() {
+            let trimmed = segment.text.trim();
+            if trimmed.is_empty() {
                 continue;
             }
-            output.push_str(&input[copied_until..matched.start()]);
-            output.push_str(&self.replacement);
-            copied_until = matched.end();
-            replacement_count += 1;
+            if !mapped_segments.is_empty() {
+                text.push(' ');
+            }
+
+            let source_start = segment
+                .text
+                .find(trimmed)
+                .expect("trimmed segment text must be a substring");
+            let canonical_start = text.len();
+            text.push_str(trimmed);
+            mapped_segments.push(CanonicalSegment {
+                canonical_end: text.len(),
+                canonical_start,
+                segment_index,
+                source_end: source_start + trimmed.len(),
+                source_start,
+            });
         }
 
-        if replacement_count == 0 {
-            return (input.to_string(), 0);
+        Self {
+            segments: mapped_segments,
+            text,
         }
-
-        output.push_str(&input[copied_until..]);
-        (output, replacement_count)
     }
+
+    fn start_location(&self, offset: usize) -> Option<SegmentLocation> {
+        for (index, segment) in self.segments.iter().enumerate() {
+            if (segment.canonical_start..segment.canonical_end).contains(&offset) {
+                return Some(SegmentLocation {
+                    byte_offset: segment.source_start + offset - segment.canonical_start,
+                    segment_index: segment.segment_index,
+                });
+            }
+
+            let next = self.segments.get(index + 1);
+            if offset == segment.canonical_end
+                && next.is_some_and(|next| offset < next.canonical_start)
+            {
+                return Some(SegmentLocation {
+                    byte_offset: segment.source_end,
+                    segment_index: segment.segment_index,
+                });
+            }
+        }
+        None
+    }
+
+    fn end_location(&self, offset: usize) -> Option<SegmentLocation> {
+        for segment in &self.segments {
+            if offset == segment.canonical_start {
+                return Some(SegmentLocation {
+                    byte_offset: segment.source_start,
+                    segment_index: segment.segment_index,
+                });
+            }
+            if offset > segment.canonical_start && offset <= segment.canonical_end {
+                return Some(SegmentLocation {
+                    byte_offset: segment.source_start + offset - segment.canonical_start,
+                    segment_index: segment.segment_index,
+                });
+            }
+        }
+        None
+    }
+}
+
+fn apply_mapped_replacement(
+    segments: &mut [TranscriptSegment],
+    matched: MappedMatch,
+    replacement: &str,
+) {
+    let first_index = matched.start.segment_index;
+    let last_index = matched.end.segment_index;
+
+    if first_index == last_index {
+        let text = &segments[first_index].text;
+        let mut output = String::with_capacity(
+            text.len() + replacement.len() - (matched.end.byte_offset - matched.start.byte_offset),
+        );
+        output.push_str(&text[..matched.start.byte_offset]);
+        output.push_str(replacement);
+        output.push_str(&text[matched.end.byte_offset..]);
+        segments[first_index].text = output;
+        return;
+    }
+
+    let prefix = segments[first_index].text[..matched.start.byte_offset].to_string();
+    let suffix = segments[last_index].text[matched.end.byte_offset..].to_string();
+    let mut first_text = String::with_capacity(prefix.len() + replacement.len() + suffix.len());
+    first_text.push_str(&prefix);
+    first_text.push_str(replacement);
+
+    if split_preserves_canonical_text(&first_text, &suffix) {
+        segments[first_index].text = first_text;
+        for segment in &mut segments[first_index + 1..last_index] {
+            segment.text.clear();
+        }
+        segments[last_index].text = suffix;
+        return;
+    }
+
+    first_text.push_str(&suffix);
+    segments[first_index].text = first_text;
+    for segment in &mut segments[first_index + 1..=last_index] {
+        segment.text.clear();
+    }
+}
+
+fn split_preserves_canonical_text(left: &str, right: &str) -> bool {
+    let direct = format!("{left}{right}");
+    let joined = match (left.trim().is_empty(), right.trim().is_empty()) {
+        (true, true) => String::new(),
+        (true, false) => right.trim().to_string(),
+        (false, true) => left.trim().to_string(),
+        (false, false) => format!("{} {}", left.trim(), right.trim()),
+    };
+    joined == direct.trim()
 }
 
 impl StageProcessor for UserRulesStage {
@@ -71,14 +245,31 @@ impl StageProcessor for UserRulesStage {
         let mut replacement_count = 0;
         let mut applied_rule_indices = HashSet::new();
 
-        for segment in &mut segments {
-            for (index, rule) in self.rules.iter().enumerate() {
-                let (text, count) = rule.apply(&segment.text);
-                if count > 0 {
-                    segment.text = text;
-                    replacement_count += count;
-                    applied_rule_indices.insert(index);
+        for (index, rule) in self.rules.iter().enumerate() {
+            let mut group_start = 0;
+            while group_start < segments.len() {
+                let speaker = segments[group_start].speaker;
+                let group_end = segments[group_start + 1..]
+                    .iter()
+                    .position(|segment| segment.speaker != speaker)
+                    .map_or(segments.len(), |offset| group_start + 1 + offset);
+                match rule.apply(&mut segments[group_start..group_end]) {
+                    Ok(count) if count > 0 => {
+                        replacement_count += count;
+                        applied_rule_indices.insert(index);
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        return StageProcess::Failed {
+                            error,
+                            payload: Some(serde_json::json!({
+                                "configuredRuleCount": self.rules.len(),
+                                "replacementCount": replacement_count,
+                            })),
+                        };
+                    }
                 }
+                group_start = group_end;
             }
         }
 
@@ -121,9 +312,42 @@ mod tests {
     use super::*;
     use crate::audio_metadata::VoiceActivityEvidence;
     use crate::engine::capabilities::{LanguageSupport, ModelFamilyCapabilities};
-    use crate::protocol::{TimestampGranularity, TimestampSource, TranscriptSegment};
+    use crate::protocol::{TimestampGranularity, TimestampSource};
     use crate::stages::StageEnablement;
+    use serde::Deserialize;
     use uuid::Uuid;
+
+    #[derive(Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct GoldenRule {
+        case_sensitive: bool,
+        enabled: bool,
+        id: String,
+        replacement: String,
+        source: String,
+        whole_word: bool,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct GoldenSegment {
+        end_ms: u64,
+        speaker: Option<u32>,
+        start_ms: u64,
+        text: String,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct GoldenCase {
+        draft: GoldenRule,
+        existing_rules: Vec<GoldenRule>,
+        expected_segment_texts: Vec<String>,
+        expected_text: String,
+        input_segments: Vec<GoldenSegment>,
+        is_new: bool,
+        name: String,
+    }
 
     fn rule(source: &str, replacement: &str) -> UserRule {
         UserRule {
@@ -146,6 +370,53 @@ mod tests {
                     speaker: None,
                     start_ms: index as u64 * 1_000,
                     text: (*text).to_string(),
+                    timestamp_granularity: TimestampGranularity::Segment,
+                    timestamp_source: TimestampSource::Engine,
+                })
+                .collect(),
+            stage_history: Vec::new(),
+        }
+    }
+
+    fn golden_cases() -> Vec<GoldenCase> {
+        serde_json::from_str(include_str!(
+            "../../../test/fixtures/personal-corrections-golden.json"
+        ))
+        .expect("personal correction golden cases should parse")
+    }
+
+    fn active_golden_rules(case: &GoldenCase) -> Vec<UserRule> {
+        let mut configured = case.existing_rules.clone();
+        if case.is_new {
+            configured.push(case.draft.clone());
+        } else if let Some(index) = configured.iter().position(|rule| rule.id == case.draft.id) {
+            configured[index] = case.draft.clone();
+        }
+
+        configured
+            .into_iter()
+            .filter(|rule| rule.enabled)
+            .map(|rule| UserRule {
+                case_sensitive: rule.case_sensitive,
+                replacement: rule.replacement,
+                source: rule.source,
+                whole_word: rule.whole_word,
+            })
+            .collect()
+    }
+
+    fn golden_transcript(case: &GoldenCase) -> Transcript {
+        Transcript {
+            utterance_id: Uuid::nil(),
+            revision: 0,
+            segments: case
+                .input_segments
+                .iter()
+                .map(|segment| TranscriptSegment {
+                    end_ms: segment.end_ms,
+                    speaker: segment.speaker,
+                    start_ms: segment.start_ms,
+                    text: segment.text.clone(),
                     timestamp_granularity: TimestampGranularity::Segment,
                     timestamp_source: TimestampSource::Engine,
                 })
@@ -216,6 +487,107 @@ mod tests {
         assert_eq!(segments[0].start_ms, 0);
         assert_eq!(segments[1].end_ms, 2_000);
         assert_eq!(payload.unwrap()["replacementCount"], 3);
+    }
+
+    #[test]
+    fn shared_golden_cases_match_preview_semantics_without_changing_segment_records() {
+        for case in golden_cases() {
+            let input = golden_transcript(&case);
+            let original_timing: Vec<_> = input
+                .segments
+                .iter()
+                .map(|segment| (segment.start_ms, segment.end_ms, segment.speaker))
+                .collect();
+            let stage = UserRulesStage::new(&active_golden_rules(&case));
+
+            let segments = match stage.process(&input, &context()) {
+                StageProcess::Ok { segments, .. } => segments,
+                StageProcess::Skipped { .. } => input.segments.clone(),
+                StageProcess::Failed { error, .. } => {
+                    panic!("golden case '{}' failed: {error}", case.name)
+                }
+            };
+
+            assert_eq!(
+                join_segment_text(&segments),
+                case.expected_text,
+                "golden case '{}' text",
+                case.name
+            );
+            assert_eq!(
+                segments
+                    .iter()
+                    .map(|segment| segment.text.clone())
+                    .collect::<Vec<_>>(),
+                case.expected_segment_texts,
+                "golden case '{}' segment allocation",
+                case.name
+            );
+            assert_eq!(
+                segments
+                    .iter()
+                    .map(|segment| (segment.start_ms, segment.end_ms, segment.speaker))
+                    .collect::<Vec<_>>(),
+                original_timing,
+                "golden case '{}' timing and speakers",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn does_not_match_across_speaker_boundaries() {
+        let stage = UserRulesStage::new(&[rule("New York", "NYC")]);
+        let mut input = transcript(&["New", "York"]);
+        input.segments[0].speaker = Some(0);
+        input.segments[1].speaker = Some(1);
+
+        let StageProcess::Skipped { reason, .. } = stage.process(&input, &context()) else {
+            panic!("expected speaker boundary to prevent a match");
+        };
+
+        assert_eq!(reason, "no_match");
+        assert_eq!(input.joined_text(), "New York");
+    }
+
+    #[test]
+    fn cross_segment_match_keeps_unrelated_records_for_later_diarization() {
+        let stage = UserRulesStage::new(&[rule("New York", "NYC")]);
+        let input = transcript(&["New", "York,", "then Albany"]);
+        let original_timing: Vec<_> = input
+            .segments
+            .iter()
+            .map(|segment| (segment.start_ms, segment.end_ms))
+            .collect();
+
+        let StageProcess::Ok { segments, .. } = stage.process(&input, &context()) else {
+            panic!("expected cross-segment replacement");
+        };
+
+        assert_eq!(join_segment_text(&segments), "NYC, then Albany");
+        assert_eq!(segments.len(), 3);
+        assert_eq!(segments[2].text, "then Albany");
+        assert_eq!(
+            segments
+                .iter()
+                .map(|segment| (segment.start_ms, segment.end_ms))
+                .collect::<Vec<_>>(),
+            original_timing
+        );
+    }
+
+    #[test]
+    fn applies_multiple_matches_right_to_left_across_segment_boundaries() {
+        let stage = UserRulesStage::new(&[rule("New York", "NYC")]);
+        let input = transcript(&["New York", "and New", "York."]);
+
+        let StageProcess::Ok { segments, payload } = stage.process(&input, &context()) else {
+            panic!("expected replacements");
+        };
+
+        assert_eq!(join_segment_text(&segments), "NYC and NYC.");
+        assert_eq!(segments.len(), input.segments.len());
+        assert_eq!(payload.unwrap()["replacementCount"], 2);
     }
 
     #[test]

--- a/native/src/stages/user_rules.rs
+++ b/native/src/stages/user_rules.rs
@@ -1,0 +1,251 @@
+use std::collections::HashSet;
+
+use regex::{Regex, RegexBuilder};
+
+use crate::protocol::{StageId, UserRule};
+use crate::stages::{StageContext, StageProcess, StageProcessor};
+use crate::transcription::Transcript;
+
+struct CompiledRule {
+    matcher: Regex,
+    replacement: String,
+    whole_word: bool,
+}
+
+pub struct UserRulesStage {
+    rules: Vec<CompiledRule>,
+}
+
+impl UserRulesStage {
+    pub fn new(rules: &[UserRule]) -> Self {
+        Self {
+            rules: rules.iter().map(CompiledRule::new).collect(),
+        }
+    }
+}
+
+impl CompiledRule {
+    fn new(rule: &UserRule) -> Self {
+        let matcher = RegexBuilder::new(&regex::escape(&rule.source))
+            .case_insensitive(!rule.case_sensitive)
+            .build()
+            .expect("escaped literal correction rules always compile");
+        Self {
+            matcher,
+            replacement: rule.replacement.clone(),
+            whole_word: rule.whole_word,
+        }
+    }
+
+    fn apply(&self, input: &str) -> (String, usize) {
+        let mut output = String::with_capacity(input.len());
+        let mut copied_until = 0;
+        let mut replacement_count = 0;
+
+        for matched in self.matcher.find_iter(input) {
+            if self.whole_word && !has_word_boundaries(input, matched.start(), matched.end()) {
+                continue;
+            }
+            output.push_str(&input[copied_until..matched.start()]);
+            output.push_str(&self.replacement);
+            copied_until = matched.end();
+            replacement_count += 1;
+        }
+
+        if replacement_count == 0 {
+            return (input.to_string(), 0);
+        }
+
+        output.push_str(&input[copied_until..]);
+        (output, replacement_count)
+    }
+}
+
+impl StageProcessor for UserRulesStage {
+    fn id(&self) -> StageId {
+        StageId::UserRules
+    }
+
+    fn process(&self, transcript: &Transcript, _ctx: &StageContext<'_>) -> StageProcess {
+        let mut segments = transcript.segments.clone();
+        let mut replacement_count = 0;
+        let mut applied_rule_indices = HashSet::new();
+
+        for segment in &mut segments {
+            for (index, rule) in self.rules.iter().enumerate() {
+                let (text, count) = rule.apply(&segment.text);
+                if count > 0 {
+                    segment.text = text;
+                    replacement_count += count;
+                    applied_rule_indices.insert(index);
+                }
+            }
+        }
+
+        if replacement_count == 0 {
+            return StageProcess::Skipped {
+                reason: "no_match".to_string(),
+                payload: Some(serde_json::json!({
+                    "configuredRuleCount": self.rules.len(),
+                    "replacementCount": 0,
+                })),
+            };
+        }
+
+        StageProcess::Ok {
+            segments,
+            payload: Some(serde_json::json!({
+                "appliedRuleCount": applied_rule_indices.len(),
+                "configuredRuleCount": self.rules.len(),
+                "replacementCount": replacement_count,
+            })),
+        }
+    }
+}
+
+fn has_word_boundaries(input: &str, start: usize, end: usize) -> bool {
+    let before_is_word = input[..start]
+        .chars()
+        .next_back()
+        .is_some_and(is_word_character);
+    let after_is_word = input[end..].chars().next().is_some_and(is_word_character);
+    !before_is_word && !after_is_word
+}
+
+fn is_word_character(character: char) -> bool {
+    character.is_alphanumeric() || character == '_'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio_metadata::VoiceActivityEvidence;
+    use crate::engine::capabilities::{LanguageSupport, ModelFamilyCapabilities};
+    use crate::protocol::{TimestampGranularity, TimestampSource, TranscriptSegment};
+    use crate::stages::StageEnablement;
+    use uuid::Uuid;
+
+    fn rule(source: &str, replacement: &str) -> UserRule {
+        UserRule {
+            case_sensitive: false,
+            replacement: replacement.to_string(),
+            source: source.to_string(),
+            whole_word: true,
+        }
+    }
+
+    fn transcript(parts: &[&str]) -> Transcript {
+        Transcript {
+            utterance_id: Uuid::nil(),
+            revision: 0,
+            segments: parts
+                .iter()
+                .enumerate()
+                .map(|(index, text)| TranscriptSegment {
+                    end_ms: (index as u64 + 1) * 1_000,
+                    speaker: None,
+                    start_ms: index as u64 * 1_000,
+                    text: (*text).to_string(),
+                    timestamp_granularity: TimestampGranularity::Segment,
+                    timestamp_source: TimestampSource::Engine,
+                })
+                .collect(),
+            stage_history: Vec::new(),
+        }
+    }
+
+    fn context() -> StageContext<'static> {
+        static CAPS: ModelFamilyCapabilities = ModelFamilyCapabilities {
+            supports_segment_timestamps: true,
+            supports_word_timestamps: false,
+            supports_initial_prompt: true,
+            supports_streaming: false,
+            supports_language_selection: false,
+            supported_languages: LanguageSupport::EnglishOnly,
+            max_audio_duration_secs: None,
+            produces_punctuation: true,
+        };
+        static ENABLEMENT: StageEnablement = StageEnablement {
+            hallucination_filter: true,
+        };
+        static VOICE_ACTIVITY: VoiceActivityEvidence = VoiceActivityEvidence {
+            audio_start_ms: 0,
+            audio_end_ms: 2_000,
+            speech_start_ms: 0,
+            speech_end_ms: 2_000,
+            voiced_ms: 2_000,
+            unvoiced_ms: 0,
+            mean_probability: 1.0,
+            max_probability: 1.0,
+        };
+        let runtime = Box::leak(Box::new(
+            tokio::runtime::Builder::new_current_thread()
+                .build()
+                .expect("runtime"),
+        ));
+        let (_, cancel_rx) = tokio::sync::watch::channel(false);
+        let cancel_rx = Box::leak(Box::new(cancel_rx));
+        StageContext {
+            cancel_rx,
+            context: None,
+            family_capabilities: &CAPS,
+            is_final: true,
+            pause_ms_before_utterance: None,
+            segment_diagnostics: &[],
+            stage_enabled: &ENABLEMENT,
+            tokio_runtime: runtime,
+            vad_probabilities: &[],
+            voice_activity: &VOICE_ACTIVITY,
+        }
+    }
+
+    #[test]
+    fn applies_ordered_literal_rules_across_segments_without_moving_boundaries() {
+        let stage = UserRulesStage::new(&[
+            rule("kuber netes", "Kubernetes"),
+            rule("Kubernetes cluster", "K8s cluster"),
+        ]);
+        let input = transcript(&["Our kuber netes cluster", "and KUBER NETES service"]);
+
+        let StageProcess::Ok { segments, payload } = stage.process(&input, &context()) else {
+            panic!("expected replacements");
+        };
+
+        assert_eq!(segments[0].text, "Our K8s cluster");
+        assert_eq!(segments[1].text, "and Kubernetes service");
+        assert_eq!(segments[0].start_ms, 0);
+        assert_eq!(segments[1].end_ms, 2_000);
+        assert_eq!(payload.unwrap()["replacementCount"], 3);
+    }
+
+    #[test]
+    fn honors_case_and_unicode_word_boundaries() {
+        let mut exact = rule("obsidian", "Obsidian");
+        exact.case_sensitive = true;
+        let stage = UserRulesStage::new(&[exact, rule("cafe", "coffee")]);
+        let input = transcript(&["obsidian Obsidian obsidianite cafe café_cafe"]);
+
+        let StageProcess::Ok { segments, .. } = stage.process(&input, &context()) else {
+            panic!("expected replacements");
+        };
+
+        assert_eq!(
+            segments[0].text,
+            "Obsidian Obsidian obsidianite coffee café_cafe"
+        );
+    }
+
+    #[test]
+    fn reports_no_match_without_mutating_the_transcript() {
+        let stage = UserRulesStage::new(&[rule("alpha", "beta")]);
+        let input = transcript(&["gamma"]);
+
+        let StageProcess::Skipped { reason, payload } = stage.process(&input, &context()) else {
+            panic!("expected skip");
+        };
+
+        assert_eq!(reason, "no_match");
+        assert_eq!(payload.unwrap()["replacementCount"], 0);
+        assert_eq!(input.segments[0].text, "gamma");
+    }
+}

--- a/native/src/transcription.rs
+++ b/native/src/transcription.rs
@@ -60,14 +60,7 @@ impl Transcript {
     /// joins with single spaces. Idempotent with respect to leading/trailing
     /// whitespace inside any individual segment.
     pub fn joined_text(&self) -> String {
-        let mut pieces = Vec::with_capacity(self.segments.len());
-        for segment in &self.segments {
-            let trimmed = segment.text.trim();
-            if !trimmed.is_empty() {
-                pieces.push(trimmed);
-            }
-        }
-        pieces.join(" ")
+        join_segment_text(&self.segments)
     }
 
     /// The engine stage outcome is the canonical record of whether a revision
@@ -81,6 +74,17 @@ impl Transcript {
             .map(|stage| stage.is_final)
             .unwrap_or(false)
     }
+}
+
+pub fn join_segment_text(segments: &[TranscriptSegment]) -> String {
+    let mut pieces = Vec::with_capacity(segments.len());
+    for segment in segments {
+        let trimmed = segment.text.trim();
+        if !trimmed.is_empty() {
+            pieces.push(trimmed);
+        }
+    }
+    pieces.join(" ")
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/native/src/worker.rs
+++ b/native/src/worker.rs
@@ -19,6 +19,7 @@ use crate::engine::traits::{LoadedModel, StreamingModel};
 use crate::panic_util::format_panic_message;
 use crate::protocol::{
     ContextWindow, EngineStagePayload, StageId, StageOutcome, StageStatus, TranscriptSegment,
+    UserRule,
 };
 use crate::session::{FinalizedUtterance, LiveUtterance};
 use crate::stages::{
@@ -40,6 +41,7 @@ pub struct SessionMetadata {
     pub session_start_unix_ms: u64,
     pub session_id: String,
     pub stage_enablement: StageEnablement,
+    pub user_rules: Vec<UserRule>,
 }
 
 #[derive(Debug)]
@@ -293,13 +295,14 @@ fn worker_main(
                         } else {
                             None
                         };
+                        let processors = post_engine_processors(&metadata.user_rules);
                         sessions.insert(
                             metadata.session_id.clone(),
                             WorkerSession {
                                 metadata,
                                 family_capabilities: resources.family_capabilities,
                                 model: resources.model,
-                                processors: post_engine_processors(),
+                                processors,
                                 diarizer,
                                 warnings,
                             },
@@ -1050,6 +1053,7 @@ mod tests {
             session_start_unix_ms: 0,
             session_id: "streaming-test".to_string(),
             stage_enablement: StageEnablement::default(),
+            user_rules: Vec::new(),
         };
         let mut worker_session = WorkerSession {
             metadata,
@@ -1058,7 +1062,7 @@ mod tests {
                 model: Box::new(FixtureStreamingModel::default()),
                 utterance: None,
             },
-            processors: post_engine_processors(),
+            processors: post_engine_processors(&[]),
             diarizer: None,
             warnings: Vec::new(),
         };
@@ -1378,6 +1382,7 @@ mod tests {
             session_start_unix_ms: 0,
             session_id: session_id.to_string(),
             stage_enablement: StageEnablement::default(),
+            user_rules: Vec::new(),
         }
     }
 
@@ -1690,6 +1695,7 @@ mod tests {
                 session_start_unix_ms: 0,
                 session_id: "streaming-reconcile-test".to_string(),
                 stage_enablement: StageEnablement::default(),
+                user_rules: Vec::new(),
             },
             family_capabilities: streaming_caps(),
             model: SessionModel::Streaming {

--- a/native/tests/common/driver.rs
+++ b/native/tests/common/driver.rs
@@ -305,6 +305,7 @@ fn start_session_command(
         session_start_unix_ms: SESSION_START_UNIX_MS,
         session_id: session_id.to_string(),
         speaking_style: style,
+        user_rules: Vec::new(),
     }
 }
 

--- a/src/corrections/correction-rules.ts
+++ b/src/corrections/correction-rules.ts
@@ -34,6 +34,8 @@ export function readPersonalCorrectionRules(value: unknown): PersonalCorrectionR
       id.length > 100 ||
       seenIds.has(id) ||
       source.trim().length === 0 ||
+      source !== source.trim() ||
+      replacement !== replacement.trim() ||
       countCharacters(source) > MAX_CORRECTION_SOURCE_CHARS ||
       countCharacters(replacement) > MAX_CORRECTION_REPLACEMENT_CHARS ||
       source === replacement
@@ -70,12 +72,39 @@ export function toActiveUserRules(rules: readonly PersonalCorrectionRule[]): Use
     }));
 }
 
+export function mergePersonalCorrectionDraft(
+  rules: readonly PersonalCorrectionRule[],
+  draft: PersonalCorrectionRule,
+  isNew: boolean,
+): PersonalCorrectionRule[] {
+  if (isNew) return [...rules, { ...draft }];
+  return rules.map((rule) => (rule.id === draft.id ? { ...draft } : { ...rule }));
+}
+
+export function previewPersonalCorrectionDraft(
+  text: string,
+  rules: readonly PersonalCorrectionRule[],
+  draft: PersonalCorrectionRule,
+  isNew: boolean,
+): CorrectionPreview {
+  return previewPersonalCorrections(
+    text,
+    toActiveUserRules(mergePersonalCorrectionDraft(rules, draft, isNew)),
+  );
+}
+
 export function validatePersonalCorrectionRule(
   rule: PersonalCorrectionRule,
   existingRules: readonly PersonalCorrectionRule[],
 ): string | null {
   if (rule.source.trim().length === 0) {
     return 'Enter the text Local Dictation should replace.';
+  }
+  if (rule.source !== rule.source.trim()) {
+    return 'Text to replace cannot begin or end with whitespace.';
+  }
+  if (rule.replacement !== rule.replacement.trim()) {
+    return 'Replacement cannot begin or end with whitespace.';
   }
   if (countCharacters(rule.source) > MAX_CORRECTION_SOURCE_CHARS) {
     return `Text to replace must be ${MAX_CORRECTION_SOURCE_CHARS} characters or fewer.`;

--- a/src/corrections/correction-rules.ts
+++ b/src/corrections/correction-rules.ts
@@ -1,0 +1,174 @@
+import { isRecord } from '../shared/type-guards';
+import type { UserRule } from '../sidecar/protocol';
+
+export const MAX_PERSONAL_CORRECTION_RULES = 100;
+export const MAX_CORRECTION_SOURCE_CHARS = 120;
+export const MAX_CORRECTION_REPLACEMENT_CHARS = 300;
+
+export interface PersonalCorrectionRule extends UserRule {
+  enabled: boolean;
+  id: string;
+}
+
+export interface CorrectionPreview {
+  appliedRuleCount: number;
+  replacementCount: number;
+  text: string;
+}
+
+export function readPersonalCorrectionRules(value: unknown): PersonalCorrectionRule[] {
+  if (!Array.isArray(value)) return [];
+
+  const accepted: PersonalCorrectionRule[] = [];
+  const seenIds = new Set<string>();
+  const seenMatchers = new Set<string>();
+  for (const candidate of value) {
+    if (accepted.length >= MAX_PERSONAL_CORRECTION_RULES) break;
+    if (!isRecord(candidate)) continue;
+
+    const id = typeof candidate.id === 'string' ? candidate.id.trim() : '';
+    const source = typeof candidate.source === 'string' ? candidate.source : '';
+    const replacement = typeof candidate.replacement === 'string' ? candidate.replacement : '';
+    if (
+      id.length === 0 ||
+      id.length > 100 ||
+      seenIds.has(id) ||
+      source.trim().length === 0 ||
+      countCharacters(source) > MAX_CORRECTION_SOURCE_CHARS ||
+      countCharacters(replacement) > MAX_CORRECTION_REPLACEMENT_CHARS ||
+      source === replacement
+    ) {
+      continue;
+    }
+
+    const rule = {
+      caseSensitive: candidate.caseSensitive === true,
+      enabled: candidate.enabled !== false,
+      id,
+      replacement,
+      source,
+      wholeWord: candidate.wholeWord !== false,
+    };
+    const matcher = matcherSignature(rule);
+    if (seenMatchers.has(matcher)) continue;
+
+    accepted.push(rule);
+    seenIds.add(id);
+    seenMatchers.add(matcher);
+  }
+  return accepted;
+}
+
+export function toActiveUserRules(rules: readonly PersonalCorrectionRule[]): UserRule[] {
+  return rules
+    .filter((rule) => rule.enabled)
+    .map(({ caseSensitive, replacement, source, wholeWord }) => ({
+      caseSensitive,
+      replacement,
+      source,
+      wholeWord,
+    }));
+}
+
+export function validatePersonalCorrectionRule(
+  rule: PersonalCorrectionRule,
+  existingRules: readonly PersonalCorrectionRule[],
+): string | null {
+  if (rule.source.trim().length === 0) {
+    return 'Enter the text Local Dictation should replace.';
+  }
+  if (countCharacters(rule.source) > MAX_CORRECTION_SOURCE_CHARS) {
+    return `Text to replace must be ${MAX_CORRECTION_SOURCE_CHARS} characters or fewer.`;
+  }
+  if (countCharacters(rule.replacement) > MAX_CORRECTION_REPLACEMENT_CHARS) {
+    return `Replacement must be ${MAX_CORRECTION_REPLACEMENT_CHARS} characters or fewer.`;
+  }
+  if (rule.source === rule.replacement) {
+    return 'The replacement must differ from the original text.';
+  }
+  const signature = matcherSignature(rule);
+  const duplicate = existingRules.some(
+    (candidate) => candidate.id !== rule.id && matcherSignature(candidate) === signature,
+  );
+  if (duplicate) {
+    return 'A correction with the same text and matching options already exists.';
+  }
+  return null;
+}
+
+export function previewPersonalCorrections(
+  text: string,
+  rules: readonly UserRule[],
+): CorrectionPreview {
+  let result = text;
+  let replacementCount = 0;
+  let appliedRuleCount = 0;
+
+  for (const rule of rules) {
+    const applied = applyRule(result, rule);
+    result = applied.text;
+    replacementCount += applied.replacementCount;
+    if (applied.replacementCount > 0) appliedRuleCount += 1;
+  }
+
+  return { appliedRuleCount, replacementCount, text: result };
+}
+
+function applyRule(text: string, rule: UserRule): { replacementCount: number; text: string } {
+  const matcher = new RegExp(escapeRegExp(rule.source), rule.caseSensitive ? 'gu' : 'giu');
+  let output = '';
+  let copiedUntil = 0;
+  let replacementCount = 0;
+
+  for (const match of text.matchAll(matcher)) {
+    const start = match.index;
+    const matchedText = match[0];
+    const end = start + matchedText.length;
+    if (rule.wholeWord && !hasWordBoundaries(text, start, end)) continue;
+
+    output += text.slice(copiedUntil, start);
+    output += rule.replacement;
+    copiedUntil = end;
+    replacementCount += 1;
+  }
+
+  if (replacementCount === 0) return { replacementCount: 0, text };
+  output += text.slice(copiedUntil);
+  return { replacementCount, text: output };
+}
+
+function hasWordBoundaries(text: string, start: number, end: number): boolean {
+  return (
+    !isWordCharacter(previousCharacter(text, start)) && !isWordCharacter(nextCharacter(text, end))
+  );
+}
+
+function previousCharacter(text: string, offset: number): string | null {
+  const codeUnit = text.charCodeAt(offset - 1);
+  if (Number.isNaN(codeUnit)) return null;
+  const width = codeUnit >= 0xdc00 && codeUnit <= 0xdfff ? 2 : 1;
+  return text.slice(Math.max(0, offset - width), offset);
+}
+
+function nextCharacter(text: string, offset: number): string | null {
+  const codePoint = text.codePointAt(offset);
+  if (codePoint === undefined) return null;
+  return String.fromCodePoint(codePoint);
+}
+
+function isWordCharacter(character: string | null): boolean {
+  return character !== null && /[\p{L}\p{N}_]/u.test(character);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}
+
+function countCharacters(value: string): number {
+  return Array.from(value).length;
+}
+
+function matcherSignature(rule: UserRule): string {
+  const source = rule.caseSensitive ? rule.source : rule.source.toLowerCase();
+  return JSON.stringify([source, rule.caseSensitive, rule.wholeWord]);
+}

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -9,6 +9,7 @@ import {
   formatSystemAudioErrorMessage,
   formatSystemAudioSidecarErrorMessage,
 } from '../audio/system-audio-permission-message';
+import { toActiveUserRules } from '../corrections/correction-rules';
 import type { NotePlacementOptions, SurfaceDesynchronization } from '../editor/note-surface';
 import {
   type LlmPostprocessMode,
@@ -33,6 +34,7 @@ import type {
   SessionState,
   SidecarEvent,
   TranscriptReadyEvent,
+  UserRule,
 } from '../sidecar/protocol';
 import { type SidecarConnection, SidecarError } from '../sidecar/sidecar-connection';
 import { SidecarNotInstalledError } from '../sidecar/sidecar-paths';
@@ -91,6 +93,7 @@ interface ActiveSessionSnapshot {
   timestamps: TranscriptRenderOptions['timestamps'];
   transcriptFormatting: PluginSettings['transcriptFormatting'];
   useNoteAsContext: PluginSettings['useNoteAsContext'];
+  userRules: UserRule[];
 }
 
 type SessionPhase = 'starting' | 'active' | 'stopping' | 'cancelling' | 'stopped';
@@ -371,6 +374,7 @@ export class DictationSessionController {
         sessionStartUnixMs: snapshot.sessionStartUnixMs,
         sessionId,
         speakingStyle: snapshot.speakingStyle,
+        userRules: snapshot.userRules,
         ...(snapshot.modelStorePathOverride.length > 0
           ? { modelStorePathOverride: snapshot.modelStorePathOverride }
           : {}),
@@ -1541,6 +1545,7 @@ function createSessionSnapshot(
     },
     transcriptFormatting: settings.transcriptFormatting,
     useNoteAsContext: settings.useNoteAsContext,
+    userRules: toActiveUserRules(settings.personalCorrectionRules),
   };
 }
 

--- a/src/settings/plugin-settings.ts
+++ b/src/settings/plugin-settings.ts
@@ -1,5 +1,8 @@
 import { randomUUID } from 'node:crypto';
-
+import {
+  type PersonalCorrectionRule,
+  readPersonalCorrectionRules,
+} from '../corrections/correction-rules';
 import {
   DEFAULT_LLM_BUILTIN_PRESET_ID,
   formatStyleRef,
@@ -128,6 +131,7 @@ export interface PluginSettings {
   llmRouting: LlmRouting;
   localTranscriptSidebarBootstrapped: boolean;
   modelStorePathOverride: string;
+  personalCorrectionRules: PersonalCorrectionRule[];
   schemaVersion: 2;
   selectedModel: SelectedModel | null;
   // Last-known-good capabilities for `selectedModel`, captured on a successful
@@ -182,6 +186,7 @@ export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
   llmRouting: 'local',
   localTranscriptSidebarBootstrapped: false,
   modelStorePathOverride: '',
+  personalCorrectionRules: [],
   schemaVersion: 2,
   selectedModel: null,
   selectedModelCapabilitiesSnapshot: null,
@@ -303,6 +308,7 @@ export function resolvePluginSettings(data: unknown): PluginSettings {
       raw.modelStorePathOverride,
       DEFAULT_PLUGIN_SETTINGS.modelStorePathOverride,
     ),
+    personalCorrectionRules: readPersonalCorrectionRules(raw.personalCorrectionRules),
     // Bump `schemaVersion` and add a migration step when renaming a key or changing default semantics.
     schemaVersion: 2,
     selectedModel: readSelectedModel(raw.selectedModel),

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -16,6 +16,7 @@ import {
   type SidecarInstallManager,
 } from '../sidecar/sidecar-install-manager';
 import { readInstallManifest, variantDirectoryPath } from '../sidecar/sidecar-installer';
+import { CorrectionRulesModal } from '../ui/correction-rules-modal';
 import { diarizationSettingDescription } from './diarization-setting';
 import { renderActiveInstallCard } from './install-progress-row';
 import { renderMicrophonePicker } from './microphone-picker';
@@ -227,6 +228,30 @@ export class LocalSttSettingTab extends PluginSettingTab {
     });
 
     this.renderTranscriptFormattingSetting(outputCard);
+
+    const correctionRules = settings.personalCorrectionRules;
+    const enabledCorrectionCount = correctionRules.filter((rule) => rule.enabled).length;
+    new Setting(outputCard)
+      .setName('Personal corrections')
+      .setDesc(
+        correctionRules.length === 0
+          ? 'Fix recurring names, terms, and transcription mistakes locally.'
+          : `${enabledCorrectionCount} of ${correctionRules.length} enabled.`,
+      )
+      .addButton((button) => {
+        button.setButtonText('Manage').onClick(() => {
+          new CorrectionRulesModal(this.app, {
+            getRules: () => this.dependencies.getSettings().personalCorrectionRules,
+            saveRules: async (rules) => {
+              await this.dependencies.saveSettings({
+                ...this.dependencies.getSettings(),
+                personalCorrectionRules: rules,
+              });
+              this.display();
+            },
+          }).open();
+        });
+      });
 
     const diarizationSetting = addToggleSetting(outputCard, this.access, {
       name: 'Speaker labels (diarization)',

--- a/src/sidecar/protocol.ts
+++ b/src/sidecar/protocol.ts
@@ -28,6 +28,13 @@ export const MAX_FRAME_PAYLOAD_BYTES = 16 * 1024 * 1024;
 export type AccelerationPreference = 'auto' | 'cpu_only';
 export type SpeakingStyle = 'responsive' | 'balanced' | 'patient';
 
+export interface UserRule {
+  caseSensitive: boolean;
+  replacement: string;
+  source: string;
+  wholeWord: boolean;
+}
+
 export const LISTENING_MODES = ['always_on', 'one_sentence'] as const;
 export type ListeningMode = (typeof LISTENING_MODES)[number];
 
@@ -119,6 +126,7 @@ export interface StartSessionCommand extends EnvelopeBase<'start_session'> {
   sessionStartUnixMs: number;
   sessionId: string;
   speakingStyle: SpeakingStyle;
+  userRules: UserRule[];
 }
 
 export interface ContextResponseCommand extends EnvelopeBase<'context_response'> {

--- a/src/ui/correction-rules-modal.ts
+++ b/src/ui/correction-rules-modal.ts
@@ -1,0 +1,318 @@
+import { randomUUID } from 'node:crypto';
+
+import type { App } from 'obsidian';
+import { Modal, Setting } from 'obsidian';
+
+import {
+  MAX_CORRECTION_REPLACEMENT_CHARS,
+  MAX_CORRECTION_SOURCE_CHARS,
+  MAX_PERSONAL_CORRECTION_RULES,
+  type PersonalCorrectionRule,
+  previewPersonalCorrections,
+  validatePersonalCorrectionRule,
+} from '../corrections/correction-rules';
+import { ConfirmModal } from './confirm-modal';
+
+interface CorrectionRulesModalDependencies {
+  getRules: () => readonly PersonalCorrectionRule[];
+  saveRules: (rules: PersonalCorrectionRule[]) => Promise<void>;
+}
+
+interface RuleEditor {
+  draft: PersonalCorrectionRule;
+  isNew: boolean;
+  previewText: string;
+  previewTouched: boolean;
+}
+
+export class CorrectionRulesModal extends Modal {
+  private editor: RuleEditor | null = null;
+  private isOpen = false;
+
+  constructor(
+    app: App,
+    private readonly dependencies: CorrectionRulesModalDependencies,
+  ) {
+    super(app);
+  }
+
+  override onOpen(): void {
+    this.isOpen = true;
+    this.modalEl.addClass('local-stt-correction-rules');
+    this.render();
+  }
+
+  override onClose(): void {
+    this.isOpen = false;
+    this.editor = null;
+    this.contentEl.empty();
+  }
+
+  private render(): void {
+    if (!this.isOpen) return;
+    this.contentEl.empty();
+
+    if (this.editor === null) {
+      this.titleEl.setText('Personal corrections');
+      this.renderList();
+      return;
+    }
+
+    this.titleEl.setText(this.editor.isNew ? 'New correction' : 'Edit correction');
+    this.renderEditor(this.editor);
+  }
+
+  private renderList(): void {
+    const rules = this.dependencies.getRules();
+    const atLimit = rules.length >= MAX_PERSONAL_CORRECTION_RULES;
+    new Setting(this.contentEl)
+      .setName(`${rules.length} correction${rules.length === 1 ? '' : 's'}`)
+      .setDesc('Applied from top to bottom after local transcription and before optional cleanup.')
+      .addButton((button) => {
+        button.setCta().setButtonText('New correction');
+        if (atLimit) {
+          button
+            .setDisabled(true)
+            .setTooltip(`Maximum ${MAX_PERSONAL_CORRECTION_RULES} corrections`);
+          return;
+        }
+        button.onClick(() => {
+          this.editor = {
+            draft: {
+              caseSensitive: false,
+              enabled: true,
+              id: randomUUID(),
+              replacement: '',
+              source: '',
+              wholeWord: true,
+            },
+            isNew: true,
+            previewText: '',
+            previewTouched: false,
+          };
+          this.render();
+        });
+      });
+
+    if (rules.length === 0) {
+      this.contentEl.createEl('p', {
+        cls: 'local-stt-correction-rules__empty',
+        text: 'No personal corrections yet.',
+      });
+      return;
+    }
+
+    rules.forEach((rule, index) => {
+      this.renderRuleRow(rule, index, rules.length);
+    });
+  }
+
+  private renderRuleRow(rule: PersonalCorrectionRule, index: number, count: number): void {
+    const replacement = rule.replacement.length === 0 ? '(remove)' : quote(rule.replacement);
+    const description = [
+      rule.caseSensitive ? 'Match case' : 'Ignore case',
+      rule.wholeWord ? 'Whole words' : 'Anywhere',
+    ].join(' | ');
+    const setting = new Setting(this.contentEl)
+      .setName(`${quote(rule.source)} -> ${replacement}`)
+      .setDesc(description);
+    setting.settingEl.addClass('local-stt-correction-rules__row');
+
+    setting.addToggle((toggle) => {
+      toggle.setTooltip(rule.enabled ? 'Disable correction' : 'Enable correction');
+      toggle.setValue(rule.enabled).onChange((enabled) => {
+        void this.updateRules((rules) =>
+          rules.map((candidate) =>
+            candidate.id === rule.id ? { ...candidate, enabled } : candidate,
+          ),
+        );
+      });
+    });
+    setting.addExtraButton((button) => {
+      button
+        .setIcon('arrow-up')
+        .setTooltip('Move up')
+        .setDisabled(index === 0);
+      button.onClick(() => {
+        void this.moveRule(index, -1);
+      });
+    });
+    setting.addExtraButton((button) => {
+      button
+        .setIcon('arrow-down')
+        .setTooltip('Move down')
+        .setDisabled(index === count - 1);
+      button.onClick(() => {
+        void this.moveRule(index, 1);
+      });
+    });
+    setting.addExtraButton((button) => {
+      button
+        .setIcon('pencil')
+        .setTooltip('Edit correction')
+        .onClick(() => {
+          this.editor = {
+            draft: { ...rule },
+            isNew: false,
+            previewText: rule.source,
+            previewTouched: false,
+          };
+          this.render();
+        });
+    });
+    setting.addExtraButton((button) => {
+      button
+        .setIcon('trash-2')
+        .setTooltip('Delete correction')
+        .onClick(() => {
+          this.confirmDelete(rule);
+        });
+    });
+  }
+
+  private renderEditor(editor: RuleEditor): void {
+    const backButton = this.contentEl.createEl('button', {
+      cls: 'local-stt-correction-rules__back',
+      text: 'Back to corrections',
+    });
+    backButton.addEventListener('click', () => {
+      this.editor = null;
+      this.render();
+    });
+
+    const previewBefore = this.contentEl.createEl('code');
+    const previewAfter = this.contentEl.createEl('code');
+    const renderPreview = (): void => {
+      previewBefore.setText(editor.previewText);
+      previewAfter.setText(previewPersonalCorrections(editor.previewText, [editor.draft]).text);
+    };
+
+    new Setting(this.contentEl).setName('Text to replace').addText((text) => {
+      text.setPlaceholder('kuber netes').setValue(editor.draft.source);
+      text.inputEl.maxLength = MAX_CORRECTION_SOURCE_CHARS;
+      text.onChange((value) => {
+        editor.draft.source = value;
+        if (!editor.previewTouched) editor.previewText = value;
+        renderPreview();
+      });
+    });
+    new Setting(this.contentEl).setName('Replace with').addText((text) => {
+      text.setPlaceholder('Kubernetes').setValue(editor.draft.replacement);
+      text.inputEl.maxLength = MAX_CORRECTION_REPLACEMENT_CHARS;
+      text.onChange((value) => {
+        editor.draft.replacement = value;
+        renderPreview();
+      });
+    });
+    new Setting(this.contentEl)
+      .setName('Whole words')
+      .setDesc('Do not change matching text inside a longer word.')
+      .addToggle((toggle) => {
+        toggle.setValue(editor.draft.wholeWord).onChange((value) => {
+          editor.draft.wholeWord = value;
+          renderPreview();
+        });
+      });
+    new Setting(this.contentEl).setName('Match case').addToggle((toggle) => {
+      toggle.setValue(editor.draft.caseSensitive).onChange((value) => {
+        editor.draft.caseSensitive = value;
+        renderPreview();
+      });
+    });
+    new Setting(this.contentEl).setName('Try it on').addText((text) => {
+      text.setPlaceholder('Type sample text').setValue(editor.previewText);
+      text.onChange((value) => {
+        editor.previewText = value;
+        editor.previewTouched = true;
+        renderPreview();
+      });
+    });
+
+    const preview = this.contentEl.createDiv({ cls: 'local-stt-correction-rules__preview' });
+    preview.createDiv({ cls: 'local-stt-correction-rules__preview-label', text: 'Before' });
+    preview.appendChild(previewBefore);
+    preview.createDiv({ cls: 'local-stt-correction-rules__preview-label', text: 'After' });
+    preview.appendChild(previewAfter);
+    renderPreview();
+
+    const errorEl = this.contentEl.createEl('p', {
+      cls: 'local-stt-correction-rules__error local-stt-hidden',
+    });
+    errorEl.setAttribute('aria-live', 'polite');
+    errorEl.setAttribute('role', 'alert');
+
+    new Setting(this.contentEl)
+      .addButton((button) => {
+        button.setButtonText('Cancel').onClick(() => {
+          this.editor = null;
+          this.render();
+        });
+      })
+      .addButton((button) => {
+        button
+          .setCta()
+          .setButtonText('Save')
+          .onClick(() => {
+            void this.saveEditor(editor, errorEl);
+          });
+      });
+  }
+
+  private async saveEditor(editor: RuleEditor, errorEl: HTMLElement): Promise<void> {
+    const current = [...this.dependencies.getRules()];
+    const validationError = validatePersonalCorrectionRule(editor.draft, current);
+    if (validationError !== null) {
+      errorEl.setText(validationError);
+      errorEl.removeClass('local-stt-hidden');
+      return;
+    }
+    if (editor.isNew && current.length >= MAX_PERSONAL_CORRECTION_RULES) {
+      errorEl.setText(`You can save up to ${MAX_PERSONAL_CORRECTION_RULES} corrections.`);
+      errorEl.removeClass('local-stt-hidden');
+      return;
+    }
+
+    const next = editor.isNew
+      ? [...current, { ...editor.draft }]
+      : current.map((rule) => (rule.id === editor.draft.id ? { ...editor.draft } : rule));
+    await this.dependencies.saveRules(next);
+    this.editor = null;
+    this.render();
+  }
+
+  private async moveRule(index: number, delta: -1 | 1): Promise<void> {
+    const rules = [...this.dependencies.getRules()];
+    const target = index + delta;
+    if (target < 0 || target >= rules.length) return;
+    const current = rules[index];
+    const adjacent = rules[target];
+    if (current === undefined || adjacent === undefined) return;
+    rules[index] = adjacent;
+    rules[target] = current;
+    await this.dependencies.saveRules(rules);
+    this.render();
+  }
+
+  private async updateRules(
+    update: (rules: PersonalCorrectionRule[]) => PersonalCorrectionRule[],
+  ): Promise<void> {
+    await this.dependencies.saveRules(update([...this.dependencies.getRules()]));
+    this.render();
+  }
+
+  private confirmDelete(rule: PersonalCorrectionRule): void {
+    new ConfirmModal(this.app, {
+      confirmLabel: 'Delete',
+      destructive: true,
+      message: `Delete the correction for ${quote(rule.source)}? This cannot be undone.`,
+      onConfirm: async () => {
+        await this.updateRules((rules) => rules.filter((candidate) => candidate.id !== rule.id));
+      },
+      title: 'Delete correction',
+    }).open();
+  }
+}
+
+function quote(value: string): string {
+  return `"${value}"`;
+}

--- a/src/ui/correction-rules-modal.ts
+++ b/src/ui/correction-rules-modal.ts
@@ -4,11 +4,10 @@ import type { App } from 'obsidian';
 import { Modal, Setting } from 'obsidian';
 
 import {
-  MAX_CORRECTION_REPLACEMENT_CHARS,
-  MAX_CORRECTION_SOURCE_CHARS,
   MAX_PERSONAL_CORRECTION_RULES,
+  mergePersonalCorrectionDraft,
   type PersonalCorrectionRule,
-  previewPersonalCorrections,
+  previewPersonalCorrectionDraft,
   validatePersonalCorrectionRule,
 } from '../corrections/correction-rules';
 import { ConfirmModal } from './confirm-modal';
@@ -184,12 +183,18 @@ export class CorrectionRulesModal extends Modal {
     const previewAfter = this.contentEl.createEl('code');
     const renderPreview = (): void => {
       previewBefore.setText(editor.previewText);
-      previewAfter.setText(previewPersonalCorrections(editor.previewText, [editor.draft]).text);
+      previewAfter.setText(
+        previewPersonalCorrectionDraft(
+          editor.previewText,
+          this.dependencies.getRules(),
+          editor.draft,
+          editor.isNew,
+        ).text,
+      );
     };
 
     new Setting(this.contentEl).setName('Text to replace').addText((text) => {
       text.setPlaceholder('kuber netes').setValue(editor.draft.source);
-      text.inputEl.maxLength = MAX_CORRECTION_SOURCE_CHARS;
       text.onChange((value) => {
         editor.draft.source = value;
         if (!editor.previewTouched) editor.previewText = value;
@@ -198,7 +203,6 @@ export class CorrectionRulesModal extends Modal {
     });
     new Setting(this.contentEl).setName('Replace with').addText((text) => {
       text.setPlaceholder('Kubernetes').setValue(editor.draft.replacement);
-      text.inputEl.maxLength = MAX_CORRECTION_REPLACEMENT_CHARS;
       text.onChange((value) => {
         editor.draft.replacement = value;
         renderPreview();
@@ -219,14 +223,17 @@ export class CorrectionRulesModal extends Modal {
         renderPreview();
       });
     });
-    new Setting(this.contentEl).setName('Try it on').addText((text) => {
-      text.setPlaceholder('Type sample text').setValue(editor.previewText);
-      text.onChange((value) => {
-        editor.previewText = value;
-        editor.previewTouched = true;
-        renderPreview();
+    new Setting(this.contentEl)
+      .setName('Try it on')
+      .setDesc('Preview the final text after all enabled corrections run in list order.')
+      .addText((text) => {
+        text.setPlaceholder('Type sample text').setValue(editor.previewText);
+        text.onChange((value) => {
+          editor.previewText = value;
+          editor.previewTouched = true;
+          renderPreview();
+        });
       });
-    });
 
     const preview = this.contentEl.createDiv({ cls: 'local-stt-correction-rules__preview' });
     preview.createDiv({ cls: 'local-stt-correction-rules__preview-label', text: 'Before' });
@@ -272,9 +279,7 @@ export class CorrectionRulesModal extends Modal {
       return;
     }
 
-    const next = editor.isNew
-      ? [...current, { ...editor.draft }]
-      : current.map((rule) => (rule.id === editor.draft.id ? { ...editor.draft } : rule));
+    const next = mergePersonalCorrectionDraft(current, editor.draft, editor.isNew);
     await this.dependencies.saveRules(next);
     this.editor = null;
     this.render();

--- a/styles.css
+++ b/styles.css
@@ -549,6 +549,45 @@
   margin: var(--size-2-2) 0;
 }
 
+/* --- Personal corrections ---------------------------------------- */
+
+.local-stt-correction-rules__back {
+  margin-bottom: var(--size-4-2);
+}
+
+.local-stt-correction-rules__empty {
+  color: var(--text-muted);
+  margin: var(--size-4-2) 0;
+}
+
+.local-stt-correction-rules__row .setting-item-name {
+  overflow-wrap: anywhere;
+}
+
+.local-stt-correction-rules__preview {
+  display: grid;
+  gap: var(--size-2-2);
+  margin: var(--size-4-2) 0;
+}
+
+.local-stt-correction-rules__preview-label {
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+}
+
+.local-stt-correction-rules__preview code {
+  display: block;
+  min-height: 2.5em;
+  overflow-wrap: anywhere;
+  padding: var(--size-4-2);
+  white-space: pre-wrap;
+}
+
+.local-stt-correction-rules__error {
+  color: var(--text-error);
+  margin: var(--size-2-2) 0;
+}
+
 /* --- Batch LLM processing pulse ----------------------------------- */
 
 .local-stt-transcript-provisional {

--- a/test/correction-rules.test.ts
+++ b/test/correction-rules.test.ts
@@ -1,12 +1,24 @@
 import { describe, expect, it } from 'vitest';
-
 import {
   type PersonalCorrectionRule,
+  previewPersonalCorrectionDraft,
   previewPersonalCorrections,
   readPersonalCorrectionRules,
   toActiveUserRules,
   validatePersonalCorrectionRule,
 } from '../src/corrections/correction-rules';
+import correctionGoldenCases from './fixtures/personal-corrections-golden.json';
+
+interface CorrectionGoldenCase {
+  draft: PersonalCorrectionRule;
+  existingRules: PersonalCorrectionRule[];
+  expectedText: string;
+  inputText: string;
+  isNew: boolean;
+  name: string;
+}
+
+const goldenCases = correctionGoldenCases as CorrectionGoldenCase[];
 
 function rule(overrides: Partial<PersonalCorrectionRule> = {}): PersonalCorrectionRule {
   return {
@@ -21,6 +33,12 @@ function rule(overrides: Partial<PersonalCorrectionRule> = {}): PersonalCorrecti
 }
 
 describe('personal correction rules', () => {
+  it.each(goldenCases)('$name', ({ draft, existingRules, expectedText, inputText, isNew }) => {
+    expect(previewPersonalCorrectionDraft(inputText, existingRules, draft, isNew).text).toBe(
+      expectedText,
+    );
+  });
+
   it('applies literal rules in order and treats replacement metacharacters literally', () => {
     const preview = previewPersonalCorrections('A KUBER NETES cluster.', [
       rule(),
@@ -83,5 +101,14 @@ describe('personal correction rules', () => {
     expect(
       validatePersonalCorrectionRule(rule({ caseSensitive: true, id: 'new' }), [rule()]),
     ).toBeNull();
+  });
+
+  it('rejects edge whitespace that canonical segment joining cannot preserve', () => {
+    expect(validatePersonalCorrectionRule(rule({ source: ' kuber netes' }), [])).toMatch(
+      /whitespace/u,
+    );
+    expect(validatePersonalCorrectionRule(rule({ replacement: 'Kubernetes ' }), [])).toMatch(
+      /whitespace/u,
+    );
   });
 });

--- a/test/correction-rules.test.ts
+++ b/test/correction-rules.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type PersonalCorrectionRule,
+  previewPersonalCorrections,
+  readPersonalCorrectionRules,
+  toActiveUserRules,
+  validatePersonalCorrectionRule,
+} from '../src/corrections/correction-rules';
+
+function rule(overrides: Partial<PersonalCorrectionRule> = {}): PersonalCorrectionRule {
+  return {
+    caseSensitive: false,
+    enabled: true,
+    id: 'rule-1',
+    replacement: 'Kubernetes',
+    source: 'kuber netes',
+    wholeWord: true,
+    ...overrides,
+  };
+}
+
+describe('personal correction rules', () => {
+  it('applies literal rules in order and treats replacement metacharacters literally', () => {
+    const preview = previewPersonalCorrections('A KUBER NETES cluster.', [
+      rule(),
+      rule({ id: 'rule-2', replacement: '$& platform', source: 'Kubernetes cluster' }),
+    ]);
+
+    expect(preview).toEqual({
+      appliedRuleCount: 2,
+      replacementCount: 2,
+      text: 'A $& platform.',
+    });
+  });
+
+  it('honors whole-word and case-sensitive matching', () => {
+    expect(
+      previewPersonalCorrections('obsidian Obsidian obsidianite', [
+        rule({ caseSensitive: true, replacement: 'Obsidian', source: 'obsidian' }),
+      ]).text,
+    ).toBe('Obsidian Obsidian obsidianite');
+    expect(
+      previewPersonalCorrections('preobsidian obsidian_post obsidian', [
+        rule({ replacement: 'Obsidian', source: 'obsidian' }),
+      ]).text,
+    ).toBe('preobsidian obsidian_post Obsidian');
+  });
+
+  it('keeps enabled-rule order while dropping ids and disabled rules from the wire payload', () => {
+    expect(
+      toActiveUserRules([
+        rule(),
+        rule({ enabled: false, id: 'disabled', source: 'skip' }),
+        rule({ id: 'last', source: 'last' }),
+      ]),
+    ).toEqual([
+      {
+        caseSensitive: false,
+        replacement: 'Kubernetes',
+        source: 'kuber netes',
+        wholeWord: true,
+      },
+      {
+        caseSensitive: false,
+        replacement: 'Kubernetes',
+        source: 'last',
+        wholeWord: true,
+      },
+    ]);
+  });
+
+  it('skips malformed persisted entries without discarding later valid rules', () => {
+    expect(
+      readPersonalCorrectionRules([null, rule(), rule({ id: 'duplicate', source: 'KUBER NETES' })]),
+    ).toEqual([rule()]);
+  });
+
+  it('rejects ambiguous duplicate matching semantics', () => {
+    expect(
+      validatePersonalCorrectionRule(rule({ id: 'new', source: 'KUBER NETES' }), [rule()]),
+    ).toMatch(/already exists/u);
+    expect(
+      validatePersonalCorrectionRule(rule({ caseSensitive: true, id: 'new' }), [rule()]),
+    ).toBeNull();
+  });
+});

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -190,6 +190,46 @@ describe('DictationSessionController', () => {
     });
   });
 
+  it('captures enabled personal corrections in session order without UI metadata', async () => {
+    const sidecarConnection = new FakeSidecarConnection();
+    const controller = createController({
+      sidecarConnection,
+      getSettings: () =>
+        createSettings({
+          personalCorrectionRules: [
+            {
+              caseSensitive: false,
+              enabled: true,
+              id: 'first',
+              replacement: 'Kubernetes',
+              source: 'kuber netes',
+              wholeWord: true,
+            },
+            {
+              caseSensitive: true,
+              enabled: false,
+              id: 'disabled',
+              replacement: 'ignored',
+              source: 'ignore me',
+              wholeWord: false,
+            },
+          ],
+          selectedModel: createExternalModelSelection(),
+        }),
+    });
+
+    await controller.startDictation();
+
+    expect(sidecarConnection.startSession.mock.calls[0]?.[0].userRules).toEqual([
+      {
+        caseSensitive: false,
+        replacement: 'Kubernetes',
+        source: 'kuber netes',
+        wholeWord: true,
+      },
+    ]);
+  });
+
   it('includes system audio without skipping microphone capture', async () => {
     const captureStream = new FakeCaptureStream();
     const sidecarConnection = new FakeSidecarConnection();

--- a/test/fixtures/personal-corrections-golden.json
+++ b/test/fixtures/personal-corrections-golden.json
@@ -1,0 +1,83 @@
+[
+  {
+    "name": "disabled draft is ignored",
+    "existingRules": [
+      {
+        "caseSensitive": false,
+        "enabled": false,
+        "id": "disabled",
+        "replacement": "beta",
+        "source": "alpha",
+        "wholeWord": true
+      }
+    ],
+    "draft": {
+      "caseSensitive": false,
+      "enabled": false,
+      "id": "disabled",
+      "replacement": "gamma",
+      "source": "alpha",
+      "wholeWord": true
+    },
+    "isNew": false,
+    "inputText": "alpha",
+    "inputSegments": [{ "endMs": 400, "speaker": null, "startMs": 0, "text": "alpha" }],
+    "expectedSegmentTexts": ["alpha"],
+    "expectedText": "alpha"
+  },
+  {
+    "name": "draft participates in configured cascade order",
+    "existingRules": [
+      {
+        "caseSensitive": false,
+        "enabled": true,
+        "id": "first",
+        "replacement": "beta",
+        "source": "alpha",
+        "wholeWord": true
+      },
+      {
+        "caseSensitive": false,
+        "enabled": true,
+        "id": "second",
+        "replacement": "old value",
+        "source": "beta",
+        "wholeWord": true
+      }
+    ],
+    "draft": {
+      "caseSensitive": false,
+      "enabled": true,
+      "id": "second",
+      "replacement": "gamma",
+      "source": "beta",
+      "wholeWord": true
+    },
+    "isNew": false,
+    "inputText": "alpha",
+    "inputSegments": [{ "endMs": 400, "speaker": null, "startMs": 0, "text": "alpha" }],
+    "expectedSegmentTexts": ["gamma"],
+    "expectedText": "gamma"
+  },
+  {
+    "name": "multiword rule crosses same-speaker segment boundaries",
+    "existingRules": [],
+    "draft": {
+      "caseSensitive": false,
+      "enabled": true,
+      "id": "new-york",
+      "replacement": "NYC",
+      "source": "New York",
+      "wholeWord": true
+    },
+    "isNew": true,
+    "inputText": "New York, then Albany",
+    "inputSegments": [
+      { "endMs": 300, "speaker": null, "startMs": 0, "text": "New" },
+      { "endMs": 700, "speaker": null, "startMs": 300, "text": "York," },
+      { "endMs": 1200, "speaker": null, "startMs": 700, "text": "then Albany" }
+    ],
+    "expectedSegmentTexts": ["NYC,", "", "then Albany"],
+    "expectedText": "NYC, then Albany"
+  }
+]

--- a/test/plugin-settings.test.ts
+++ b/test/plugin-settings.test.ts
@@ -61,6 +61,45 @@ describe('resolvePluginSettings', () => {
     ).toBe(false);
   });
 
+  it('loads valid personal corrections and rejects unsafe persisted entries', () => {
+    expect(
+      resolvePluginSettings({
+        personalCorrectionRules: [
+          null,
+          {
+            caseSensitive: false,
+            enabled: true,
+            id: 'valid',
+            replacement: 'Kubernetes',
+            source: 'kuber netes',
+            wholeWord: true,
+          },
+          {
+            enabled: true,
+            id: 'blank',
+            replacement: 'dangerous',
+            source: '   ',
+          },
+          {
+            enabled: true,
+            id: 'valid',
+            replacement: 'duplicate',
+            source: 'dupe',
+          },
+        ],
+      }).personalCorrectionRules,
+    ).toEqual([
+      {
+        caseSensitive: false,
+        enabled: true,
+        id: 'valid',
+        replacement: 'Kubernetes',
+        source: 'kuber netes',
+        wholeWord: true,
+      },
+    ]);
+  });
+
   it('merges valid persisted values', () => {
     expect(
       resolvePluginSettings({

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -238,6 +238,14 @@ describe('command serialization', () => {
         sessionStartUnixMs: 1_700_000_000_000,
         sessionId: 'session-gpu',
         speakingStyle: 'balanced',
+        userRules: [
+          {
+            caseSensitive: false,
+            replacement: 'Kubernetes',
+            source: 'kuber netes',
+            wholeWord: true,
+          },
+        ],
       }),
     );
     const payload = readPayload(frame) as Record<string, unknown>;
@@ -247,6 +255,14 @@ describe('command serialization', () => {
     expect(payload.includeSystemAudio).toBe(true);
     expect(payload).not.toHaveProperty('audioSource');
     expect(payload.sessionId).toBe('session-gpu');
+    expect(payload.userRules).toEqual([
+      {
+        caseSensitive: false,
+        replacement: 'Kubernetes',
+        source: 'kuber netes',
+        wholeWord: true,
+      },
+    ]);
   });
 
   it('encodes session-addressed lifecycle commands with sessionId echoed in the payload', () => {


### PR DESCRIPTION
## Summary

- Add ordered, literal personal correction rules for recurring names, technical terms, and recognition mistakes.
- Apply enabled rules locally to finalized transcripts before optional LLM cleanup.
- Provide add, edit, enable/disable, delete, reorder, and complete ordered before/after preview controls.

Relates to #123
Relates to #228

## Key changes

- **Plugin:** Persists bounded per-vault rules, validates unsafe or duplicate entries, snapshots enabled rules at session start, and adds a dedicated management modal.
- **Preview:** Evaluates the complete configured rule list with the draft at its saved position, filters disabled rules, and shows cascading output in runtime order.
- **Sidecar:** Adds the UserRules post-engine stage after hallucination filtering with explicit case and whole-word semantics over canonical visible transcript text.
- **Cross-segment matching:** Allows multiword rules to span adjacent same-speaker engine segments while preserving every segment record, timestamp, and speaker field.
- **Protocol:** Adds optional/default-empty `userRules` to `start_session`; count, bounds, edge-whitespace, duplicate matcher, and rule validity checks are enforced at the native boundary.
- **Privacy:** Stage diagnostics contain counts only, never transcript or rule text.
- **Docs/tests:** Documents canonical stage ordering/allocation and shares golden disabled/cascade/cross-segment cases across TypeScript preview and Rust runtime.

## Matching and timing semantics

Rules execute top to bottom and each consumes the preceding output. Matching is literal; replacement text is never interpreted as a regex expansion. Whole-word boundaries use Unicode letters/numbers plus underscore.

Visible text is the trimmed non-empty segment text joined with one space. Rules cannot begin or end with whitespace because that canonical boundary cannot be represented reliably.

For a cross-segment match, replacement text is assigned to the first touched segment and consumed text is cleared from later touched segments. A remaining suffix stays in its original segment unless that would add a false visible space, in which case it moves beside the replacement. All segment timing and speaker records remain unchanged; replacement text spanning boundaries therefore uses the first touched segment's time range. Runtime never matches across different existing speaker labels.

## Compatibility

The new `start_session.userRules` array defaults to empty, so older plugin payloads continue to work. The plugin always sends its session snapshot. No settings migration is required because the new persisted field defaults to an empty array.

## Test plan

- [x] `npm run check` (release validation, typecheck, Biome, Obsidian ESLint, 737 Vitest tests, frontend build, all-engine sidecar build/output verification, Rust fmt/clippy/unit/integration tests)
- [x] Focused TypeScript correction/settings/protocol/controller tests (171 passed)
- [x] Focused native correction, canonical-order, protocol, duplicate, boundary, and segment-allocation tests
- [ ] Manual Obsidian settings/dictation smoke not available in this environment
