### PR TITLE
feat: re-dictate a selected text range

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ _The first-run wizard installs the native engine and helps you choose between li
 
 All transcription models in the current catalog run locally and support English. Moonshine is optimized for live dictation; speaker labels currently require a batch model.
 
+Selection re-dictation applies active replace-style AI cleanup. Presets that add summaries or action items above or below a transcript are skipped because this workflow has only the selected replacement target.
+
 ## Features
 
 - **Live text.** Moonshine streaming models show provisional words and revise them in place until each utterance finalizes.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ _The first-run wizard installs the native engine and helps you choose between li
 | Workflow | What happens | Model fit |
 | --- | --- | --- |
 | **Live dictation** | Provisional words appear and revise in place while you speak. | Moonshine streaming models |
+| **Selection re-dictation** | Select text and speak a replacement; the original stays untouched until the first final transcript is ready. | Any transcription model |
 | **Notes and drafts** | Final text lands at your cursor after each pause. | Whisper or Cohere Transcribe batch models |
 | **Meetings and calls** | Add computer audio to microphone capture, then optionally label speakers and add timestamps. | Whisper or Cohere Transcribe batch models |
 
@@ -37,6 +38,7 @@ All transcription models in the current catalog run locally and support English.
 ## Features
 
 - **Live text.** Moonshine streaming models show provisional words and revise them in place until each utterance finalizes.
+- **Selection re-dictation.** Select one text range and run **Local Dictation: Re-dictate selection** to replace it with a single spoken utterance.
 - **Meeting capture.** Include system audio from meetings, calls, or videos alongside your microphone on Windows, Linux, and macOS 14.2 or later.
 - **Speaker labels.** Optional on-device diarization assigns session-stable speaker labels. Speaker embeddings stay in memory and are discarded after the session.
 - **Timestamps.** Add elapsed or wall-clock timestamps at configurable intervals.

--- a/src/commands/register-commands.ts
+++ b/src/commands/register-commands.ts
@@ -10,6 +10,7 @@ interface CommandDependencies {
   cancelDictation: () => Promise<void>;
   canRedictateSelection: (editor: Editor, file: TFile | null) => boolean;
   checkSidecarHealth: () => Promise<void>;
+  onSelectionRedictationError: (error: unknown) => void;
   plugin: Plugin;
   restartSidecar: () => Promise<void>;
   startSelectionRedictation: (editor: Editor, file: TFile | null) => Promise<void>;
@@ -59,7 +60,9 @@ export function registerCommands(dependencies: CommandDependencies): void {
         return false;
       }
       if (!checking) {
-        void dependencies.startSelectionRedictation(editor, context.file);
+        void dependencies
+          .startSelectionRedictation(editor, context.file)
+          .catch(dependencies.onSelectionRedictationError);
       }
       return true;
     },

--- a/src/commands/register-commands.ts
+++ b/src/commands/register-commands.ts
@@ -1,15 +1,18 @@
-import type { Plugin } from 'obsidian';
+import type { Editor, Plugin, TFile } from 'obsidian';
 
 const START_DICTATION_COMMAND_ID = 'start-dictation-session';
 const STOP_DICTATION_COMMAND_ID = 'stop-dictation-session';
 const CANCEL_DICTATION_COMMAND_ID = 'cancel-dictation-session';
 const TOGGLE_DICTATION_COMMAND_ID = 'toggle-dictation-session';
+const REDICTATE_SELECTION_COMMAND_ID = 'redictate-selection';
 
 interface CommandDependencies {
   cancelDictation: () => Promise<void>;
+  canRedictateSelection: (editor: Editor, file: TFile | null) => boolean;
   checkSidecarHealth: () => Promise<void>;
   plugin: Plugin;
   restartSidecar: () => Promise<void>;
+  startSelectionRedictation: (editor: Editor, file: TFile | null) => Promise<void>;
   startDictation: () => Promise<void>;
   stopDictation: () => Promise<void>;
   toggleDictation: () => Promise<void>;
@@ -45,6 +48,20 @@ export function registerCommands(dependencies: CommandDependencies): void {
     name: 'Cancel dictation',
     callback: async () => {
       await dependencies.cancelDictation();
+    },
+  });
+
+  dependencies.plugin.addCommand({
+    id: REDICTATE_SELECTION_COMMAND_ID,
+    name: 'Re-dictate selection',
+    editorCheckCallback: (checking, editor, context) => {
+      if (!dependencies.canRedictateSelection(editor, context.file)) {
+        return false;
+      }
+      if (!checking) {
+        void dependencies.startSelectionRedictation(editor, context.file);
+      }
+      return true;
     },
   });
 

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -98,6 +98,9 @@ type SessionPhase = 'starting' | 'active' | 'stopping' | 'cancelling' | 'stopped
 // Stable across sidecar lifecycle acknowledgements. Terminal causes claim the
 // feedback slot, while cancellation also permanently rejects transcript work.
 type TerminalArbitrationState = 'open' | 'feedback-claimed' | 'cancelled';
