### PR TITLE
fix(moonshine): allow final decodes to reach EOS

### DIFF
--- a/native/src/adapters/moonshine.rs
+++ b/native/src/adapters/moonshine.rs
@@ -18,6 +18,11 @@ use crate::transcription::{
 const SAMPLE_RATE: usize = 16_000;
 const FRONTEND_CHUNK_SAMPLES: usize = 1_280;
 const MAX_TOKENS_PER_SECOND: f32 = 6.5;
+/// Final-only slack above the duration guard. The tensor-validated Moonshine
+/// Streaming port in `handy-computer/transcribe.cpp` calls the same 24-token
+/// floor "headroom for very short clips". Partials keep the strict rate limit
+/// so live runaway decodes remain bounded while final decodes can reach EOS.
+const FINAL_GENERATION_HEADROOM_TOKENS: usize = 24;
 /// Tokens at the partial frontier that may be revised as encoder memory grows.
 const PARTIAL_REDECODE_WINDOW_TOKENS: usize = 12;
 
@@ -888,10 +893,10 @@ impl OrtMoonshineInference {
     fn generate_tokens(
         &mut self,
         mut generated: Vec<i64>,
+        is_final: bool,
     ) -> Result<(Vec<i64>, bool), TranscriptionError> {
-        let duration_seconds = self.state.sample_count as f32 / SAMPLE_RATE as f32;
-        let max_tokens = ((duration_seconds * MAX_TOKENS_PER_SECOND).ceil() as usize)
-            .min(self.config.max_seq_len);
+        let max_tokens =
+            generation_token_budget(self.state.sample_count, self.config.max_seq_len, is_final);
         let mut current = generated.last().copied().unwrap_or(self.config.bos_id);
         let mut reached_eos = false;
 
@@ -933,7 +938,7 @@ impl OrtMoonshineInference {
             .saturating_sub(PARTIAL_REDECODE_WINDOW_TOKENS);
         self.truncate_self_kv(commit);
         let (generated, reached_eos) =
-            self.generate_tokens(self.state.partial_tokens[..commit].to_vec())?;
+            self.generate_tokens(self.state.partial_tokens[..commit].to_vec(), false)?;
 
         self.state.partial_tokens.clone_from(&generated);
         self.decoded_transcript(&generated, reached_eos)
@@ -945,9 +950,25 @@ impl OrtMoonshineInference {
         }
 
         self.reset_decoder();
-        let (generated, reached_eos) = self.generate_tokens(Vec::new())?;
+        let (generated, reached_eos) = self.generate_tokens(Vec::new(), true)?;
         self.decoded_transcript(&generated, reached_eos)
     }
+}
+
+fn generation_token_budget(sample_count: usize, max_seq_len: usize, is_final: bool) -> usize {
+    if sample_count == 0 {
+        return 0;
+    }
+
+    let duration_seconds = sample_count as f32 / SAMPLE_RATE as f32;
+    let duration_budget = (duration_seconds * MAX_TOKENS_PER_SECOND).ceil() as usize;
+    let headroom = if is_final {
+        FINAL_GENERATION_HEADROOM_TOKENS
+    } else {
+        0
+    };
+
+    duration_budget.saturating_add(headroom).min(max_seq_len)
 }
 
 impl MoonshineInference for OrtMoonshineInference {
@@ -1132,6 +1153,32 @@ mod tests {
         assert_eq!(final_output.segments[0].text, "fixture final.");
         assert_eq!(final_output.segments[0].end_ms, 1_000);
         assert_eq!(model.partial().unwrap().segments, Vec::new());
+    }
+
+    #[test]
+    fn final_generation_budget_adds_bounded_headroom_without_expanding_partials() {
+        let max_seq_len = 448;
+
+        for (sample_count, partial_budget, final_budget) in [
+            (SAMPLE_RATE / 10, 1, 25),
+            (SAMPLE_RATE * 2, 13, 37),
+            (SAMPLE_RATE * 66, 429, max_seq_len),
+        ] {
+            assert_eq!(
+                generation_token_budget(sample_count, max_seq_len, false),
+                partial_budget,
+            );
+            assert_eq!(
+                generation_token_budget(sample_count, max_seq_len, true),
+                final_budget,
+            );
+        }
+    }
+
+    #[test]
+    fn generation_budget_is_zero_for_empty_audio() {
+        assert_eq!(generation_token_budget(0, 448, false), 0);
+        assert_eq!(generation_token_budget(0, 448, true), 0);
     }
 
     /// Characterizes why the cross-KV projection cannot be cached incrementally.


### PR DESCRIPTION
## Summary

- Give final Moonshine decodes 24 tokens of bounded headroom above the duration-derived runaway guard, so short utterances have enough room to emit EOS.
- Preserve the existing 6.5 tokens/second budget for every partial decode.
- Clamp both paths to the model's `max_seq_len`.

## Key changes

- Sidecar: centralize Moonshine generation budgeting and apply headroom only when finalizing an utterance.
- Sidecar: use saturating addition before the existing model-position cap.
- Tests: assert exact partial/final budgets for 100 ms (`1/25`), 2 s (`13/37`), and a near-cap 66 s utterance (`429/448`), plus empty audio.

## Why 24 tokens

The tensor-validated Moonshine Streaming implementation in `handy-computer/transcribe.cpp` uses a 24-token budget floor specifically as ["headroom for very short clips"](https://github.com/handy-computer/transcribe.cpp/blob/a94e021ef658dc7c788837341a13f6acea3baf3c/src/arch/moonshine_streaming/model.cpp#L436-L449). This change uses the same fixed allowance for final decode only; repeated live partials retain the tighter duration guard.

No wire-protocol, model-format, or settings-schema changes.

## Test plan

- [x] `npm run check` (release validation, typecheck, Biome, Obsidian ESLint, 726 Vitest tests, frontend build, sidecar build/output verification, Rust fmt, Clippy with warnings denied, and Rust tests)
- [x] Focused Moonshine budget regression test
- [ ] Manual real-model decode (not run; model-backed Moonshine E2E tests require `MOONSHINE_MODEL_PATH` and remain explicitly ignored by the standard suite)