### PR TITLE
Clear unavailable saved microphones after fallback

### DIFF
--- a/src/audio/audio-capture-stream.ts
+++ b/src/audio/audio-capture-stream.ts
@@ -18,6 +18,11 @@ interface AudioCaptureStreamOptions {
   onUnexpectedEnd?: (sessionId: string) => void;
 }
 
+interface UserMediaRequest {
+  mediaStream: MediaStream;
+  unavailableDeviceId: string | null;
+}
+
 export interface AudioCaptureStartOptions {
   audioInputDeviceId?: string | null;
   sessionId: string;
@@ -54,7 +59,10 @@ export class AudioCaptureStream {
       throw new Error('Microphone capture is not available in this Obsidian runtime.');
     }
 
-    const mediaStream = await this.requestUserMedia(mediaDevices, audioInputDeviceId);
+    const { mediaStream, unavailableDeviceId } = await this.requestUserMedia(
+      mediaDevices,
+      audioInputDeviceId,
+    );
 
     let audioContext: AudioContext | null = null;
 
@@ -101,6 +109,10 @@ export class AudioCaptureStream {
       this.sourceNode = sourceNode;
       this.observeUnexpectedTrackEnd(mediaStream, sessionId);
       this.options.logger?.debug('audio', 'capture started');
+
+      if (unavailableDeviceId !== null) {
+        void this.handleDeviceFallback(unavailableDeviceId);
+      }
     } catch (error) {
       this.options.logger?.error('audio', 'failed to initialize streaming audio capture', error);
       await stopMediaStream(mediaStream);
@@ -125,7 +137,7 @@ export class AudioCaptureStream {
   private async requestUserMedia(
     mediaDevices: MediaDevices,
     audioInputDeviceId: string | null | undefined,
-  ): Promise<MediaStream> {
+  ): Promise<UserMediaRequest> {
     const baseConstraints: MediaTrackConstraints = {
       autoGainControl: false,
       channelCount: PCM_CHANNEL_COUNT,
@@ -134,14 +146,20 @@ export class AudioCaptureStream {
     };
 
     if (typeof audioInputDeviceId !== 'string' || audioInputDeviceId.length === 0) {
-      return mediaDevices.getUserMedia({ audio: baseConstraints, video: false });
+      return {
+        mediaStream: await mediaDevices.getUserMedia({ audio: baseConstraints, video: false }),
+        unavailableDeviceId: null,
+      };
     }
 
     try {
-      return await mediaDevices.getUserMedia({
-        audio: { ...baseConstraints, deviceId: { exact: audioInputDeviceId } },
-        video: false,
-      });
+      return {
+        mediaStream: await mediaDevices.getUserMedia({
+          audio: { ...baseConstraints, deviceId: { exact: audioInputDeviceId } },
+          video: false,
+        }),
+        unavailableDeviceId: null,
+      };
     } catch (error) {
       if (!isDeviceConstraintError(error)) {
         throw error;
@@ -159,18 +177,21 @@ export class AudioCaptureStream {
         audio: baseConstraints,
         video: false,
       });
-      try {
-        await this.options.onDeviceFallback?.(audioInputDeviceId);
-      } catch (callbackError) {
-        // Settings repair is secondary to capture. The default device is open,
-        // so keep dictation usable even if persisting the fallback failed.
-        this.options.logger?.warn(
-          'audio',
-          'microphone fallback handler failed; continuing with the default input device',
-          callbackError,
-        );
-      }
-      return mediaStream;
+      return { mediaStream, unavailableDeviceId: audioInputDeviceId };
+    }
+  }
+
+  private async handleDeviceFallback(unavailableDeviceId: string): Promise<void> {
+    try {
+      await this.options.onDeviceFallback?.(unavailableDeviceId);
+    } catch (callbackError) {
+      // Settings repair is secondary to capture. It runs only after the stream
+      // is owned, so failure or indefinite delay cannot block capture teardown.
+      this.options.logger?.warn(
+        'audio',
+        'microphone fallback handler failed; continuing with the default input device',
+        callbackError,
+      );
     }
   }
 

--- a/src/audio/audio-capture-stream.ts
+++ b/src/audio/audio-capture-stream.ts
@@ -9,9 +9,9 @@ type AudioFrameListener = (sessionId: string, frameBytes: Uint8Array) => void;
 interface AudioCaptureStreamOptions {
   logger?: PluginLogger;
   // Invoked when a saved deviceId is unavailable and we transparently fall back
-  // to the OS default. Lets the wiring layer (main.ts) surface a Notice without
-  // pulling Obsidian UI imports into this module.
-  onDeviceFallback?: () => void;
+  // to the OS default. The attempted id lets the settings layer avoid clearing
+  // a newer selection if the user changed it while capture was starting.
+  onDeviceFallback?: (unavailableDeviceId: string) => Promise<void> | void;
   // A track can end while its MediaStream still exists (for example, when a
   // USB microphone is unplugged). Include the session id so a late event from
   // an old track cannot stop a newer capture.
@@ -159,7 +159,17 @@ export class AudioCaptureStream {
         audio: baseConstraints,
         video: false,
       });
-      this.options.onDeviceFallback?.();
+      try {
+        await this.options.onDeviceFallback?.(audioInputDeviceId);
+      } catch (callbackError) {
+        // Settings repair is secondary to capture. The default device is open,
+        // so keep dictation usable even if persisting the fallback failed.
+        this.options.logger?.warn(
+          'audio',
+          'microphone fallback handler failed; continuing with the default input device',
+          callbackError,
+        );
+      }
       return mediaStream;
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import { ModelInstallManager } from './models/model-install-manager';
 import { Session } from './session/session';
 import { logAccelerationFallbacks } from './settings/acceleration-info';
 import { LlmPresetStateStore } from './settings/llm-preset-state';
+import { handleMicrophoneDeviceFallback } from './settings/microphone-fallback';
 import { getOpenRouterApiKey, loadPluginSettings } from './settings/openrouter-secret-storage';
 import {
   DEFAULT_PLUGIN_SETTINGS,
@@ -105,11 +106,14 @@ export default class LocalSttPlugin extends Plugin {
     this.audioLevelMeter = new SidecarAudioLevelMeter();
     this.audioCaptureStream = new AudioCaptureStream({
       logger: this.logger,
-      onDeviceFallback: () => {
-        this.feedback.show({
-          intent: 'warning',
-          key: 'microphone-device-fallback',
-          message: 'Saved microphone unavailable. Using the default input device.',
+      onDeviceFallback: async (unavailableDeviceId) => {
+        await handleMicrophoneDeviceFallback(unavailableDeviceId, {
+          clearSelectionIfMatches: async (deviceId) =>
+            this.requirePresetStateStore().commitPreservingPresetStateIf(
+              (settings) => settings.audioInputDevice?.deviceId === deviceId,
+              (settings) => ({ ...settings, audioInputDevice: null }),
+            ),
+          feedback: this.feedback,
         });
       },
       onUnexpectedEnd: (sessionId) => {

--- a/src/settings/llm-preset-state.ts
+++ b/src/settings/llm-preset-state.ts
@@ -99,7 +99,28 @@ export class LlmPresetStateStore {
     });
   }
 
-  private enqueue(operation: () => Promise<void>): Promise<void> {
+  commitPreservingPresetStateIf(
+    condition: (settings: Readonly<PluginSettings>) => boolean,
+    createNextSettings: (settings: Readonly<PluginSettings>) => PluginSettings,
+  ): Promise<boolean> {
+    return this.enqueue(async () => {
+      const currentSettings = this.dependencies.getSettings();
+      if (!condition(currentSettings)) {
+        return false;
+      }
+
+      await this.dependencies.commit(
+        withLlmPresetState(
+          createNextSettings(currentSettings),
+          readLlmPresetState(currentSettings),
+        ),
+        { persist: true },
+      );
+      return true;
+    });
+  }
+
+  private enqueue<T>(operation: () => Promise<T>): Promise<T> {
     const result = this.operationTail.then(operation, operation);
     this.operationTail = result.then(
       () => undefined,

--- a/src/settings/microphone-fallback.ts
+++ b/src/settings/microphone-fallback.ts
@@ -1,0 +1,43 @@
+import type { UserFeedback } from '../shared/user-feedback';
+
+interface MicrophoneFallbackDependencies {
+  clearSelectionIfMatches: (unavailableDeviceId: string) => Promise<boolean>;
+  feedback: Pick<UserFeedback, 'show'>;
+}
+
+export async function handleMicrophoneDeviceFallback(
+  unavailableDeviceId: string,
+  dependencies: MicrophoneFallbackDependencies,
+): Promise<void> {
+  let cleared: boolean;
+
+  try {
+    cleared = await dependencies.clearSelectionIfMatches(unavailableDeviceId);
+  } catch (error) {
+    dependencies.feedback.show({
+      cause: error,
+      intent: 'warning',
+      key: 'microphone-device-fallback',
+      message:
+        'Saved microphone unavailable. Using the default microphone, but this change could not be saved. Select an available microphone in Settings before restarting Obsidian.',
+    });
+    return;
+  }
+
+  if (!cleared) {
+    dependencies.feedback.show({
+      intent: 'warning',
+      key: 'microphone-device-fallback',
+      message:
+        'Saved microphone unavailable. Using the default microphone for this session; the current microphone setting was left unchanged.',
+    });
+    return;
+  }
+
+  dependencies.feedback.show({
+    intent: 'warning',
+    key: 'microphone-device-fallback',
+    message:
+      'Saved microphone unavailable. Using the default microphone; the saved selection was cleared for future sessions.',
+  });
+}

--- a/test/audio-device-fallback.test.ts
+++ b/test/audio-device-fallback.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/audio/pcm-recorder-worklet-source', () => ({
+  PCM_RECORDER_WORKLET_SOURCE: 'registerProcessor("pcm-recorder", class {});',
+}));
+
+import { AudioCaptureStream } from '../src/audio/audio-capture-stream';
+
+class FakeAudioNode {
+  readonly connect = vi.fn();
+  readonly disconnect = vi.fn();
+}
+
+class FakeGainNode extends FakeAudioNode {
+  readonly gain = { value: 1 };
+}
+
+class FakeAudioContext {
+  readonly audioWorklet = { addModule: vi.fn(async (_url: string) => {}) };
+  readonly destination = new FakeAudioNode();
+  readonly close = vi.fn(async () => {
+    this.state = 'closed';
+  });
+  readonly createGain = vi.fn(() => new FakeGainNode());
+  readonly createMediaStreamSource = vi.fn((_stream: MediaStream) => new FakeAudioNode());
+  readonly resume = vi.fn(async () => {});
+  state: AudioContextState = 'running';
+}
+
+class FakeAudioWorkletNode extends FakeAudioNode {
+  readonly port = { onmessage: null as ((event: MessageEvent<ArrayBuffer>) => void) | null };
+}
+
+function createMediaStream(): MediaStream {
+  return { getTracks: () => [] } as unknown as MediaStream;
+}
+
+function createUnavailableDeviceError(): Error {
+  return Object.assign(new Error('deviceId does not match an available input'), {
+    constraint: 'deviceId',
+    name: 'OverconstrainedError',
+  });
+}
+
+describe('audio device fallback', () => {
+  beforeEach(() => {
+    vi.stubGlobal('AudioContext', FakeAudioContext);
+    vi.stubGlobal('AudioWorkletNode', FakeAudioWorkletNode);
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:recorder-worklet');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('reports the unavailable device and waits for settings repair after default capture opens', async () => {
+    const defaultStream = createMediaStream();
+    let openDefaultMicrophone: ((stream: MediaStream) => void) | undefined;
+    const getUserMedia = vi
+      .fn()
+      .mockRejectedValueOnce(createUnavailableDeviceError())
+      .mockImplementationOnce(
+        () =>
+          new Promise<MediaStream>((resolve) => {
+            openDefaultMicrophone = resolve;
+          }),
+      );
+    vi.stubGlobal('navigator', { mediaDevices: { getUserMedia } });
+    const repairControl: { finish?: () => void } = {};
+    const onDeviceFallback = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          repairControl.finish = resolve;
+        }),
+    );
+    const capture = new AudioCaptureStream({ onDeviceFallback });
+
+    let startSettled = false;
+    const start = capture
+      .start({ audioInputDeviceId: 'missing-device', sessionId: 'session-a' }, vi.fn())
+      .then(() => {
+        startSettled = true;
+      });
+    await vi.waitFor(() => {
+      expect(getUserMedia).toHaveBeenCalledTimes(2);
+    });
+
+    expect(onDeviceFallback).not.toHaveBeenCalled();
+    expect(startSettled).toBe(false);
+    expect(getUserMedia).toHaveBeenNthCalledWith(1, {
+      audio: expect.objectContaining({ deviceId: { exact: 'missing-device' } }),
+      video: false,
+    });
+    expect(getUserMedia).toHaveBeenNthCalledWith(2, {
+      audio: expect.not.objectContaining({ deviceId: expect.anything() }),
+      video: false,
+    });
+
+    openDefaultMicrophone?.(defaultStream);
+    await vi.waitFor(() => {
+      expect(onDeviceFallback).toHaveBeenCalledWith('missing-device');
+    });
+
+    const finishRepair = repairControl.finish;
+    if (finishRepair === undefined) {
+      throw new Error('fallback repair did not start');
+    }
+    finishRepair();
+    await start;
+    expect(capture.isCapturing()).toBe(true);
+  });
+
+  it('does not announce fallback when opening the default microphone also fails', async () => {
+    const fallbackError = Object.assign(new Error('permission denied'), {
+      name: 'NotAllowedError',
+    });
+    const getUserMedia = vi
+      .fn()
+      .mockRejectedValueOnce(createUnavailableDeviceError())
+      .mockRejectedValueOnce(fallbackError);
+    vi.stubGlobal('navigator', { mediaDevices: { getUserMedia } });
+    const onDeviceFallback = vi.fn();
+    const capture = new AudioCaptureStream({ onDeviceFallback });
+
+    await expect(
+      capture.start({ audioInputDeviceId: 'missing-device', sessionId: 'session-a' }, vi.fn()),
+    ).rejects.toBe(fallbackError);
+    expect(onDeviceFallback).not.toHaveBeenCalled();
+    expect(capture.isCapturing()).toBe(false);
+  });
+
+  it.each([
+    [
+      'a different unsatisfied constraint',
+      Object.assign(new Error('channel count unavailable'), {
+        constraint: 'channelCount',
+        name: 'OverconstrainedError',
+      }),
+    ],
+    [
+      'a non-constraint capture error',
+      Object.assign(new Error('microphone is busy'), {
+        name: 'NotReadableError',
+      }),
+    ],
+  ])('does not fall back for %s', async (_description, captureError) => {
+    const getUserMedia = vi.fn().mockRejectedValueOnce(captureError);
+    vi.stubGlobal('navigator', { mediaDevices: { getUserMedia } });
+    const onDeviceFallback = vi.fn();
+    const capture = new AudioCaptureStream({ onDeviceFallback });
+
+    await expect(
+      capture.start({ audioInputDeviceId: 'saved-device', sessionId: 'session-a' }, vi.fn()),
+    ).rejects.toBe(captureError);
+
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+    expect(onDeviceFallback).not.toHaveBeenCalled();
+    expect(capture.isCapturing()).toBe(false);
+  });
+
+  it('continues default capture when the fallback callback rejects', async () => {
+    const callbackError = new Error('settings persistence failed');
+    const getUserMedia = vi
+      .fn()
+      .mockRejectedValueOnce(createUnavailableDeviceError())
+      .mockResolvedValueOnce(createMediaStream());
+    vi.stubGlobal('navigator', { mediaDevices: { getUserMedia } });
+    const logger = { debug: vi.fn(), error: vi.fn(), warn: vi.fn() };
+    const capture = new AudioCaptureStream({
+      logger,
+      onDeviceFallback: vi.fn(async () => {
+        throw callbackError;
+      }),
+    });
+
+    await capture.start({ audioInputDeviceId: 'missing-device', sessionId: 'session-a' }, vi.fn());
+
+    expect(capture.isCapturing()).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'audio',
+      'microphone fallback handler failed; continuing with the default input device',
+      callbackError,
+    );
+  });
+});

--- a/test/audio-device-fallback.test.ts
+++ b/test/audio-device-fallback.test.ts
@@ -32,7 +32,7 @@ class FakeAudioWorkletNode extends FakeAudioNode {
 }
 
 function createMediaStream(tracks: MediaStreamTrack[] = []): MediaStream {
-  return { getTracks: () => tracks } as unknown as MediaStream;
+  return { getAudioTracks: () => [], getTracks: () => tracks } as unknown as MediaStream;
 }
 
 function createUnavailableDeviceError(): Error {

--- a/test/audio-device-fallback.test.ts
+++ b/test/audio-device-fallback.test.ts
@@ -31,8 +31,8 @@ class FakeAudioWorkletNode extends FakeAudioNode {
   readonly port = { onmessage: null as ((event: MessageEvent<ArrayBuffer>) => void) | null };
 }
 
-function createMediaStream(): MediaStream {
-  return { getTracks: () => [] } as unknown as MediaStream;
+function createMediaStream(tracks: MediaStreamTrack[] = []): MediaStream {
+  return { getTracks: () => tracks } as unknown as MediaStream;
 }
 
 function createUnavailableDeviceError(): Error {
@@ -55,7 +55,7 @@ describe('audio device fallback', () => {
     vi.unstubAllGlobals();
   });
 
-  it('reports the unavailable device and waits for settings repair after default capture opens', async () => {
+  it('starts capture without waiting for fallback settings repair', async () => {
     const defaultStream = createMediaStream();
     let openDefaultMicrophone: ((stream: MediaStream) => void) | undefined;
     const getUserMedia = vi
@@ -102,6 +102,11 @@ describe('audio device fallback', () => {
     await vi.waitFor(() => {
       expect(onDeviceFallback).toHaveBeenCalledWith('missing-device');
     });
+    await vi.waitFor(() => {
+      expect(startSettled).toBe(true);
+    });
+
+    expect(capture.isCapturing()).toBe(true);
 
     const finishRepair = repairControl.finish;
     if (finishRepair === undefined) {
@@ -109,7 +114,28 @@ describe('audio device fallback', () => {
     }
     finishRepair();
     await start;
+    await capture.stop();
+  });
+
+  it('stops fallback media while settings repair remains pending', async () => {
+    const stopTrack = vi.fn();
+    const defaultStream = createMediaStream([{ stop: stopTrack } as unknown as MediaStreamTrack]);
+    const getUserMedia = vi
+      .fn()
+      .mockRejectedValueOnce(createUnavailableDeviceError())
+      .mockResolvedValueOnce(defaultStream);
+    vi.stubGlobal('navigator', { mediaDevices: { getUserMedia } });
+    const onDeviceFallback = vi.fn(() => new Promise<void>(() => {}));
+    const capture = new AudioCaptureStream({ onDeviceFallback });
+
+    await capture.start({ audioInputDeviceId: 'missing-device', sessionId: 'session-a' }, vi.fn());
+    expect(onDeviceFallback).toHaveBeenCalledWith('missing-device');
     expect(capture.isCapturing()).toBe(true);
+
+    await capture.stop();
+
+    expect(stopTrack).toHaveBeenCalledOnce();
+    expect(capture.isCapturing()).toBe(false);
   });
 
   it('does not announce fallback when opening the default microphone also fails', async () => {
@@ -178,10 +204,12 @@ describe('audio device fallback', () => {
     await capture.start({ audioInputDeviceId: 'missing-device', sessionId: 'session-a' }, vi.fn());
 
     expect(capture.isCapturing()).toBe(true);
-    expect(logger.warn).toHaveBeenCalledWith(
-      'audio',
-      'microphone fallback handler failed; continuing with the default input device',
-      callbackError,
-    );
+    await vi.waitFor(() => {
+      expect(logger.warn).toHaveBeenCalledWith(
+        'audio',
+        'microphone fallback handler failed; continuing with the default input device',
+        callbackError,
+      );
+    });
   });
 });

--- a/test/llm-preset-state.test.ts
+++ b/test/llm-preset-state.test.ts
@@ -13,10 +13,15 @@ function settings(overrides: Partial<PluginSettings> = {}): PluginSettings {
   return { ...DEFAULT_PLUGIN_SETTINGS, ...overrides };
 }
 
-function createStore(args: { current?: PluginSettings; loadData?: () => Promise<unknown> }) {
+function createStore(args: {
+  current?: PluginSettings;
+  loadData?: () => Promise<unknown>;
+  onCommit?: (settings: PluginSettings) => Promise<void>;
+}) {
   let current = args.current ?? settings();
   const commit = vi.fn(async (next: PluginSettings) => {
     current = next;
+    await args.onCommit?.(next);
   });
   const onExternalChange = vi.fn();
   const warn = vi.fn();
@@ -347,5 +352,136 @@ describe('LlmPresetStateStore.mutate', () => {
       userPresets: [externalPreset],
     });
     expect(fixture.commit).toHaveBeenLastCalledWith(expect.any(Object), { persist: true });
+  });
+});
+
+describe('LlmPresetStateStore.commitPreservingPresetStateIf', () => {
+  it('commits when the condition matches and preserves preset state', async () => {
+    const preset = createUserPreset({ id: 'keep' });
+    const fixture = createStore({
+      current: settings({
+        audioInputDevice: { deviceId: 'missing-device', label: 'Desk microphone' },
+        llmPostprocessActivePresetRef: 'user:keep',
+        llmPostprocessUserPresets: [preset],
+      }),
+    });
+
+    const updated = await fixture.store.commitPreservingPresetStateIf(
+      (current) => current.audioInputDevice?.deviceId === 'missing-device',
+      (current) => ({
+        ...current,
+        audioInputDevice: null,
+        llmPostprocessActivePresetRef: 'builtin:clean-up',
+        llmPostprocessUserPresets: [],
+      }),
+    );
+
+    expect(updated).toBe(true);
+    expect(fixture.getCurrent().audioInputDevice).toBeNull();
+    expect(readLlmPresetState(fixture.getCurrent())).toEqual({
+      activePresetRef: 'user:keep',
+      userPresets: [preset],
+    });
+  });
+
+  it('evaluates the condition after earlier queued settings changes', async () => {
+    const fixture = createStore({
+      current: settings({
+        audioInputDevice: { deviceId: 'missing-device', label: 'Desk microphone' },
+      }),
+    });
+    const selectNewMicrophone = fixture.store.commitPreservingPresetState(
+      settings({
+        audioInputDevice: { deviceId: 'new-device', label: 'Headset microphone' },
+      }),
+    );
+    const clearUnavailableMicrophone = fixture.store.commitPreservingPresetStateIf(
+      (current) => current.audioInputDevice?.deviceId === 'missing-device',
+      (current) => ({ ...current, audioInputDevice: null }),
+    );
+
+    await selectNewMicrophone;
+    await expect(clearUnavailableMicrophone).resolves.toBe(false);
+    expect(fixture.getCurrent().audioInputDevice).toEqual({
+      deviceId: 'new-device',
+      label: 'Headset microphone',
+    });
+    expect(fixture.commit).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a newer selection queued while the conditional commit is in flight', async () => {
+    let finishPersistence: (() => void) | undefined;
+    let commitCount = 0;
+    const fixture = createStore({
+      current: settings({
+        audioInputDevice: { deviceId: 'missing-device', label: 'Desk microphone' },
+      }),
+      onCommit: () => {
+        commitCount += 1;
+        if (commitCount > 1) {
+          return Promise.resolve();
+        }
+        return new Promise<void>((resolve) => {
+          finishPersistence = resolve;
+        });
+      },
+    });
+
+    const clearUnavailableMicrophone = fixture.store.commitPreservingPresetStateIf(
+      (current) => current.audioInputDevice?.deviceId === 'missing-device',
+      (current) => ({ ...current, audioInputDevice: null }),
+    );
+    await vi.waitFor(() => {
+      expect(fixture.commit).toHaveBeenCalledTimes(1);
+    });
+    const selectNewMicrophone = fixture.store.commitPreservingPresetState(
+      settings({
+        audioInputDevice: { deviceId: 'new-device', label: 'Headset microphone' },
+      }),
+    );
+
+    finishPersistence?.();
+    await expect(clearUnavailableMicrophone).resolves.toBe(true);
+    await selectNewMicrophone;
+
+    expect(fixture.getCurrent().audioInputDevice).toEqual({
+      deviceId: 'new-device',
+      label: 'Headset microphone',
+    });
+    expect(fixture.commit).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects a failed conditional save without blocking later settings commits', async () => {
+    const persistenceError = new Error('data.json is read-only');
+    let commitCount = 0;
+    const fixture = createStore({
+      current: settings({
+        audioInputDevice: { deviceId: 'missing-device', label: 'Desk microphone' },
+      }),
+      onCommit: async () => {
+        commitCount += 1;
+        if (commitCount === 1) {
+          throw persistenceError;
+        }
+      },
+    });
+
+    await expect(
+      fixture.store.commitPreservingPresetStateIf(
+        (current) => current.audioInputDevice?.deviceId === 'missing-device',
+        (current) => ({ ...current, audioInputDevice: null }),
+      ),
+    ).rejects.toBe(persistenceError);
+    await fixture.store.commitPreservingPresetState(
+      settings({
+        audioInputDevice: { deviceId: 'new-device', label: 'Headset microphone' },
+      }),
+    );
+
+    expect(fixture.getCurrent().audioInputDevice).toEqual({
+      deviceId: 'new-device',
+      label: 'Headset microphone',
+    });
+    expect(fixture.commit).toHaveBeenCalledTimes(2);
   });
 });

--- a/test/microphone-fallback.test.ts
+++ b/test/microphone-fallback.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { handleMicrophoneDeviceFallback } from '../src/settings/microphone-fallback';
+import { DEFAULT_PLUGIN_SETTINGS, type PluginSettings } from '../src/settings/plugin-settings';
+
+describe('microphone device fallback', () => {
+  it('persists the default microphone when the unavailable device is still selected', async () => {
+    let settings: PluginSettings = {
+      ...DEFAULT_PLUGIN_SETTINGS,
+      audioInputDevice: { deviceId: 'missing-device', label: 'Desk microphone' },
+    };
+    const show = vi.fn();
+    const clearSelectionIfMatches = vi.fn(async (deviceId: string) => {
+      if (settings.audioInputDevice?.deviceId !== deviceId) {
+        return false;
+      }
+      settings = { ...settings, audioInputDevice: null };
+      return true;
+    });
+
+    await handleMicrophoneDeviceFallback('missing-device', {
+      clearSelectionIfMatches,
+      feedback: { show },
+    });
+
+    expect(clearSelectionIfMatches).toHaveBeenCalledWith('missing-device');
+    expect(settings.audioInputDevice).toBeNull();
+    expect(show).toHaveBeenCalledWith({
+      intent: 'warning',
+      key: 'microphone-device-fallback',
+      message:
+        'Saved microphone unavailable. Using the default microphone; the saved selection was cleared for future sessions.',
+    });
+  });
+
+  it('reports an unchanged setting when the conditional clear is skipped', async () => {
+    const show = vi.fn();
+    const clearSelectionIfMatches = vi.fn(async () => false);
+
+    await handleMicrophoneDeviceFallback('old-device', {
+      clearSelectionIfMatches,
+      feedback: { show },
+    });
+
+    expect(clearSelectionIfMatches).toHaveBeenCalledWith('old-device');
+    expect(show).toHaveBeenCalledWith({
+      intent: 'warning',
+      key: 'microphone-device-fallback',
+      message:
+        'Saved microphone unavailable. Using the default microphone for this session; the current microphone setting was left unchanged.',
+    });
+  });
+
+  it('reports persistence failure without rejecting the fallback handler', async () => {
+    const error = new Error('data.json is read-only');
+    const show = vi.fn();
+
+    await expect(
+      handleMicrophoneDeviceFallback('missing-device', {
+        clearSelectionIfMatches: vi.fn(async () => {
+          throw error;
+        }),
+        feedback: { show },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(show).toHaveBeenCalledWith({
+      cause: error,
+      intent: 'warning',
+      key: 'microphone-device-fallback',
+      message:
+        'Saved microphone unavailable. Using the default microphone, but this change could not be saved. Select an available microphone in Settings before restarting Obsidian.',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Retry an unavailable exact saved microphone on the OS default only for a `deviceId` `OverconstrainedError`.
- Clear the saved selection through a queued conditional commit only when the attempted device is still current, preserving concurrent selections and LLM preset state.
- Keep default-device capture usable when settings persistence fails and show outcome-specific feedback.

## Scope
This is independent of #231: this PR repairs a stale saved device at session startup, while #231 handles a microphone disconnecting during an active session.

## Testing
- `npm run check`
- `npm test -- --run test/audio-device-fallback.test.ts test/microphone-fallback.test.ts test/llm-preset-state.test.ts`