### PR TITLE
Remove redundant Obsidian wording from plugin descriptions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Local Dictation",
   "version": "2026.7.4",
   "minAppVersion": "1.11.5",
-  "description": "Private, offline speech-to-text and meeting transcription for Obsidian. Dictate voice notes live or transcribe meetings and system audio with local Whisper, speaker labels, timestamps, and optional AI cleanup.",
+  "description": "Private, offline speech-to-text and meeting transcription. Dictate voice notes live or transcribe meetings and system audio with local Whisper, speaker labels, timestamps, and optional AI cleanup.",
   "author": "Alexander Brittain",
   "authorUrl": "https://github.com/brittain9",
   "helpUrl": "https://github.com/brittain9/local-dictation-obsidian-plugin",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "local-dictation",
   "version": "2026.7.4",
-  "description": "Private, offline speech-to-text and meeting transcription for Obsidian. Dictate voice notes live or transcribe meetings and system audio with local Whisper, speaker labels, timestamps, and optional AI cleanup.",
+  "description": "Private, offline speech-to-text and meeting transcription. Dictate voice notes live or transcribe meetings and system audio with local Whisper, speaker labels, timestamps, and optional AI cleanup.",
   "private": true,
   "license": "MIT",
   "main": "main.js",


### PR DESCRIPTION
## Summary

- Remove the redundant host name from the plugin description in `manifest.json`.
- Keep the private `package.json` description synchronized with the manifest.

## Root cause

The community-store validator rejects plugin descriptions containing the word "Obsidian" because the plugin directory already establishes that context.

## Validation

- `git diff --check`
- JSON metadata validation: manifest description contains no case-insensitive "Obsidian" and matches package metadata
- `npm run check:release`