+type ManagedSessionMode =
+  | { kind: 'dictation' }
+  | { finalClaimed: boolean; kind: 'selection_redictation' };
 
 interface ManagedSession {
   anchorTimerId: number | null;
@@ -106,8 +109,7 @@ interface ManagedSession {
   cleanupChain: Promise<void>;
   cleanupAbortControllers: Set<AbortController>;
   llmFailureLogged: boolean;
-  oneUtteranceFinalClaimed: boolean;
-  oneUtteranceMode: boolean;
+  mode: ManagedSessionMode;
   pendingTranscriptWork: Set<Promise<void>>;
   phase: SessionPhase;
   session: ControllerSession;
@@ -136,6 +138,7 @@ interface DictationSessionControllerDependencies {
   createLlmRouter: (settings: PluginSettings) => LlmRouter;
   feedback: Pick<UserFeedback, 'show'>;
   getSettings: () => PluginSettings;
+  isSelectionRedictationSnapshotCurrent: (selection: SelectionRedictationSnapshot) => boolean;
   logger?: PluginLogger;
   onLlmCleanupFailure?: (failure: LlmCleanupFailure) => void;
   onLlmCleanupSuccess?: () => void;
@@ -323,6 +326,20 @@ export class DictationSessionController {
       return;
     }
 
+    if (
+      request.kind === 'selection_redictation' &&
+      !this.dependencies.isSelectionRedictationSnapshotCurrent(request.selection)
+    ) {
+      this.applyUiState('idle');
+      this.dependencies.feedback.show({
+        intent: 'warning',
+        key: 'selection-redictation-start-stale',
+        message:
+          'Re-dictation did not start because the selected note changed or closed. No audio was captured. Select the text again and retry.',
+      });
+      return;
+    }
+
     const sessionId = createSessionId();
     const baseSnapshot = createSessionSnapshot(
       settings,
@@ -331,7 +348,7 @@ export class DictationSessionController {
     );
     const snapshot =
       request.kind === 'selection_redictation'
-        ? applySelectionRedictationCleanupPolicy(baseSnapshot)
+        ? applySelectionRedictationPolicy(baseSnapshot)
         : baseSnapshot;
     let session: ControllerSession;
 
@@ -378,8 +395,10 @@ export class DictationSessionController {
       cleanupChain: Promise.resolve(),
       cleanupAbortControllers: new Set(),
       llmFailureLogged: false,
-      oneUtteranceFinalClaimed: false,
-      oneUtteranceMode: request.kind === 'selection_redictation',
+      mode:
+        request.kind === 'selection_redictation'
+          ? { finalClaimed: false, kind: 'selection_redictation' }
+          : { kind: 'dictation' },
       pendingTranscriptWork: new Set(),
       phase: 'starting',
       session,
@@ -822,12 +841,12 @@ export class DictationSessionController {
     entry: ManagedSession,
     event: TranscriptReadyEvent,
   ): Promise<void> {
-    if (entry.oneUtteranceMode) {
-      if (entry.oneUtteranceFinalClaimed) {
+    if (entry.mode.kind === 'selection_redictation') {
+      if (entry.mode.finalClaimed) {
         return;
       }
       if (event.isFinal) {
-        entry.oneUtteranceFinalClaimed = true;
+        entry.mode.finalClaimed = true;
         if (this.activeSessionId === event.sessionId) {
           await this.requestSessionStop(event.sessionId, entry);
           if (!this.sessions.has(event.sessionId)) {
@@ -1596,21 +1615,25 @@ function createSessionSnapshot(
   };
 }
 
-function applySelectionRedictationCleanupPolicy(
-  snapshot: ActiveSessionSnapshot,
-): ActiveSessionSnapshot {
+function applySelectionRedictationPolicy(snapshot: ActiveSessionSnapshot): ActiveSessionSnapshot {
   // The selection surface has exactly one atomic replacement target. Batch
   // rewrites can run on its single final; additive output has no safe target
-  // and must not invoke a provider as an implicit side effect.
-  if (snapshot.llmPostprocessOutput !== 'replace') {
-    return { ...snapshot, llmPostprocessMode: 'off' };
-  }
+  // and must not invoke a provider as an implicit side effect. Capture is
+  // microphone-only because mixed system audio could claim the first final;
+  // diarization has no meaningful single-source output in this workflow.
+  const llmPostprocessMode =
+    snapshot.llmPostprocessOutput !== 'replace'
+      ? 'off'
+      : snapshot.llmPostprocessMode === 'batch'
+        ? 'per_utterance'
+        : snapshot.llmPostprocessMode;
 
-  if (snapshot.llmPostprocessMode === 'batch') {
-    return { ...snapshot, llmPostprocessMode: 'per_utterance' };
-  }
-
-  return snapshot;
+  return {
+    ...snapshot,
+    diarizationEnabled: false,
+    includeSystemAudio: false,
+    llmPostprocessMode,
+  };
 }
 
 function shouldRunBatchCleanup(

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -9,7 +9,8 @@ import {
   formatSystemAudioErrorMessage,
   formatSystemAudioSidecarErrorMessage,
 } from '../audio/system-audio-permission-message';
-import type { NotePlacementOptions, SurfaceDesynchronization } from '../editor/note-surface';
+import type { NotePlacementOptions } from '../editor/note-surface';
+import type { SelectionRedictationSnapshot } from '../editor/selection-redictation';
 import {
   type LlmPostprocessMode,
   type LlmPresetOutput,
@@ -18,7 +19,7 @@ import {
 } from '../llm/presets';
 import { type LlmCleanupFailure, type LlmProviderId, ProviderError } from '../llm/provider';
 import type { LlmRouter } from '../llm/router';
-import type { Session, SessionAcceptResult } from '../session/session';
+import type { Session, SessionAcceptResult, SessionLifecycleCallbacks } from '../session/session';
 import type { StageId, StageOutcome, TranscriptRevision } from '../session/session-journal';
 import type { PluginSettings, SmartParagraphPauseSettings } from '../settings/plugin-settings';
 import { formatErrorMessage } from '../shared/format-utils';
@@ -64,7 +65,7 @@ type ControllerSession = Pick<
   | 'readPriorUtterances'
   | 'replaceSessionRangeWithCleaned'
   | 'setAnchorMode'
->;
+> & { onUserCancellation?: () => void };
 
 interface ActiveSessionSnapshot {
   accelerationPreference: PluginSettings['accelerationPreference'];
@@ -105,6 +106,8 @@ interface ManagedSession {
   cleanupChain: Promise<void>;
   cleanupAbortControllers: Set<AbortController>;
   llmFailureLogged: boolean;
+  oneUtteranceFinalClaimed: boolean;
+  oneUtteranceMode: boolean;
   pendingTranscriptWork: Set<Promise<void>>;
   phase: SessionPhase;
   session: ControllerSession;
@@ -120,13 +123,14 @@ interface DictationSessionControllerDependencies {
   audioLevelMeter: Pick<SidecarAudioLevelMeter, 'bindSession' | 'clearSession' | 'update'>;
   captureStream: Pick<AudioCaptureStream, 'isCapturing' | 'start' | 'stop'>;
   createSession: (options: {
-    callbacks: {
-      onLockedNoteClosed: () => void;
-      onLockedNoteDeleted: () => void;
-      onSurfaceDesynchronized: (failure: SurfaceDesynchronization) => void;
-    };
+    callbacks: SessionLifecycleCallbacks;
     placement: NotePlacementOptions;
     rendererOptions: TranscriptRenderOptions;
+    sessionId: string;
+  }) => ControllerSession;
+  createSelectionRedictationSession: (options: {
+    callbacks: SessionLifecycleCallbacks;
+    selection: SelectionRedictationSnapshot;
     sessionId: string;
   }) => ControllerSession;
   createLlmRouter: (settings: PluginSettings) => LlmRouter;
@@ -232,6 +236,7 @@ export class DictationSessionController {
       return;
     }
 
+    this.sessions.get(sessionId)?.session.onUserCancellation?.();
     await this.cancelSession(sessionId);
   }
 
@@ -272,6 +277,18 @@ export class DictationSessionController {
   }
 
   async startDictation(): Promise<void> {
+    await this.startSession({ kind: 'dictation' });
+  }
+
+  async startSelectionRedictation(selection: SelectionRedictationSnapshot): Promise<void> {
+    await this.startSession({ kind: 'selection_redictation', selection });
+  }
+
+  private async startSession(
+    request:
+      | { kind: 'dictation' }
+      | { kind: 'selection_redictation'; selection: SelectionRedictationSnapshot },
+  ): Promise<void> {
     if (this.activeSessionId !== null || this.sessions.size >= MAX_CONTROLLER_SESSIONS) {
       return;
     }
@@ -307,38 +324,50 @@ export class DictationSessionController {
     }
 
     const sessionId = createSessionId();
-    const snapshot = createSessionSnapshot(
+    const baseSnapshot = createSessionSnapshot(
       settings,
       settings.selectedModel,
       this.dependencies.createLlmRouter(settings),
     );
+    const snapshot =
+      request.kind === 'selection_redictation'
+        ? applySelectionRedictationCleanupPolicy(baseSnapshot)
+        : baseSnapshot;
     let session: ControllerSession;
 
     try {
-      session = this.dependencies.createSession({
-        callbacks: {
-          onLockedNoteClosed: () => {
-            this.cancelOnLockedNoteEvent(sessionId, 'closed');
-          },
-          onLockedNoteDeleted: () => {
-            this.cancelOnLockedNoteEvent(sessionId, 'deleted');
-          },
-          onSurfaceDesynchronized: (failure) => {
-            this.cancelOnFatalTranscriptFailure(
+      const callbacks: SessionLifecycleCallbacks = {
+        onLockedNoteClosed: () => {
+          this.cancelOnLockedNoteEvent(sessionId, 'closed');
+        },
+        onLockedNoteDeleted: () => {
+          this.cancelOnLockedNoteEvent(sessionId, 'deleted');
+        },
+        onSurfaceDesynchronized: (failure) => {
+          this.cancelOnFatalTranscriptFailure(
+            sessionId,
+            FEEDBACK_FAILURES.surfaceDesynchronized,
+            failure,
+          );
+        },
+      };
+      session =
+        request.kind === 'selection_redictation'
+          ? this.dependencies.createSelectionRedictationSession({
+              callbacks,
+              selection: request.selection,
               sessionId,
-              FEEDBACK_FAILURES.surfaceDesynchronized,
-              failure,
-            );
-          },
-        },
-        placement: { anchor: snapshot.dictationAnchor },
-        rendererOptions: {
-          smartParagraphPauses: snapshot.smartParagraphPauses,
-          timestamps: snapshot.timestamps,
-          transcriptFormatting: snapshot.transcriptFormatting,
-        },
-        sessionId,
-      });
+            })
+          : this.dependencies.createSession({
+              callbacks,
+              placement: { anchor: snapshot.dictationAnchor },
+              rendererOptions: {
+                smartParagraphPauses: snapshot.smartParagraphPauses,
+                timestamps: snapshot.timestamps,
+                transcriptFormatting: snapshot.transcriptFormatting,
+              },
+              sessionId,
+            });
     } catch (error) {
       this.handleError(FEEDBACK_FAILURES.startDictation, error);
       return;
@@ -349,6 +378,8 @@ export class DictationSessionController {
       cleanupChain: Promise.resolve(),
       cleanupAbortControllers: new Set(),
       llmFailureLogged: false,
+      oneUtteranceFinalClaimed: false,
+      oneUtteranceMode: request.kind === 'selection_redictation',
       pendingTranscriptWork: new Set(),
       phase: 'starting',
       session,
@@ -432,7 +463,13 @@ export class DictationSessionController {
       return;
     }
 
-    const entry = this.sessions.get(sessionId);
+    await this.requestSessionStop(sessionId, this.sessions.get(sessionId));
+  }
+
+  private async requestSessionStop(
+    sessionId: string,
+    entry: ManagedSession | undefined,
+  ): Promise<void> {
     if (entry !== undefined) {
       entry.phase = 'stopping';
       // Keep the cursor where text will land while queued transcripts drain.
@@ -785,6 +822,21 @@ export class DictationSessionController {
     entry: ManagedSession,
     event: TranscriptReadyEvent,
   ): Promise<void> {
+    if (entry.oneUtteranceMode) {
+      if (entry.oneUtteranceFinalClaimed) {
+        return;
+      }
+      if (event.isFinal) {
+        entry.oneUtteranceFinalClaimed = true;
+        if (this.activeSessionId === event.sessionId) {
+          await this.requestSessionStop(event.sessionId, entry);
+          if (!this.sessions.has(event.sessionId)) {
+            return;
+          }
+        }
+      }
+    }
+
     if (event.isFinal && event.text.length > 0) {
       this.dependencies.logger?.debug(
         'session',
@@ -1542,6 +1594,23 @@ function createSessionSnapshot(
     transcriptFormatting: settings.transcriptFormatting,
     useNoteAsContext: settings.useNoteAsContext,
   };
+}
+
+function applySelectionRedictationCleanupPolicy(
+  snapshot: ActiveSessionSnapshot,
+): ActiveSessionSnapshot {
+  // The selection surface has exactly one atomic replacement target. Batch
+  // rewrites can run on its single final; additive output has no safe target
+  // and must not invoke a provider as an implicit side effect.
+  if (snapshot.llmPostprocessOutput !== 'replace') {
+    return { ...snapshot, llmPostprocessMode: 'off' };
+  }
+
+  if (snapshot.llmPostprocessMode === 'batch') {
+    return { ...snapshot, llmPostprocessMode: 'per_utterance' };
+  }
+
+  return snapshot;
 }
 
 function shouldRunBatchCleanup(

--- a/src/editor/note-surface.ts
+++ b/src/editor/note-surface.ts
@@ -584,7 +584,7 @@ export class NoteSurface {
       return null;
     }
 
-    return buildGlossary(this.view.state.doc.toString(), maxChars);
+    return buildNoteGlossary(this.view.state.doc.toString(), maxChars);
   }
 
   readNoteText(maxChars: number): { text: string; truncated: boolean } | null {
@@ -868,7 +868,7 @@ function isAtSentenceStart(noteText: string, offset: number): boolean {
 // case-insensitively (first-seen casing wins) and bounded by `maxChars`.
 // Stops scanning at the first token that would overflow the budget, including
 // the terminal period.
-function buildGlossary(
+export function buildNoteGlossary(
   noteText: string,
   maxChars: number,
 ): { text: string; truncated: boolean } | null {

--- a/src/editor/selection-redictation.ts
+++ b/src/editor/selection-redictation.ts
@@ -9,10 +9,10 @@ import { buildNoteGlossary } from './note-surface';
 type SelectionEditor = Pick<Editor, 'getRange' | 'getValue' | 'listSelections' | 'transaction'>;
 
 export interface SelectionRedictationSnapshot {
+  readonly documentText: string;
   readonly editor: SelectionEditor;
   readonly file: TFile;
   readonly from: EditorPosition;
-  readonly originalText: string;
   readonly to: EditorPosition;
 }
 
@@ -66,21 +66,35 @@ export function captureSelectionRedictation(
     return { kind: 'empty_selection' };
   }
 
-  const originalText = editor.getRange(from, to);
-  if (originalText.length === 0) {
+  if (editor.getRange(from, to).length === 0) {
     return { kind: 'empty_selection' };
   }
 
   return {
     kind: 'captured',
     snapshot: {
+      documentText: editor.getValue(),
       editor,
       file,
       from: { ...from },
-      originalText,
       to: { ...to },
     },
   };
+}
+
+export function isSelectionRedictationSnapshotCurrent(
+  app: Pick<App, 'workspace'>,
+  snapshot: SelectionRedictationSnapshot,
+): boolean {
+  if (!isSelectionRedictationTargetOpen(app, snapshot)) {
+    return false;
+  }
+
+  try {
+    return snapshot.editor.getValue() === snapshot.documentText;
+  } catch {
+    return false;
+  }
 }
 
 export class SelectionRedictationSession {
@@ -202,18 +216,13 @@ export class SelectionRedictationSession {
       return;
     }
 
-    const { editor, from, originalText, to } = this.dependencies.snapshot;
+    const { editor, from, to } = this.dependencies.snapshot;
     if (!this.canReadTarget()) {
       this.reportStaleSelection();
       return;
     }
 
     try {
-      if (editor.getRange(from, to) !== originalText) {
-        this.reportStaleSelection();
-        return;
-      }
-
       editor.transaction(
         {
           changes: [{ from, text, to }],
@@ -237,15 +246,15 @@ export class SelectionRedictationSession {
   }
 
   private canReadTarget(): boolean {
-    return !this.disposed && !this.targetUnavailable && this.isTargetOpen();
+    return (
+      !this.disposed &&
+      !this.targetUnavailable &&
+      isSelectionRedictationSnapshotCurrent(this.dependencies.app, this.dependencies.snapshot)
+    );
   }
 
   private isTargetOpen(): boolean {
-    const { editor, file } = this.dependencies.snapshot;
-    return this.dependencies.app.workspace.getLeavesOfType('markdown').some((leaf) => {
-      const view = leaf.view as unknown as MarkdownEditorViewLike;
-      return view.editor === editor && view.file === file;
-    });
+    return isSelectionRedictationTargetOpen(this.dependencies.app, this.dependencies.snapshot);
   }
 
   private reportStaleSelection(): void {
@@ -253,7 +262,7 @@ export class SelectionRedictationSession {
       intent: 'warning',
       key: 'selection-redictation-stale',
       message:
-        'The selection changed while re-dictating. No text was replaced. Select it again and retry.',
+        'The note changed while re-dictating. No text was replaced. Select the text again and retry.',
     });
   }
 
@@ -292,6 +301,16 @@ export class SelectionRedictationSession {
       }
     }
   }
+}
+
+function isSelectionRedictationTargetOpen(
+  app: Pick<App, 'workspace'>,
+  snapshot: SelectionRedictationSnapshot,
+): boolean {
+  return app.workspace.getLeavesOfType('markdown').some((leaf) => {
+    const view = leaf.view as unknown as MarkdownEditorViewLike;
+    return view.editor === snapshot.editor && view.file === snapshot.file;
+  });
 }
 
 function orderPositions(

--- a/src/editor/selection-redictation.ts
+++ b/src/editor/selection-redictation.ts
@@ -1,0 +1,322 @@
+import type { App, Editor, EditorPosition, EventRef, TAbstractFile, TFile } from 'obsidian';
+
+import type { SessionAcceptResult, SessionLifecycleCallbacks } from '../session/session';
+import type { TranscriptRevision } from '../session/session-journal';
+import { truncateTrailingText } from '../shared/text-truncation';
+import type { UserFeedback } from '../shared/user-feedback';
+import { buildNoteGlossary } from './note-surface';
+
+type SelectionEditor = Pick<Editor, 'getRange' | 'getValue' | 'listSelections' | 'transaction'>;
+
+export interface SelectionRedictationSnapshot {
+  readonly editor: SelectionEditor;
+  readonly file: TFile;
+  readonly from: EditorPosition;
+  readonly originalText: string;
+  readonly to: EditorPosition;
+}
+
+export type SelectionRedictationCaptureResult =
+  | { kind: 'captured'; snapshot: SelectionRedictationSnapshot }
+  | { kind: 'empty_selection' }
+  | { kind: 'multiple_selections' }
+  | { kind: 'no_file' };
+
+interface SelectionRedictationSessionDependencies {
+  app: Pick<App, 'vault' | 'workspace'>;
+  callbacks: SessionLifecycleCallbacks;
+  feedback: Pick<UserFeedback, 'show'>;
+  snapshot: SelectionRedictationSnapshot;
+}
+
+interface MarkdownEditorViewLike {
+  editor?: Editor;
+  file: TFile | null;
+}
+
+export function canCaptureSelectionRedictation(
+  editor: SelectionEditor,
+  file: TFile | null,
+): boolean {
+  return captureSelectionRedictation(editor, file).kind === 'captured';
+}
+
+export function captureSelectionRedictation(
+  editor: SelectionEditor,
+  file: TFile | null,
+): SelectionRedictationCaptureResult {
+  if (file === null) {
+    return { kind: 'no_file' };
+  }
+
+  const selections = editor.listSelections();
+  if (selections.length === 0) {
+    return { kind: 'empty_selection' };
+  }
+  if (selections.length !== 1) {
+    return { kind: 'multiple_selections' };
+  }
+
+  const selection = selections[0];
+  if (selection === undefined) {
+    return { kind: 'empty_selection' };
+  }
+  const [from, to] = orderPositions(selection.anchor, selection.head);
+  if (positionsEqual(from, to)) {
+    return { kind: 'empty_selection' };
+  }
+
+  const originalText = editor.getRange(from, to);
+  if (originalText.length === 0) {
+    return { kind: 'empty_selection' };
+  }
+
+  return {
+    kind: 'captured',
+    snapshot: {
+      editor,
+      file,
+      from: { ...from },
+      originalText,
+      to: { ...to },
+    },
+  };
+}
+
+export class SelectionRedictationSession {
+  private cancelled = false;
+  private disposed = false;
+  private finalHandled = false;
+  private readonly refs: Array<{ offref: (ref: EventRef) => void; ref: EventRef }> = [];
+  private targetUnavailable = false;
+
+  constructor(private readonly dependencies: SelectionRedictationSessionDependencies) {
+    this.registerLifecycleSubscriptions();
+  }
+
+  acceptTranscript(revision: TranscriptRevision): SessionAcceptResult {
+    if (this.disposed) {
+      return { kind: 'rejected', reason: 'Selection re-dictation session is disposed.' };
+    }
+    if (this.cancelled) {
+      return { kind: 'stale' };
+    }
+    if (!revision.isFinal) {
+      return { kind: 'accepted' };
+    }
+    if (this.finalHandled) {
+      return { kind: 'duplicate' };
+    }
+
+    this.finalHandled = true;
+    this.applyFinalReplacement(revision.text.trim());
+    return { kind: 'accepted' };
+  }
+
+  clearSessionProcessingMark(): void {}
+
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.releaseSubscriptions();
+  }
+
+  insertAdjacentToSessionRange(_blockText: string, _placement: 'above' | 'below'): boolean {
+    return false;
+  }
+
+  markSessionRangeAsProcessing(): boolean {
+    return false;
+  }
+
+  onUserCancellation(): void {
+    if (this.cancelled || this.finalHandled) {
+      return;
+    }
+    this.cancelled = true;
+    this.dependencies.feedback.show({
+      intent: 'information',
+      key: 'selection-redictation-cancelled',
+      message: 'Re-dictation cancelled. The selected text was left unchanged.',
+    });
+  }
+
+  readCurrentSessionText(): string {
+    return '';
+  }
+
+  readNoteGlossary(maxChars: number): { text: string; truncated: boolean } | null {
+    if (!this.canReadTarget() || maxChars <= 0) {
+      return null;
+    }
+
+    try {
+      return buildNoteGlossary(this.dependencies.snapshot.editor.getValue(), maxChars);
+    } catch {
+      return null;
+    }
+  }
+
+  readNoteText(maxChars: number): { text: string; truncated: boolean } | null {
+    if (!this.canReadTarget() || maxChars <= 0) {
+      return null;
+    }
+
+    try {
+      const textBeforeSelection = this.dependencies.snapshot.editor
+        .getRange({ ch: 0, line: 0 }, this.dependencies.snapshot.from)
+        .trim();
+      return textBeforeSelection.length > 0
+        ? truncateTrailingText(textBeforeSelection, maxChars)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+
+  readPriorUtterances(
+    _maxCount: number,
+    _maxCharsPerUtterance: number,
+  ): Array<{ text: string; truncated: boolean }> {
+    return [];
+  }
+
+  replaceSessionRangeWithCleaned(
+    _cleanText: string,
+    _options?: { rawTextForCallout?: string; showRawBelow?: boolean },
+  ): boolean {
+    return false;
+  }
+
+  setAnchorMode(_mode: 'hidden' | 'visible'): void {}
+
+  private applyFinalReplacement(text: string): void {
+    if (text.length === 0) {
+      this.dependencies.feedback.show({
+        intent: 'warning',
+        key: 'selection-redictation-empty',
+        message: 'No replacement speech was recognized. The selected text was left unchanged.',
+      });
+      return;
+    }
+
+    const { editor, from, originalText, to } = this.dependencies.snapshot;
+    if (!this.canReadTarget()) {
+      this.reportStaleSelection();
+      return;
+    }
+
+    try {
+      if (editor.getRange(from, to) !== originalText) {
+        this.reportStaleSelection();
+        return;
+      }
+
+      editor.transaction(
+        {
+          changes: [{ from, text, to }],
+          selection: { from: advancePosition(from, text) },
+        },
+        'local-dictation-redictate-selection',
+      );
+      this.dependencies.feedback.show({
+        intent: 'success',
+        key: 'selection-redictation-complete',
+        message: 'Replaced the selected text.',
+      });
+    } catch (error) {
+      this.dependencies.feedback.show({
+        cause: error,
+        intent: 'error',
+        key: 'selection-redictation-failed',
+        message: 'Could not replace the selected text. Select it again and retry.',
+      });
+    }
+  }
+
+  private canReadTarget(): boolean {
+    return !this.disposed && !this.targetUnavailable && this.isTargetOpen();
+  }
+
+  private isTargetOpen(): boolean {
+    const { editor, file } = this.dependencies.snapshot;
+    return this.dependencies.app.workspace.getLeavesOfType('markdown').some((leaf) => {
+      const view = leaf.view as unknown as MarkdownEditorViewLike;
+      return view.editor === editor && view.file === file;
+    });
+  }
+
+  private reportStaleSelection(): void {
+    this.dependencies.feedback.show({
+      intent: 'warning',
+      key: 'selection-redictation-stale',
+      message:
+        'The selection changed while re-dictating. No text was replaced. Select it again and retry.',
+    });
+  }
+
+  private registerLifecycleSubscriptions(): void {
+    const { vault, workspace } = this.dependencies.app;
+    this.refs.push({
+      offref: (ref) => workspace.offref(ref),
+      ref: workspace.on('layout-change', () => {
+        if (!this.disposed && !this.targetUnavailable && !this.isTargetOpen()) {
+          this.targetUnavailable = true;
+          this.dependencies.callbacks.onLockedNoteClosed();
+        }
+      }),
+    });
+    this.refs.push({
+      offref: (ref) => vault.offref(ref),
+      ref: vault.on('delete', (file) => {
+        this.handleDelete(file);
+      }),
+    });
+  }
+
+  private handleDelete(file: TAbstractFile): void {
+    if (this.disposed || this.targetUnavailable || file !== this.dependencies.snapshot.file) {
+      return;
+    }
+    this.targetUnavailable = true;
+    this.dependencies.callbacks.onLockedNoteDeleted();
+  }
+
+  private releaseSubscriptions(): void {
+    while (this.refs.length > 0) {
+      const subscription = this.refs.pop();
+      if (subscription !== undefined) {
+        subscription.offref(subscription.ref);
+      }
+    }
+  }
+}
+
+function orderPositions(
+  first: EditorPosition,
+  second: EditorPosition,
+): [EditorPosition, EditorPosition] {
+  return comparePositions(first, second) <= 0 ? [first, second] : [second, first];
+}
+
+function comparePositions(first: EditorPosition, second: EditorPosition): number {
+  return first.line === second.line ? first.ch - second.ch : first.line - second.line;
+}
+
+function positionsEqual(first: EditorPosition, second: EditorPosition): boolean {
+  return first.line === second.line && first.ch === second.ch;
+}
+
+function advancePosition(position: EditorPosition, text: string): EditorPosition {
+  const lines = text.split('\n');
+  if (lines.length === 1) {
+    return { ch: position.ch + text.length, line: position.line };
+  }
+
+  return {
+    ch: lines.at(-1)?.length ?? 0,
+    line: position.line + lines.length - 1,
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,11 @@ import { DictationSessionController } from './dictation/dictation-session-contro
 import { dictationAnchorExtension } from './editor/dictation-anchor-extension';
 import { noteSurfaceUpdateListenerExtension } from './editor/note-surface';
 import { provisionalTranscriptExtension } from './editor/provisional-transcript-extension';
+import {
+  canCaptureSelectionRedictation,
+  captureSelectionRedictation,
+  SelectionRedictationSession,
+} from './editor/selection-redictation';
 import { sessionProcessingExtension } from './editor/session-processing-extension';
 import { TemporaryLeafPinLeaseManager } from './editor/temporary-leaf-pin';
 import type { LlmCleanupFailure } from './llm/provider';
@@ -169,6 +174,13 @@ export default class LocalSttPlugin extends Plugin {
           rendererOptions,
           sessionId,
         }),
+      createSelectionRedictationSession: ({ callbacks, selection }) =>
+        new SelectionRedictationSession({
+          app: this.app,
+          callbacks,
+          feedback: this.feedback,
+          snapshot: selection,
+        }),
       createLlmRouter: (settings) =>
         createLlmRouter(
           settings,
@@ -230,10 +242,35 @@ export default class LocalSttPlugin extends Plugin {
 
     registerCommands({
       cancelDictation: async () => this.requireDictationController().cancelDictation(),
+      canRedictateSelection: (editor, file) =>
+        !this.requireDictationController().isBusy() && canCaptureSelectionRedictation(editor, file),
       checkSidecarHealth: async () => this.checkSidecarHealth(),
       plugin: this,
       restartSidecar: async () => this.restartSidecar(),
       startDictation: async () => this.requireDictationController().startDictation(),
+      startSelectionRedictation: async (editor, file) => {
+        const controller = this.requireDictationController();
+        if (controller.isBusy()) {
+          this.feedback.show({
+            intent: 'information',
+            key: 'selection-redictation-busy',
+            message: 'Finish or cancel the current dictation before re-dictating a selection.',
+          });
+          return;
+        }
+
+        const capture = captureSelectionRedictation(editor, file);
+        if (capture.kind !== 'captured') {
+          this.feedback.show({
+            intent: 'information',
+            key: 'selection-redictation-unavailable',
+            message: 'Select one non-empty text range and try again.',
+          });
+          return;
+        }
+
+        await controller.startSelectionRedictation(capture.snapshot);
+      },
       stopDictation: async () => this.requireDictationController().stopDictation(),
       toggleDictation: async () => this.requireDictationController().toggleDictation(),
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { provisionalTranscriptExtension } from './editor/provisional-transcript-
 import {
   canCaptureSelectionRedictation,
   captureSelectionRedictation,
+  isSelectionRedictationSnapshotCurrent,
   SelectionRedictationSession,
 } from './editor/selection-redictation';
 import { sessionProcessingExtension } from './editor/session-processing-extension';
@@ -189,6 +190,8 @@ export default class LocalSttPlugin extends Plugin {
           () => this.getOpenRouterApiKey(),
         ),
       getSettings: () => this.settings,
+      isSelectionRedictationSnapshotCurrent: (selection) =>
+        isSelectionRedictationSnapshotCurrent(this.app, selection),
       feedback: this.feedback,
       logger: this.logger,
       onLlmCleanupFailure: (failure) => {
@@ -245,6 +248,15 @@ export default class LocalSttPlugin extends Plugin {
       canRedictateSelection: (editor, file) =>
         !this.requireDictationController().isBusy() && canCaptureSelectionRedictation(editor, file),
       checkSidecarHealth: async () => this.checkSidecarHealth(),
+      onSelectionRedictationError: (error) => {
+        this.logger.error('session', 'selection re-dictation command failed', error);
+        this.feedback.show({
+          cause: error,
+          intent: 'error',
+          key: 'selection-redictation-command-failed',
+          message: 'Could not start selection re-dictation. Select the text and try again.',
+        });
+      },
       plugin: this,
       restartSidecar: async () => this.restartSidecar(),
       startDictation: async () => this.requireDictationController().startDictation(),

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -5,6 +5,7 @@ import {
   DictationSessionController,
 } from '../src/dictation/dictation-session-controller';
 import type { NotePlacementOptions, SurfaceDesynchronization } from '../src/editor/note-surface';
+import type { SelectionRedictationSnapshot } from '../src/editor/selection-redictation';
 import { type LlmCleanupFailure, ProviderError } from '../src/llm/provider';
 import type { LlmRouter, LlmRouterCleanupResult } from '../src/llm/router';
 import type { SessionAcceptResult } from '../src/session/session';
@@ -68,6 +69,7 @@ class FakeSession {
     (_blockText: string, _placement: 'above' | 'below') => true,
   );
   public readonly markSessionRangeAsProcessing = vi.fn(() => true);
+  public readonly onUserCancellation = vi.fn();
   public readonly readCurrentSessionText = vi.fn(() => this.currentSessionText);
   public readonly readNoteGlossary = vi.fn(
     (_maxChars: number): { text: string; truncated: boolean } | null => null,
@@ -162,6 +164,205 @@ describe('DictationSessionController', () => {
 
     expect(sidecarConnection.sendAudioFrame).toHaveBeenCalledWith(startPayload?.sessionId, frame);
     expect(controller.getState()).toBe('listening');
+  });
+
+  it('stops capture on the first selection final and ignores every later revision', async () => {
+    const captureStream = new FakeCaptureStream();
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const controller = createController({
+      captureStream,
+      createSelectionRedictationSession: (session) => {
+        sessions.push(session);
+      },
+      sidecarConnection,
+    });
+
+    await controller.startSelectionRedictation(createSelectionSnapshot());
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    const session = sessions[0];
+    if (session === undefined) {
+      throw new Error('expected selection session fixture');
+    }
+
+    sidecarConnection.emit(transcriptReady(sessionId, 'partial', { isFinal: false }));
+    await vi.waitFor(() => {
+      expect(session.acceptTranscript).toHaveBeenCalledWith(
+        expect.objectContaining({ isFinal: false, text: 'partial' }),
+      );
+    });
+    expect(sidecarConnection.requestStopSession).not.toHaveBeenCalled();
+
+    sidecarConnection.emit(transcriptReady(sessionId, 'first final'));
+    sidecarConnection.emit(transcriptReady(sessionId, 'second final'));
+
+    await vi.waitFor(() => {
+      expect(sidecarConnection.requestStopSession).toHaveBeenCalledWith(sessionId);
+      expect(session.acceptTranscript).toHaveBeenCalledWith(
+        expect.objectContaining({ isFinal: true, text: 'first final' }),
+      );
+    });
+    expect(captureStream.stop).toHaveBeenCalledOnce();
+    expect(session.acceptedTexts).toEqual(['partial', 'first final']);
+    expect(controller.getState()).toBe('idle');
+
+    sidecarConnection.emit({ reason: 'user_stop', sessionId, type: 'session_stopped' });
+    await vi.waitFor(() => {
+      expect(session.dispose).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('notifies the selection session before cancellation rejects transcript work', async () => {
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const controller = createController({
+      createSelectionRedictationSession: (session) => {
+        sessions.push(session);
+      },
+      sidecarConnection,
+    });
+
+    await controller.startSelectionRedictation(createSelectionSnapshot());
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    const session = sessions[0];
+    if (session === undefined) {
+      throw new Error('expected selection session fixture');
+    }
+
+    await controller.cancelDictation();
+    sidecarConnection.emit(transcriptReady(sessionId, 'late final'));
+
+    expect(session.onUserCancellation).toHaveBeenCalledOnce();
+    expect(session.acceptTranscript).not.toHaveBeenCalled();
+    expect(session.dispose).toHaveBeenCalledOnce();
+  });
+
+  it('converts replace-style batch cleanup to one transform before selection replacement', async () => {
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const cleanup = vi.fn(
+      async (): Promise<LlmRouterCleanupResult> => ({
+        model: 'm',
+        providerId: 'ollama',
+        text: 'Clean replacement.',
+      }),
+    );
+    const llmRouter = createFakeLlmRouter({ cleanup });
+    const controller = createController({
+      createSelectionRedictationSession: (session) => {
+        sessions.push(session);
+      },
+      getSettings: () =>
+        createSettings({
+          llmFeaturesEnabled: true,
+          llmPostprocessActivePresetRef: 'builtin:markdown-formatting',
+          llmPostprocessMode: 'batch',
+          llmPostprocessSkipMinWords: 0,
+          selectedModel: createExternalModelSelection(),
+        }),
+      llmRouter,
+      sidecarConnection,
+    });
+
+    await controller.startSelectionRedictation(createSelectionSnapshot());
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    sidecarConnection.emit(transcriptReady(sessionId, 'raw replacement'));
+
+    await vi.waitFor(() => {
+      expect(cleanup).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userMessage: '<utterance>\nraw replacement\n</utterance>',
+        }),
+      );
+      expect(sessions[0]?.acceptTranscript).toHaveBeenCalledWith(
+        expect.objectContaining({ isFinal: true, text: 'Clean replacement.' }),
+      );
+    });
+    sidecarConnection.emit({ reason: 'user_stop', sessionId, type: 'session_stopped' });
+    await vi.waitFor(() => {
+      expect(sessions[0]?.dispose).toHaveBeenCalledOnce();
+    });
+
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(llmRouter.selectProviderId).toHaveBeenCalledOnce();
+    expect(sessions[0]?.readCurrentSessionText).not.toHaveBeenCalled();
+    expect(sessions[0]?.replaceSessionRangeWithCleaned).not.toHaveBeenCalled();
+    expect(sessions[0]?.insertAdjacentToSessionRange).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'builtin:tldr',
+    'builtin:action-items',
+  ] as const)('disables additive preset %s for selection re-dictation', async (activePresetRef) => {
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const cleanup = vi.fn(
+      async (): Promise<LlmRouterCleanupResult> => ({
+        model: 'remote-model',
+        providerId: 'openrouter',
+        text: 'Adjacent content',
+      }),
+    );
+    const llmRouter = createFakeLlmRouter({ cleanup, providerId: 'openrouter' });
+    const controller = createController({
+      createSelectionRedictationSession: (session) => {
+        sessions.push(session);
+      },
+      getSettings: () =>
+        createSettings({
+          llmFeaturesEnabled: true,
+          llmPostprocessActivePresetRef: activePresetRef,
+          llmPostprocessMode: 'batch',
+          llmRemoteFeaturesEnabled: true,
+          llmRouting: 'remote',
+          selectedModel: createExternalModelSelection(),
+        }),
+      llmRouter,
+      sidecarConnection,
+    });
+
+    await controller.startSelectionRedictation(createSelectionSnapshot());
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    sidecarConnection.emit(transcriptReady(sessionId, 'raw replacement'));
+    await vi.waitFor(() => {
+      expect(sessions[0]?.acceptTranscript).toHaveBeenCalledWith(
+        expect.objectContaining({ isFinal: true, text: 'raw replacement' }),
+      );
+    });
+    sidecarConnection.emit({ reason: 'user_stop', sessionId, type: 'session_stopped' });
+    await vi.waitFor(() => {
+      expect(sessions[0]?.dispose).toHaveBeenCalledOnce();
+    });
+
+    expect(cleanup).not.toHaveBeenCalled();
+    expect(llmRouter.selectProviderId).not.toHaveBeenCalled();
+    expect(sessions[0]?.readCurrentSessionText).not.toHaveBeenCalled();
+    expect(sessions[0]?.replaceSessionRangeWithCleaned).not.toHaveBeenCalled();
+    expect(sessions[0]?.insertAdjacentToSessionRange).not.toHaveBeenCalled();
+  });
+
+  it('stops on an empty first final and ignores a later non-empty selection final', async () => {
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const controller = createController({
+      createSelectionRedictationSession: (session) => {
+        sessions.push(session);
+      },
+      sidecarConnection,
+    });
+
+    await controller.startSelectionRedictation(createSelectionSnapshot());
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    sidecarConnection.emit(transcriptReady(sessionId, ''));
+    sidecarConnection.emit(transcriptReady(sessionId, 'late replacement', { revision: 1 }));
+
+    await vi.waitFor(() => {
+      expect(sidecarConnection.requestStopSession).toHaveBeenCalledWith(sessionId);
+      expect(sessions[0]?.acceptTranscript).toHaveBeenCalledWith(
+        expect.objectContaining({ isFinal: true, text: '' }),
+      );
+    });
+    expect(sessions[0]?.acceptedTexts).toEqual(['']);
   });
 
   it('passes smart paragraph thresholds to renderer options', async () => {
@@ -2281,6 +2482,7 @@ function createController({
   captureStream = new FakeCaptureStream(),
   countAudioInputDevices,
   createSession,
+  createSelectionRedictationSession,
   llmRouter = createFakeLlmRouter(),
   getSettings = () => createSettings({ selectedModel: createExternalModelSelection() }),
   logger = new FakeLogger(),
@@ -2293,6 +2495,10 @@ function createController({
   captureStream?: FakeCaptureStream;
   countAudioInputDevices?: () => Promise<number | null>;
   createSession?: (session: FakeSession, options: CreateSessionOptions) => void;
+  createSelectionRedictationSession?: (
+    session: FakeSession,
+    options: CreateSelectionRedictationSessionOptions,
+  ) => void;
   getSettings?: () => PluginSettings;
   llmRouter?: LlmRouter;
   logger?: FakeLogger;
@@ -2308,6 +2514,11 @@ function createController({
     createSession: (_options: CreateSessionOptions) => {
       const session = new FakeSession();
       createSession?.(session, _options);
+      return session;
+    },
+    createSelectionRedictationSession: (_options: CreateSelectionRedictationSessionOptions) => {
+      const session = new FakeSession();
+      createSelectionRedictationSession?.(session, _options);
       return session;
     },
     createLlmRouter: () => llmRouter,
@@ -2335,6 +2546,12 @@ interface CreateSessionOptions {
   sessionId: string;
 }
 
+interface CreateSelectionRedictationSessionOptions {
+  callbacks: CreateSessionOptions['callbacks'];
+  selection: SelectionRedictationSnapshot;
+  sessionId: string;
+}
+
 function createSettings(overrides: Partial<PluginSettings> = {}): PluginSettings {
   return {
     ...DEFAULT_PLUGIN_SETTINGS,
@@ -2349,6 +2566,16 @@ function createExternalModelSelection(): NonNullable<PluginSettings['selectedMod
     kind: 'external_file',
     runtimeId: 'whisper_cpp',
   };
+}
+
+function createSelectionSnapshot(): SelectionRedictationSnapshot {
+  return {
+    editor: {},
+    file: { path: 'note.md' },
+    from: { ch: 0, line: 0 },
+    originalText: 'original',
+    to: { ch: 8, line: 0 },
+  } as unknown as SelectionRedictationSnapshot;
 }
 
 function transcriptReady(

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -166,6 +166,76 @@ describe('DictationSessionController', () => {
     expect(controller.getState()).toBe('listening');
   });
 
+  it('does not start selection capture when its target becomes stale during preflight', async () => {
+    const captureStream = new FakeCaptureStream();
+    const feedback = { show: vi.fn() };
+    const sidecarConnection = new FakeSidecarConnection();
+    const preflight: { finish?: () => void } = {};
+    sidecarConnection.ensureStarted.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          preflight.finish = resolve;
+        }),
+    );
+    let targetCurrent = true;
+    const isSelectionRedictationSnapshotCurrent = vi.fn(() => targetCurrent);
+    const createSelectionRedictationSession = vi.fn();
+    const controller = createController({
+      captureStream,
+      createSelectionRedictationSession,
+      feedback,
+      isSelectionRedictationSnapshotCurrent,
+      sidecarConnection,
+    });
+    const selection = createSelectionSnapshot();
+
+    const start = controller.startSelectionRedictation(selection);
+    await vi.waitFor(() => {
+      expect(sidecarConnection.ensureStarted).toHaveBeenCalledOnce();
+    });
+    targetCurrent = false;
+    const finishPreflight = preflight.finish;
+    if (finishPreflight === undefined) {
+      throw new Error('sidecar preflight did not start');
+    }
+    finishPreflight();
+    await start;
+
+    expect(isSelectionRedictationSnapshotCurrent).toHaveBeenCalledWith(selection);
+    expect(createSelectionRedictationSession).not.toHaveBeenCalled();
+    expect(sidecarConnection.startSession).not.toHaveBeenCalled();
+    expect(captureStream.start).not.toHaveBeenCalled();
+    expect(controller.getState()).toBe('idle');
+    expect(feedback.show).toHaveBeenCalledWith({
+      intent: 'warning',
+      key: 'selection-redictation-start-stale',
+      message:
+        'Re-dictation did not start because the selected note changed or closed. No audio was captured. Select the text again and retry.',
+    });
+  });
+
+  it('starts selection re-dictation with microphone-only capture and no diarization', async () => {
+    const sidecarConnection = new FakeSidecarConnection();
+    const controller = createController({
+      getSettings: () =>
+        createSettings({
+          diarizationEnabled: true,
+          includeSystemAudio: true,
+          selectedModel: createExternalModelSelection(),
+        }),
+      sidecarConnection,
+    });
+
+    await controller.startSelectionRedictation(createSelectionSnapshot());
+
+    expect(sidecarConnection.startSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        diarizationEnabled: false,
+        includeSystemAudio: false,
+      }),
+    );
+  });
+
   it('stops capture on the first selection final and ignores every later revision', async () => {
     const captureStream = new FakeCaptureStream();
     const sidecarConnection = new FakeSidecarConnection();
@@ -2485,6 +2555,7 @@ function createController({
   createSelectionRedictationSession,
   llmRouter = createFakeLlmRouter(),
   getSettings = () => createSettings({ selectedModel: createExternalModelSelection() }),
+  isSelectionRedictationSnapshotCurrent = () => true,
   logger = new FakeLogger(),
   feedback = { show: vi.fn() },
   sidecarConnection = new FakeSidecarConnection(),
@@ -2500,6 +2571,7 @@ function createController({
     options: CreateSelectionRedictationSessionOptions,
   ) => void;
   getSettings?: () => PluginSettings;
+  isSelectionRedictationSnapshotCurrent?: (selection: SelectionRedictationSnapshot) => boolean;
   llmRouter?: LlmRouter;
   logger?: FakeLogger;
   feedback?: Pick<UserFeedback, 'show'>;
@@ -2524,6 +2596,7 @@ function createController({
     createLlmRouter: () => llmRouter,
     feedback,
     getSettings,
+    isSelectionRedictationSnapshotCurrent,
     logger,
     ...(onLlmCleanupFailure !== undefined ? { onLlmCleanupFailure } : {}),
     ...(onLlmCleanupSuccess !== undefined ? { onLlmCleanupSuccess } : {}),
@@ -2570,10 +2643,10 @@ function createExternalModelSelection(): NonNullable<PluginSettings['selectedMod
 
 function createSelectionSnapshot(): SelectionRedictationSnapshot {
   return {
+    documentText: 'original',
     editor: {},
     file: { path: 'note.md' },
     from: { ch: 0, line: 0 },
-    originalText: 'original',
     to: { ch: 8, line: 0 },
   } as unknown as SelectionRedictationSnapshot;
 }

--- a/test/register-commands.test.ts
+++ b/test/register-commands.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { registerCommands } from '../src/commands/register-commands';
 
 describe('registerCommands', () => {
-  it('checks re-dictation eligibility without starting capture and executes only when available', () => {
+  it('checks eligibility and contains an unexpected re-dictation startup rejection', async () => {
     const commands: Command[] = [];
     const plugin = {
       addCommand: vi.fn((command: Command) => {
@@ -13,11 +13,16 @@ describe('registerCommands', () => {
     } as unknown as Plugin;
     let available = false;
     const canRedictateSelection = vi.fn(() => available);
-    const startSelectionRedictation = vi.fn(async () => {});
+    const startError = new Error('unexpected startup failure');
+    const startSelectionRedictation = vi.fn(async () => {
+      throw startError;
+    });
+    const onSelectionRedictationError = vi.fn();
     registerCommands({
       cancelDictation: vi.fn(async () => {}),
       canRedictateSelection,
       checkSidecarHealth: vi.fn(async () => {}),
+      onSelectionRedictationError,
       plugin,
       restartSidecar: vi.fn(async () => {}),
       startDictation: vi.fn(async () => {}),
@@ -41,5 +46,8 @@ describe('registerCommands', () => {
     expect(command?.editorCheckCallback?.(false, editor, context)).toBe(true);
     expect(startSelectionRedictation).toHaveBeenCalledOnce();
     expect(startSelectionRedictation).toHaveBeenCalledWith(editor, file);
+    await vi.waitFor(() => {
+      expect(onSelectionRedictationError).toHaveBeenCalledWith(startError);
+    });
   });
 });

--- a/test/register-commands.test.ts
+++ b/test/register-commands.test.ts
@@ -1,0 +1,45 @@
+import type { Command, Editor, Plugin, TFile } from 'obsidian';
+import { describe, expect, it, vi } from 'vitest';
+
+import { registerCommands } from '../src/commands/register-commands';
+
+describe('registerCommands', () => {
+  it('checks re-dictation eligibility without starting capture and executes only when available', () => {
+    const commands: Command[] = [];
+    const plugin = {
+      addCommand: vi.fn((command: Command) => {
+        commands.push(command);
+      }),
+    } as unknown as Plugin;
+    let available = false;
+    const canRedictateSelection = vi.fn(() => available);
+    const startSelectionRedictation = vi.fn(async () => {});
+    registerCommands({
+      cancelDictation: vi.fn(async () => {}),
+      canRedictateSelection,
+      checkSidecarHealth: vi.fn(async () => {}),
+      plugin,
+      restartSidecar: vi.fn(async () => {}),
+      startDictation: vi.fn(async () => {}),
+      startSelectionRedictation,
+      stopDictation: vi.fn(async () => {}),
+      toggleDictation: vi.fn(async () => {}),
+    });
+    const command = commands.find(({ id }) => id === 'redictate-selection');
+    const editor = {} as Editor;
+    const file = { path: 'note.md' } as TFile;
+    const context = { file } as never;
+
+    expect(command?.name).toBe('Re-dictate selection');
+    expect(command?.editorCheckCallback?.(true, editor, context)).toBe(false);
+    expect(startSelectionRedictation).not.toHaveBeenCalled();
+
+    available = true;
+    expect(command?.editorCheckCallback?.(true, editor, context)).toBe(true);
+    expect(startSelectionRedictation).not.toHaveBeenCalled();
+
+    expect(command?.editorCheckCallback?.(false, editor, context)).toBe(true);
+    expect(startSelectionRedictation).toHaveBeenCalledOnce();
+    expect(startSelectionRedictation).toHaveBeenCalledWith(editor, file);
+  });
+});

--- a/test/selection-redictation.test.ts
+++ b/test/selection-redictation.test.ts
@@ -1,0 +1,349 @@
+import type { App, Editor, EditorPosition, EventRef, TFile } from 'obsidian';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  canCaptureSelectionRedictation,
+  captureSelectionRedictation,
+  SelectionRedictationSession,
+  type SelectionRedictationSnapshot,
+} from '../src/editor/selection-redictation';
+import { transcript } from './fixtures/transcript';
+
+describe('selection re-dictation capture', () => {
+  it('captures one non-empty selection in document order without mutating the editor', () => {
+    const editor = createEditor({
+      selection: {
+        anchor: { ch: 12, line: 2 },
+        head: { ch: 4, line: 2 },
+      },
+      selectedText: 'original',
+    });
+    const file = { path: 'note.md' } as TFile;
+
+    const result = captureSelectionRedictation(editor.editor, file);
+
+    expect(result).toEqual({
+      kind: 'captured',
+      snapshot: {
+        editor: editor.editor,
+        file,
+        from: { ch: 4, line: 2 },
+        originalText: 'original',
+        to: { ch: 12, line: 2 },
+      },
+    });
+    expect(editor.transaction).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty and multiple selections without side effects', () => {
+    const file = { path: 'note.md' } as TFile;
+    const empty = createEditor({
+      selection: {
+        anchor: { ch: 4, line: 2 },
+        head: { ch: 4, line: 2 },
+      },
+      selectedText: '',
+    });
+    const multiple = createEditor({
+      selection: {
+        anchor: { ch: 0, line: 0 },
+        head: { ch: 3, line: 0 },
+      },
+      selectedText: 'one',
+    });
+    multiple.listSelections.mockReturnValue([
+      { anchor: { ch: 0, line: 0 }, head: { ch: 3, line: 0 } },
+      { anchor: { ch: 0, line: 1 }, head: { ch: 3, line: 1 } },
+    ]);
+    const none = createEditor({
+      selection: {
+        anchor: { ch: 0, line: 0 },
+        head: { ch: 0, line: 0 },
+      },
+      selectedText: '',
+    });
+    none.listSelections.mockReturnValue([]);
+
+    expect(captureSelectionRedictation(empty.editor, file)).toEqual({
+      kind: 'empty_selection',
+    });
+    expect(canCaptureSelectionRedictation(empty.editor, file)).toBe(false);
+    expect(captureSelectionRedictation(none.editor, file)).toEqual({ kind: 'empty_selection' });
+    expect(canCaptureSelectionRedictation(multiple.editor, file)).toBe(false);
+    expect(captureSelectionRedictation(multiple.editor, null)).toEqual({ kind: 'no_file' });
+    expect(empty.transaction).not.toHaveBeenCalled();
+    expect(multiple.transaction).not.toHaveBeenCalled();
+  });
+});
+
+describe('SelectionRedictationSession', () => {
+  it('replaces the unchanged snapshot exactly once in one undoable editor transaction', () => {
+    const harness = createSessionHarness();
+
+    expect(
+      harness.session.acceptTranscript(
+        transcript({
+          isFinal: false,
+          text: 'partial',
+          utteranceId: 'selection-1',
+        }),
+      ),
+    ).toEqual({ kind: 'accepted' });
+    expect(harness.editor.transaction).not.toHaveBeenCalled();
+
+    expect(
+      harness.session.acceptTranscript(
+        transcript({ text: '  replacement text  ', utteranceId: 'selection-1' }),
+      ),
+    ).toEqual({ kind: 'accepted' });
+
+    expect(harness.editor.transaction).toHaveBeenCalledWith(
+      {
+        changes: [
+          {
+            from: { ch: 4, line: 1 },
+            text: 'replacement text',
+            to: { ch: 12, line: 1 },
+          },
+        ],
+        selection: { from: { ch: 20, line: 1 } },
+      },
+      'local-dictation-redictate-selection',
+    );
+    expect(harness.feedback.show).toHaveBeenCalledWith({
+      intent: 'success',
+      key: 'selection-redictation-complete',
+      message: 'Replaced the selected text.',
+    });
+
+    expect(
+      harness.session.acceptTranscript(
+        transcript({ revision: 1, text: 'must not apply', utteranceId: 'selection-2' }),
+      ),
+    ).toEqual({ kind: 'duplicate' });
+    expect(harness.editor.transaction).toHaveBeenCalledOnce();
+  });
+
+  it('leaves the note unchanged when the selected range content becomes stale', () => {
+    const harness = createSessionHarness();
+    harness.editor.getRange.mockImplementation((from: EditorPosition) =>
+      from.line === 0 ? 'Context before selection' : 'user-edited',
+    );
+
+    harness.session.acceptTranscript(
+      transcript({ text: 'replacement text', utteranceId: 'selection-1' }),
+    );
+
+    expect(harness.editor.transaction).not.toHaveBeenCalled();
+    expect(harness.feedback.show).toHaveBeenCalledWith({
+      intent: 'warning',
+      key: 'selection-redictation-stale',
+      message:
+        'The selection changed while re-dictating. No text was replaced. Select it again and retry.',
+    });
+  });
+
+  it('leaves the note unchanged when the target editor is no longer open', () => {
+    const harness = createSessionHarness();
+    harness.setTargetOpen(false);
+
+    harness.session.acceptTranscript(
+      transcript({ text: 'replacement text', utteranceId: 'selection-1' }),
+    );
+
+    expect(harness.editor.getRange).not.toHaveBeenCalled();
+    expect(harness.editor.transaction).not.toHaveBeenCalled();
+    expect(harness.feedback.show).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'selection-redictation-stale' }),
+    );
+  });
+
+  it('leaves the note unchanged when the editor now belongs to another file', () => {
+    const harness = createSessionHarness();
+    harness.setOpenFile({ path: 'other.md' } as TFile);
+
+    harness.session.acceptTranscript(
+      transcript({ text: 'replacement text', utteranceId: 'selection-1' }),
+    );
+
+    expect(harness.editor.getRange).not.toHaveBeenCalled();
+    expect(harness.editor.transaction).not.toHaveBeenCalled();
+    expect(harness.feedback.show).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'selection-redictation-stale' }),
+    );
+  });
+
+  it('keeps the original selection when the first final is empty', () => {
+    const harness = createSessionHarness();
+
+    expect(
+      harness.session.acceptTranscript(transcript({ text: '  \n  ', utteranceId: 'selection-1' })),
+    ).toEqual({ kind: 'accepted' });
+    expect(harness.editor.transaction).not.toHaveBeenCalled();
+    expect(harness.feedback.show).toHaveBeenCalledWith({
+      intent: 'warning',
+      key: 'selection-redictation-empty',
+      message: 'No replacement speech was recognized. The selected text was left unchanged.',
+    });
+
+    expect(
+      harness.session.acceptTranscript(
+        transcript({ revision: 1, text: 'late replacement', utteranceId: 'selection-1' }),
+      ),
+    ).toEqual({ kind: 'duplicate' });
+    expect(harness.editor.transaction).not.toHaveBeenCalled();
+  });
+
+  it('never mutates the note after user cancellation', () => {
+    const harness = createSessionHarness();
+
+    harness.session.onUserCancellation();
+
+    expect(
+      harness.session.acceptTranscript(
+        transcript({ text: 'late replacement', utteranceId: 'selection-1' }),
+      ),
+    ).toEqual({ kind: 'stale' });
+    expect(harness.editor.transaction).not.toHaveBeenCalled();
+    expect(harness.feedback.show).toHaveBeenCalledWith({
+      intent: 'information',
+      key: 'selection-redictation-cancelled',
+      message: 'Re-dictation cancelled. The selected text was left unchanged.',
+    });
+  });
+
+  it('cancels through the existing target lifecycle when the note closes', () => {
+    const harness = createSessionHarness();
+    harness.setTargetOpen(false);
+
+    harness.emitLayoutChange();
+    harness.emitLayoutChange();
+
+    expect(harness.callbacks.onLockedNoteClosed).toHaveBeenCalledOnce();
+  });
+
+  it('cancels once when the target file is deleted and ignores unrelated deletes', () => {
+    const harness = createSessionHarness();
+
+    harness.emitDelete({ path: 'other.md' } as TFile);
+    expect(harness.callbacks.onLockedNoteDeleted).not.toHaveBeenCalled();
+
+    harness.emitDelete();
+    harness.emitDelete();
+
+    expect(harness.callbacks.onLockedNoteDeleted).toHaveBeenCalledOnce();
+    expect(
+      harness.session.acceptTranscript(
+        transcript({ text: 'late replacement', utteranceId: 'selection-1' }),
+      ),
+    ).toEqual({ kind: 'accepted' });
+    expect(harness.editor.transaction).not.toHaveBeenCalled();
+  });
+
+  it('releases lifecycle subscriptions once and rejects every revision after disposal', () => {
+    const harness = createSessionHarness();
+
+    harness.session.dispose();
+    harness.session.dispose();
+
+    expect(harness.workspace.offref).toHaveBeenCalledOnce();
+    expect(harness.vault.offref).toHaveBeenCalledOnce();
+    expect(
+      harness.session.acceptTranscript(
+        transcript({ text: 'late replacement', utteranceId: 'selection-1' }),
+      ),
+    ).toEqual({ kind: 'rejected', reason: 'Selection re-dictation session is disposed.' });
+    expect(harness.editor.transaction).not.toHaveBeenCalled();
+  });
+});
+
+function createSessionHarness() {
+  const editor = createEditor({
+    selection: {
+      anchor: { ch: 4, line: 1 },
+      head: { ch: 12, line: 1 },
+    },
+    selectedText: 'original',
+  });
+  const file = { path: 'note.md' } as TFile;
+  let targetOpen = true;
+  let openFile: TFile = file;
+  let layoutChange: (() => void) | null = null;
+  let deleted: ((file: TFile) => void) | null = null;
+  const workspace = {
+    getLeavesOfType: vi.fn(() =>
+      targetOpen ? [{ view: { editor: editor.editor as unknown as Editor, file: openFile } }] : [],
+    ),
+    offref: vi.fn(),
+    on: vi.fn((_event: string, callback: () => void) => {
+      layoutChange = callback;
+      return {} as EventRef;
+    }),
+  };
+  const vault = {
+    offref: vi.fn(),
+    on: vi.fn((_event: string, callback: (target: TFile) => void) => {
+      deleted = callback;
+      return {} as EventRef;
+    }),
+  };
+  const callbacks = {
+    onLockedNoteClosed: vi.fn(),
+    onLockedNoteDeleted: vi.fn(),
+    onSurfaceDesynchronized: vi.fn(),
+  };
+  const feedback = { show: vi.fn() };
+  const snapshot: SelectionRedictationSnapshot = {
+    editor: editor.editor,
+    file,
+    from: { ch: 4, line: 1 },
+    originalText: 'original',
+    to: { ch: 12, line: 1 },
+  };
+  const session = new SelectionRedictationSession({
+    app: { vault, workspace } as unknown as Pick<App, 'vault' | 'workspace'>,
+    callbacks,
+    feedback,
+    snapshot,
+  });
+
+  return {
+    callbacks,
+    editor,
+    emitDelete: (deletedFile: TFile = file) => deleted?.(deletedFile),
+    emitLayoutChange: () => layoutChange?.(),
+    feedback,
+    session,
+    setOpenFile: (nextFile: TFile) => {
+      openFile = nextFile;
+    },
+    setTargetOpen: (open: boolean) => {
+      targetOpen = open;
+    },
+    vault,
+    workspace,
+  };
+}
+
+function createEditor({
+  selectedText,
+  selection,
+}: {
+  selectedText: string;
+  selection: { anchor: EditorPosition; head: EditorPosition };
+}) {
+  const getRange = vi.fn((from: EditorPosition) =>
+    from.line === 0 ? 'Context before selection' : selectedText,
+  );
+  const getValue = vi.fn(() => `Context before selection ${selectedText}`);
+  const listSelections = vi.fn(() => [selection]);
+  const transaction = vi.fn();
+  const editor = {
+    getRange,
+    getValue,
+    listSelections,
+    transaction,
+  } as unknown as SelectionRedictationSnapshot['editor'];
+
+  return { editor, getRange, getValue, listSelections, transaction };
+}

--- a/test/selection-redictation.test.ts
+++ b/test/selection-redictation.test.ts
@@ -25,10 +25,10 @@ describe('selection re-dictation capture', () => {
     expect(result).toEqual({
       kind: 'captured',
       snapshot: {
+        documentText: 'Context before selection original',
         editor: editor.editor,
         file,
         from: { ch: 4, line: 2 },
-        originalText: 'original',
         to: { ch: 12, line: 2 },
       },
     });
@@ -124,11 +124,9 @@ describe('SelectionRedictationSession', () => {
     expect(harness.editor.transaction).toHaveBeenCalledOnce();
   });
 
-  it('leaves the note unchanged when the selected range content becomes stale', () => {
+  it('leaves the note unchanged when its captured document changes', () => {
     const harness = createSessionHarness();
-    harness.editor.getRange.mockImplementation((from: EditorPosition) =>
-      from.line === 0 ? 'Context before selection' : 'user-edited',
-    );
+    harness.editor.getValue.mockReturnValue('user-edited document');
 
     harness.session.acceptTranscript(
       transcript({ text: 'replacement text', utteranceId: 'selection-1' }),
@@ -139,8 +137,25 @@ describe('SelectionRedictationSession', () => {
       intent: 'warning',
       key: 'selection-redictation-stale',
       message:
-        'The selection changed while re-dictating. No text was replaced. Select it again and retry.',
+        'The note changed while re-dictating. No text was replaced. Select the text again and retry.',
     });
+  });
+
+  it('rejects a prepended repeated string even when the old range still matches', () => {
+    const harness = createSessionHarness();
+    harness.editor.getRange.mockReturnValue('original');
+    harness.editor.getValue.mockReturnValue(`original ${harness.snapshot.documentText}`);
+
+    expect(harness.editor.getRange(harness.snapshot.from, harness.snapshot.to)).toBe('original');
+
+    harness.session.acceptTranscript(
+      transcript({ text: 'replacement text', utteranceId: 'selection-1' }),
+    );
+
+    expect(harness.editor.transaction).not.toHaveBeenCalled();
+    expect(harness.feedback.show).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'selection-redictation-stale' }),
+    );
   });
 
   it('leaves the note unchanged when the target editor is no longer open', () => {
@@ -151,7 +166,7 @@ describe('SelectionRedictationSession', () => {
       transcript({ text: 'replacement text', utteranceId: 'selection-1' }),
     );
 
-    expect(harness.editor.getRange).not.toHaveBeenCalled();
+    expect(harness.editor.getValue).not.toHaveBeenCalled();
     expect(harness.editor.transaction).not.toHaveBeenCalled();
     expect(harness.feedback.show).toHaveBeenCalledWith(
       expect.objectContaining({ key: 'selection-redictation-stale' }),
@@ -166,7 +181,7 @@ describe('SelectionRedictationSession', () => {
       transcript({ text: 'replacement text', utteranceId: 'selection-1' }),
     );
 
-    expect(harness.editor.getRange).not.toHaveBeenCalled();
+    expect(harness.editor.getValue).not.toHaveBeenCalled();
     expect(harness.editor.transaction).not.toHaveBeenCalled();
     expect(harness.feedback.show).toHaveBeenCalledWith(
       expect.objectContaining({ key: 'selection-redictation-stale' }),
@@ -294,10 +309,10 @@ function createSessionHarness() {
   };
   const feedback = { show: vi.fn() };
   const snapshot: SelectionRedictationSnapshot = {
+    documentText: 'Context before selection original',
     editor: editor.editor,
     file,
     from: { ch: 4, line: 1 },
-    originalText: 'original',
     to: { ch: 12, line: 1 },
   };
   const session = new SelectionRedictationSession({
@@ -314,6 +329,7 @@ function createSessionHarness() {
     emitLayoutChange: () => layoutChange?.(),
     feedback,
     session,
+    snapshot,
     setOpenFile: (nextFile: TFile) => {
       openFile = nextFile;
     },
@@ -332,7 +348,7 @@ function createEditor({
   selectedText: string;
   selection: { anchor: EditorPosition; head: EditorPosition };
 }) {
-  const getRange = vi.fn((from: EditorPosition) =>
+  const getRange = vi.fn((from: EditorPosition, _to?: EditorPosition) =>
     from.line === 0 ? 'Context before selection' : selectedText,
   );
   const getValue = vi.fn(() => `Context before selection ${selectedText}`);


### PR DESCRIPTION
## Summary

- Add a **Local Dictation: Re-dictate selection** editor command for replacing one selected range with one spoken utterance.
- Keep the original text untouched during capture and replace it only when the first final transcript is ready.
- Fail closed if the exact editor, file, or captured document changes before startup or replacement.

## Key changes

- **Target safety:** Capture one non-empty selection plus the complete document snapshot. Any note-content change, target closure, deletion, editor replacement, or disposal leaves the original text untouched.
- **Preflight:** Revalidate after asynchronous microphone/sidecar checks and before starting a sidecar session or microphone capture.
- **Capture policy:** Use microphone audio only; force system audio and diarization off so computer audio cannot claim the one replacement utterance.
- **Finalization:** Stop capture on the first final revision, ignore every later revision, and apply the replacement in one undoable editor transaction.
- **Cleanup:** Convert replace-style batch timing to one per-utterance transform. Disable additive presets because this workflow has no adjacent output target or safe reason to invoke the provider.
- **Commands/feedback:** Contain unexpected command-start failures and provide specific cancellation, stale-target, empty-result, and replacement feedback.
- **Docs/tests:** Document the selection workflow and additive-cleanup policy; cover command, controller, cleanup, source, lifecycle, repeated-text, and editor behavior.

## Safety and privacy decisions

The full note snapshot is held only for the short re-dictation session and is never persisted or logged. Exact-document equality is intentionally conservative: editing any part of the note while re-dictating invalidates the replacement and requires selecting the target again.

Audio remains ephemeral. Selection re-dictation never includes system audio.

## Test plan

- [x] `npm run check:frontend` (typecheck, Biome, Obsidian ESLint, 747 Vitest tests, production frontend build)
- [x] Focused command/controller/selection suite (75 tests)
- [ ] Manual Obsidian microphone/undo pass not run in this non-interactive environment
