### PR TITLE
Add raw transcript recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ All transcription models in the current catalog run locally and support English.
 - **Timestamps.** Add elapsed or wall-clock timestamps at configurable intervals.
 - **Local model choices.** Choose Whisper, Cohere Transcribe, or Moonshine models and download them from Settings.
 - **Optional text transformation.** Clean up, summarize, extract action items, or apply a custom prompt through local Ollama or remote OpenRouter models.
+- **Short-lived recovery.** Reinsert the latest finalized utterance, or copy and safely restore the raw text from the most recent replace-style batch cleanup.
 - **Explicit remote controls.** Keep transformations local, allow OpenRouter only for oversized transcripts, or disable remote and LLM features entirely.
 
 ## Getting started
@@ -75,6 +76,7 @@ For CUDA requirements and Flatpak-specific setup, see the [CUDA setup guide](doc
 - **Remote cleanup uses text, not audio.** If you configure and select OpenRouter, it receives the transcript plus any note context you choose to include. Ollama requests stay on your computer through its loopback interface.
 - **Remote processing is optional.** You can disable OpenRouter routing or all LLM features from Settings. If you use OpenRouter, configure its provider and zero-data-retention controls to match your requirements.
 - **Speaker identity is session-only.** Diarization embeddings are held in memory for the active session and are not persisted as voice profiles.
+- **Recovery text is memory-only.** At most one recent utterance and one raw/transformed batch-cleanup record with its document snapshot are retained. Disable retention or use the clear commands to discard them immediately; none of this recovery state is written to disk.
 
 ## Contributing
 

--- a/src/commands/register-commands.ts
+++ b/src/commands/register-commands.ts
@@ -6,14 +6,21 @@ const CANCEL_DICTATION_COMMAND_ID = 'cancel-dictation-session';
 const TOGGLE_DICTATION_COMMAND_ID = 'toggle-dictation-session';
 const REINSERT_LAST_UTTERANCE_COMMAND_ID = 'reinsert-last-utterance';
 const CLEAR_LAST_UTTERANCE_COMMAND_ID = 'clear-last-utterance';
+const RESTORE_RAW_TRANSCRIPT_COMMAND_ID = 'restore-raw-transcript';
+const COPY_RAW_TRANSCRIPT_COMMAND_ID = 'copy-raw-transcript';
+const CLEAR_RAW_RECOVERY_COMMAND_ID = 'clear-raw-transcript-recovery';
 
 interface CommandDependencies {
   cancelDictation: () => Promise<void>;
   clearLastUtterance: () => void;
+  clearRawTranscriptRecovery: () => void;
   checkSidecarHealth: () => Promise<void>;
+  copyRawTranscript: () => void;
+  hasRawTranscriptRecovery: () => boolean;
   plugin: Plugin;
   hasLastUtterance: () => boolean;
   reinsertLastUtterance: (editor: Editor) => void;
+  restoreRawTranscript: () => void;
   restartSidecar: () => Promise<void>;
   startDictation: () => Promise<void>;
   stopDictation: () => Promise<void>;
@@ -82,6 +89,39 @@ export function registerCommands(dependencies: CommandDependencies): void {
   });
 
   dependencies.plugin.addCommand({
+    id: RESTORE_RAW_TRANSCRIPT_COMMAND_ID,
+    name: 'Restore raw transcript',
+    checkCallback: (checking) =>
+      runAvailableCommand(
+        checking,
+        dependencies.hasRawTranscriptRecovery,
+        dependencies.restoreRawTranscript,
+      ),
+  });
+
+  dependencies.plugin.addCommand({
+    id: COPY_RAW_TRANSCRIPT_COMMAND_ID,
+    name: 'Copy raw transcript',
+    checkCallback: (checking) =>
+      runAvailableCommand(
+        checking,
+        dependencies.hasRawTranscriptRecovery,
+        dependencies.copyRawTranscript,
+      ),
+  });
+
+  dependencies.plugin.addCommand({
+    id: CLEAR_RAW_RECOVERY_COMMAND_ID,
+    name: 'Clear raw recovery',
+    checkCallback: (checking) =>
+      runAvailableCommand(
+        checking,
+        dependencies.hasRawTranscriptRecovery,
+        dependencies.clearRawTranscriptRecovery,
+      ),
+  });
+
+  dependencies.plugin.addCommand({
     id: 'check-sidecar-health',
     name: 'Check sidecar health',
     callback: async () => {
@@ -96,4 +136,18 @@ export function registerCommands(dependencies: CommandDependencies): void {
       await dependencies.restartSidecar();
     },
   });
+}
+
+function runAvailableCommand(
+  checking: boolean,
+  isAvailable: () => boolean,
+  run: () => void,
+): boolean {
+  if (!isAvailable()) {
+    return false;
+  }
+  if (!checking) {
+    run();
+  }
+  return true;
 }

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -10,6 +10,7 @@ import {
   formatSystemAudioSidecarErrorMessage,
 } from '../audio/system-audio-permission-message';
 import type { NotePlacementOptions, SurfaceDesynchronization } from '../editor/note-surface';
+import type { RawTranscriptRecoveryReceipt } from '../editor/raw-transcript-recovery';
 import {
   type LlmPostprocessMode,
   type LlmPresetOutput,
@@ -136,6 +137,7 @@ interface DictationSessionControllerDependencies {
   onLlmCleanupFailure?: (failure: LlmCleanupFailure) => void;
   onLlmCleanupSuccess?: () => void;
   onFinalizedUtteranceAccepted?: (text: string) => void;
+  onRawTranscriptRecoveryAvailable?: (receipt: RawTranscriptRecoveryReceipt) => void;
   onModelMissing?: () => void;
   onSidecarMissing?: () => void;
   countAudioInputDevices?: () => Promise<number | null>;
@@ -1208,7 +1210,7 @@ export class DictationSessionController {
         throw new ProviderError('Provider returned empty cleaned text.', 'invalid_response');
       }
 
-      const replaced = entry.session.replaceSessionRangeWithCleaned(cleanedText, {
+      const replacement = entry.session.replaceSessionRangeWithCleaned(cleanedText, {
         rawTextForCallout: transcriptText,
         showRawBelow: entry.snapshot.llmPostprocessShowRawBelow,
       });
@@ -1216,12 +1218,13 @@ export class DictationSessionController {
         return;
       }
 
-      if (!replaced) {
+      if (replacement.kind === 'denied') {
         this.dependencies.logger?.warn(
           'llm',
           'batch cleanup replacement skipped; session range no longer available',
         );
       } else {
+        this.dependencies.onRawTranscriptRecoveryAvailable?.(replacement.recovery);
         this.dependencies.logger?.debug('llm', 'batch cleanup complete', {
           chars: cleanedText.length,
         });

--- a/src/editor/note-surface.ts
+++ b/src/editor/note-surface.ts
@@ -325,6 +325,10 @@ export class NoteSurface {
     return this.view.state.doc.sliceString(range.from, range.to);
   }
 
+  readDocumentText(): string {
+    return this.view.state.doc.toString();
+  }
+
   rewriteRegion(
     range: RewriteRange,
     newText: string,

--- a/src/editor/raw-transcript-recovery.ts
+++ b/src/editor/raw-transcript-recovery.ts
@@ -1,0 +1,228 @@
+import type { EditorView } from '@codemirror/view';
+import type { App, TFile } from 'obsidian';
+
+import type { UserFeedback } from '../shared/user-feedback';
+
+interface ClipboardWriter {
+  writeText(text: string): Promise<void>;
+}
+
+interface MarkdownLeafLike {
+  view?: {
+    editor?: { cm?: EditorView };
+    file: TFile | null;
+  };
+}
+
+export interface RawTranscriptRecoveryReceipt {
+  readonly documentText: string;
+  readonly file: TFile;
+  readonly filePath: string;
+  readonly from: number;
+  readonly rawText: string;
+  readonly to: number;
+  readonly transformedText: string;
+  readonly view: EditorView;
+}
+
+interface RawTranscriptRecoveryDependencies {
+  feedback: Pick<UserFeedback, 'show'>;
+  getClipboard: () => ClipboardWriter | null | undefined;
+  workspace: Pick<App['workspace'], 'getLeavesOfType'>;
+}
+
+export class RawTranscriptRecovery {
+  private enabled = true;
+  private receipt: RawTranscriptRecoveryReceipt | null = null;
+
+  constructor(private readonly dependencies: RawTranscriptRecoveryDependencies) {}
+
+  hasRecovery(): boolean {
+    return this.enabled && this.receipt !== null;
+  }
+
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+    if (!enabled) {
+      this.clear();
+    }
+  }
+
+  record(receipt: RawTranscriptRecoveryReceipt): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    this.receipt = { ...receipt };
+  }
+
+  clear(): void {
+    this.receipt = null;
+  }
+
+  clearWithFeedback(): boolean {
+    if (!this.hasRecovery()) {
+      this.reportUnavailable();
+      return false;
+    }
+
+    this.clear();
+    this.dependencies.feedback.show({
+      intent: 'success',
+      key: 'raw-transcript-recovery-cleared',
+      message: 'Cleared the raw transcript recovery.',
+    });
+    return true;
+  }
+
+  async copyRawTranscript(): Promise<boolean> {
+    const receipt = this.receipt;
+    if (!this.enabled || receipt === null) {
+      this.reportUnavailable();
+      return false;
+    }
+
+    try {
+      const clipboard = this.dependencies.getClipboard();
+      if (clipboard === null || clipboard === undefined) {
+        throw new Error('Clipboard API unavailable.');
+      }
+      await clipboard.writeText(receipt.rawText);
+    } catch {
+      // Do not attach the clipboard error as feedback cause: a hostile or buggy
+      // implementation could echo the private text it was asked to copy.
+      this.dependencies.feedback.show({
+        intent: 'error',
+        key: 'raw-transcript-copy-failed',
+        message: 'Could not copy the raw transcript.',
+      });
+      return false;
+    }
+
+    this.dependencies.feedback.show({
+      intent: 'success',
+      key: 'raw-transcript-copied',
+      message: 'Copied the raw transcript.',
+    });
+    return true;
+  }
+
+  restoreRawTranscript(): boolean {
+    const receipt = this.receipt;
+    if (!this.enabled || receipt === null) {
+      this.reportUnavailable();
+      return false;
+    }
+
+    if (!this.isExactTargetOpen(receipt)) {
+      this.dependencies.feedback.show({
+        intent: 'warning',
+        key: 'raw-transcript-target-unavailable',
+        message:
+          'Could not restore the raw transcript because its original note is no longer open in the same editor.',
+      });
+      return false;
+    }
+
+    let currentDocument: string;
+    try {
+      currentDocument = receipt.view.state.doc.toString();
+    } catch {
+      this.dependencies.feedback.show({
+        intent: 'error',
+        key: 'raw-transcript-restore-failed',
+        message: 'Could not restore the raw transcript.',
+      });
+      return false;
+    }
+    if (
+      currentDocument !== receipt.documentText ||
+      !isValidRange(receipt.from, receipt.to, currentDocument.length) ||
+      currentDocument.slice(receipt.from, receipt.to) !== receipt.transformedText
+    ) {
+      this.dependencies.feedback.show({
+        intent: 'warning',
+        key: 'raw-transcript-restore-stale',
+        message: 'Could not restore the raw transcript because the note changed after cleanup.',
+      });
+      return false;
+    }
+
+    let actualRestoredDocument: string;
+    try {
+      // One dispatch produces one undoable document edit. No selection or
+      // follow-up transaction is needed; CodeMirror maps the existing caret.
+      receipt.view.dispatch({
+        changes: {
+          from: receipt.from,
+          insert: receipt.rawText,
+          to: receipt.to,
+        },
+      });
+      actualRestoredDocument = receipt.view.state.doc.toString();
+    } catch {
+      this.dependencies.feedback.show({
+        intent: 'error',
+        key: 'raw-transcript-restore-failed',
+        message: 'Could not restore the raw transcript.',
+      });
+      return false;
+    }
+
+    const restoredDocument = `${currentDocument.slice(0, receipt.from)}${receipt.rawText}${currentDocument.slice(receipt.to)}`;
+    if (actualRestoredDocument !== restoredDocument) {
+      this.dependencies.feedback.show({
+        intent: 'error',
+        key: 'raw-transcript-restore-failed',
+        message: 'Could not restore the raw transcript.',
+      });
+      return false;
+    }
+
+    if (this.receipt === receipt) {
+      this.clear();
+    }
+    this.dependencies.feedback.show({
+      intent: 'success',
+      key: 'raw-transcript-restored',
+      message: 'Restored the raw transcript.',
+    });
+    return true;
+  }
+
+  private isExactTargetOpen(receipt: RawTranscriptRecoveryReceipt): boolean {
+    if (receipt.file.path !== receipt.filePath) {
+      return false;
+    }
+
+    let matchingLeaves = 0;
+    for (const leaf of this.dependencies.workspace.getLeavesOfType(
+      'markdown',
+    ) as unknown as MarkdownLeafLike[]) {
+      if (leaf.view?.file !== receipt.file || leaf.view.editor?.cm !== receipt.view) {
+        continue;
+      }
+      matchingLeaves += 1;
+    }
+
+    return matchingLeaves === 1;
+  }
+
+  private reportUnavailable(): void {
+    this.dependencies.feedback.show({
+      intent: 'information',
+      key: 'raw-transcript-recovery-unavailable',
+      message: 'No raw transcript recovery is available.',
+    });
+  }
+}
+
+function isValidRange(from: number, to: number, documentLength: number): boolean {
+  return (
+    Number.isInteger(from) &&
+    Number.isInteger(to) &&
+    from >= 0 &&
+    to >= from &&
+    to <= documentLength
+  );
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { LastUtteranceRecovery } from './dictation/last-utterance-recovery';
 import { dictationAnchorExtension } from './editor/dictation-anchor-extension';
 import { noteSurfaceUpdateListenerExtension } from './editor/note-surface';
 import { provisionalTranscriptExtension } from './editor/provisional-transcript-extension';
+import { RawTranscriptRecovery } from './editor/raw-transcript-recovery';
 import { sessionProcessingExtension } from './editor/session-processing-extension';
 import { TemporaryLeafPinLeaseManager } from './editor/temporary-leaf-pin';
 import type { LlmCleanupFailure } from './llm/provider';
@@ -67,6 +68,11 @@ export default class LocalSttPlugin extends Plugin {
   private readonly llmCleanupFailureSubscribers = new Set<() => void>();
   private modelInstallManager: ModelInstallManager | null = null;
   private presetStateStore: LlmPresetStateStore | null = null;
+  private readonly rawTranscriptRecovery = new RawTranscriptRecovery({
+    feedback: this.feedback,
+    getClipboard: () => window.navigator.clipboard,
+    workspace: this.app.workspace,
+  });
   private ribbonController: DictationRibbonController | null = null;
   private settings: PluginSettings = DEFAULT_PLUGIN_SETTINGS;
   private sidecarConnection: SidecarConnection | null = null;
@@ -77,6 +83,7 @@ export default class LocalSttPlugin extends Plugin {
     const loadedSettings = loadPluginSettings(await this.loadData(), this.app.secretStorage);
     this.settings = loadedSettings.settings;
     this.lastUtteranceRecovery.setEnabled(this.settings.retainLastUtterance);
+    this.rawTranscriptRecovery.setEnabled(this.settings.retainLastUtterance);
     if (loadedSettings.shouldPersist) {
       await this.saveData(this.settings);
     }
@@ -202,6 +209,9 @@ export default class LocalSttPlugin extends Plugin {
       onFinalizedUtteranceAccepted: (text) => {
         this.lastUtteranceRecovery.recordFinalizedUtterance(text);
       },
+      onRawTranscriptRecoveryAvailable: (receipt) => {
+        this.rawTranscriptRecovery.record(receipt);
+      },
       onModelMissing: () => {
         void this.openModelPicker();
       },
@@ -251,11 +261,21 @@ export default class LocalSttPlugin extends Plugin {
           message: 'Cleared the last retained utterance.',
         });
       },
+      clearRawTranscriptRecovery: () => {
+        this.rawTranscriptRecovery.clearWithFeedback();
+      },
       checkSidecarHealth: async () => this.checkSidecarHealth(),
+      copyRawTranscript: () => {
+        void this.rawTranscriptRecovery.copyRawTranscript();
+      },
       hasLastUtterance: () => this.lastUtteranceRecovery.hasUtterance(),
+      hasRawTranscriptRecovery: () => this.rawTranscriptRecovery.hasRecovery(),
       plugin: this,
       reinsertLastUtterance: (editor) => {
         this.lastUtteranceRecovery.reinsert(editor);
+      },
+      restoreRawTranscript: () => {
+        this.rawTranscriptRecovery.restoreRawTranscript();
       },
       restartSidecar: async () => this.restartSidecar(),
       startDictation: async () => this.requireDictationController().startDictation(),
@@ -412,6 +432,7 @@ export default class LocalSttPlugin extends Plugin {
 
   private async disposeAll(): Promise<void> {
     this.lastUtteranceRecovery.clear();
+    this.rawTranscriptRecovery.clear();
 
     try {
       this.modelInstallManager?.dispose();
@@ -514,6 +535,7 @@ export default class LocalSttPlugin extends Plugin {
     const previousSettings = this.settings;
     this.settings = resolvePluginSettings(nextSettings);
     this.lastUtteranceRecovery.setEnabled(this.settings.retainLastUtterance);
+    this.rawTranscriptRecovery.setEnabled(this.settings.retainLastUtterance);
     if (options.persist) {
       await this.saveData(this.settings);
     }

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -14,6 +14,7 @@ import {
   type RewriteResult,
   type SurfaceDesynchronization,
 } from '../editor/note-surface';
+import type { RawTranscriptRecoveryReceipt } from '../editor/raw-transcript-recovery';
 import type {
   PinnableLeaf,
   TemporaryLeafPinLease,
@@ -58,6 +59,10 @@ export type SessionAcceptResult =
   | { kind: 'rejected'; reason: string }
   | { kind: 'stale' };
 
+export type SessionRangeReplacementResult =
+  | { kind: 'denied' }
+  | { kind: 'replaced'; recovery: RawTranscriptRecoveryReceipt };
+
 export interface SessionLifecycleCallbacks {
   onLockedNoteClosed: () => void;
   onLockedNoteDeleted: () => void;
@@ -89,6 +94,7 @@ interface NoteSurfaceLike {
   readNoteGlossary(maxChars: number): { text: string; truncated: boolean } | null;
   readNoteText(maxChars: number): { text: string; truncated: boolean } | null;
   readProjectionContext(): NoteProjectionContext;
+  readDocumentText(): string;
   replaceAnchor(
     utteranceId: string,
     newText: string,
@@ -247,14 +253,19 @@ export class Session {
       rawTextForCallout?: string;
       showRawBelow?: boolean;
     } = {},
-  ): boolean {
+  ): SessionRangeReplacementResult {
     if (this.surface === null || this.rawSessionEntries.length === 0) {
-      return false;
+      return { kind: 'denied' };
     }
 
     const range = this.resolveSessionRange();
     if (range === null) {
-      return false;
+      return { kind: 'denied' };
+    }
+
+    const rawText = this.surface.readRange(range);
+    if (rawText === null) {
+      return { kind: 'denied' };
     }
 
     const replacement = this.buildCleanedReplacement(
@@ -275,10 +286,26 @@ export class Session {
 
     if (result.kind === 'denied' && result.reason.kind === 'surface_desynchronized') {
       this.handleSurfaceDesynchronization(result.reason);
-      return false;
+      return { kind: 'denied' };
     }
 
-    return result.kind === 'rewritten';
+    if (result.kind !== 'rewritten') {
+      return { kind: 'denied' };
+    }
+
+    return {
+      kind: 'replaced',
+      recovery: {
+        documentText: this.surface.readDocumentText(),
+        file: this.dependencies.lockedFile,
+        filePath: this.dependencies.lockedFile.path,
+        from: result.range.from,
+        rawText,
+        to: result.range.from + replacement.length,
+        transformedText: replacement,
+        view: this.dependencies.view,
+      },
+    };
   }
 
   insertAdjacentToSessionRange(blockText: string, placement: 'above' | 'below'): boolean {

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -245,8 +245,8 @@ export class LocalSttSettingTab extends PluginSettingTab {
     this.disposeDiarizationDesc = manager.subscribe(updateDiarizationDesc);
 
     addToggleSetting(outputCard, this.access, {
-      name: 'Keep last utterance for recovery',
-      desc: 'Keep the latest finalized utterance in memory for the Reinsert last utterance command. The text is never saved to disk and is cleared when disabled or the plugin unloads.',
+      name: 'Keep recovery text in memory',
+      desc: 'Keep the latest utterance and one raw/transformed batch-cleanup record with its document snapshot. Nothing is saved to disk; disabling this clears it immediately.',
       key: 'retainLastUtterance',
     });
 

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -5,9 +5,10 @@ import {
   DictationSessionController,
 } from '../src/dictation/dictation-session-controller';
 import type { NotePlacementOptions, SurfaceDesynchronization } from '../src/editor/note-surface';
+import type { RawTranscriptRecoveryReceipt } from '../src/editor/raw-transcript-recovery';
 import { type LlmCleanupFailure, ProviderError } from '../src/llm/provider';
 import type { LlmRouter, LlmRouterCleanupResult } from '../src/llm/router';
-import type { SessionAcceptResult } from '../src/session/session';
+import type { SessionAcceptResult, SessionRangeReplacementResult } from '../src/session/session';
 import type { TranscriptRevision } from '../src/session/session-journal';
 import { DEFAULT_PLUGIN_SETTINGS, type PluginSettings } from '../src/settings/plugin-settings';
 import type { UserFeedback } from '../src/shared/user-feedback';
@@ -91,9 +92,22 @@ class FakeSession {
         rawTextForCallout?: string;
         showRawBelow?: boolean;
       },
-    ) => {
+    ): SessionRangeReplacementResult => {
+      const rawText = this.currentSessionText;
       this.currentSessionText = cleanText;
-      return true;
+      return {
+        kind: 'replaced' as const,
+        recovery: {
+          documentText: cleanText,
+          file: {} as never,
+          filePath: 'note.md',
+          from: 0,
+          rawText,
+          to: cleanText.length,
+          transformedText: cleanText,
+          view: {} as never,
+        },
+      };
     },
   );
   public readonly setAnchorMode = vi.fn((_mode: 'hidden' | 'visible') => {});
@@ -1369,6 +1383,8 @@ describe('DictationSessionController', () => {
   it('runs batch cleanup through the router and replaces the session range', async () => {
     const sidecarConnection = new FakeSidecarConnection();
     const sessions: FakeSession[] = [];
+    const logger = new FakeLogger();
+    const onRawTranscriptRecoveryAvailable = vi.fn();
     const cleanup = vi.fn(
       async (): Promise<LlmRouterCleanupResult> => ({
         model: 'llama3.2:latest',
@@ -1387,6 +1403,8 @@ describe('DictationSessionController', () => {
           selectedModel: createExternalModelSelection(),
         }),
       llmRouter: createFakeLlmRouter({ cleanup }),
+      logger,
+      onRawTranscriptRecoveryAvailable,
       sidecarConnection,
     });
 
@@ -1409,7 +1427,59 @@ describe('DictationSessionController', () => {
         expect.objectContaining({ rawTextForCallout: 'raw transcript' }),
       );
     });
+    expect(onRawTranscriptRecoveryAvailable).toHaveBeenCalledOnce();
+    expect(onRawTranscriptRecoveryAvailable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rawText: 'raw transcript',
+        transformedText: 'Clean batch.',
+      }),
+    );
+    const serializedLogs = JSON.stringify([
+      logger.debug.mock.calls,
+      logger.error.mock.calls,
+      logger.warn.mock.calls,
+    ]);
+    expect(serializedLogs).not.toContain('raw transcript');
+    expect(serializedLogs).not.toContain('Clean batch.');
     expect(sessions[0]?.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not capture raw recovery when the batch replacement is denied', async () => {
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const onRawTranscriptRecoveryAvailable = vi.fn();
+    const controller = createController({
+      createSession: (session) => {
+        sessions.push(session);
+        session.replaceSessionRangeWithCleaned.mockReturnValueOnce({ kind: 'denied' });
+      },
+      getSettings: () =>
+        createSettings({
+          llmFeaturesEnabled: true,
+          llmPostprocessMode: 'batch',
+          selectedModel: createExternalModelSelection(),
+        }),
+      llmRouter: createFakeLlmRouter({
+        cleanup: vi.fn(async () => ({
+          model: 'm',
+          providerId: 'ollama' as const,
+          text: 'Clean batch.',
+        })),
+      }),
+      onRawTranscriptRecoveryAvailable,
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    sidecarConnection.emit(transcriptReady(sessionId, 'raw transcript'));
+    await controller.stopDictation();
+    sidecarConnection.emit({ reason: 'user_stop', sessionId, type: 'session_stopped' });
+
+    await vi.waitFor(() => {
+      expect(sessions[0]?.replaceSessionRangeWithCleaned).toHaveBeenCalledOnce();
+    });
+    expect(onRawTranscriptRecoveryAvailable).not.toHaveBeenCalled();
   });
 
   it('keeps the raw utterance and reports failure when per-utterance cleanup returns empty text', async () => {
@@ -1503,6 +1573,7 @@ describe('DictationSessionController', () => {
         text: 'TLDR\n- point',
       }),
     );
+    const onRawTranscriptRecoveryAvailable = vi.fn();
     const controller = createController({
       createSession: (session) => {
         sessions.push(session);
@@ -1515,6 +1586,7 @@ describe('DictationSessionController', () => {
           selectedModel: createExternalModelSelection(),
         }),
       llmRouter: createFakeLlmRouter({ cleanup }),
+      onRawTranscriptRecoveryAvailable,
       sidecarConnection,
     });
 
@@ -1531,6 +1603,7 @@ describe('DictationSessionController', () => {
       );
     });
     expect(sessions[0]?.replaceSessionRangeWithCleaned).not.toHaveBeenCalled();
+    expect(onRawTranscriptRecoveryAvailable).not.toHaveBeenCalled();
     expect(sessions[0]?.dispose).toHaveBeenCalledTimes(1);
   });
 
@@ -1902,12 +1975,17 @@ describe('DictationSessionController', () => {
         kind: 'surface_desynchronized',
         trackedPosition: 4314,
       });
-      return false;
     };
     if (activePresetRef === undefined) {
-      session.replaceSessionRangeWithCleaned.mockImplementationOnce(reportFatalFailure);
+      session.replaceSessionRangeWithCleaned.mockImplementationOnce(() => {
+        reportFatalFailure();
+        return { kind: 'denied' };
+      });
     } else {
-      session.insertAdjacentToSessionRange.mockImplementationOnce(reportFatalFailure);
+      session.insertAdjacentToSessionRange.mockImplementationOnce(() => {
+        reportFatalFailure();
+        return false;
+      });
     }
     sidecarConnection.emit({ reason: 'user_stop', sessionId, type: 'session_stopped' });
 
@@ -2399,6 +2477,7 @@ function createController({
   onLlmCleanupFailure,
   onLlmCleanupSuccess,
   onFinalizedUtteranceAccepted,
+  onRawTranscriptRecoveryAvailable,
 }: {
   audioLevelMeter?: FakeAudioLevelMeter;
   captureStream?: FakeCaptureStream;
@@ -2411,6 +2490,7 @@ function createController({
   onLlmCleanupFailure?: (failure: LlmCleanupFailure) => void;
   onLlmCleanupSuccess?: () => void;
   onFinalizedUtteranceAccepted?: (text: string) => void;
+  onRawTranscriptRecoveryAvailable?: (receipt: RawTranscriptRecoveryReceipt) => void;
   sidecarConnection?: FakeSidecarConnection;
 } = {}): DictationSessionController {
   return new DictationSessionController({
@@ -2429,6 +2509,7 @@ function createController({
     ...(onLlmCleanupFailure !== undefined ? { onLlmCleanupFailure } : {}),
     ...(onLlmCleanupSuccess !== undefined ? { onLlmCleanupSuccess } : {}),
     ...(onFinalizedUtteranceAccepted !== undefined ? { onFinalizedUtteranceAccepted } : {}),
+    ...(onRawTranscriptRecoveryAvailable !== undefined ? { onRawTranscriptRecoveryAvailable } : {}),
     onModelMissing: vi.fn(),
     onSidecarMissing: vi.fn(),
     setRibbonQueueTier: vi.fn((_tier: QueueBackpressureTier) => {}),

--- a/test/raw-transcript-recovery.test.ts
+++ b/test/raw-transcript-recovery.test.ts
@@ -1,0 +1,248 @@
+import { EditorState, type TransactionSpec } from '@codemirror/state';
+import type { EditorView } from '@codemirror/view';
+import type { TFile } from 'obsidian';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  RawTranscriptRecovery,
+  type RawTranscriptRecoveryReceipt,
+} from '../src/editor/raw-transcript-recovery';
+
+class StateBackedEditorView {
+  state: EditorState;
+  readonly dispatch = vi.fn((spec: TransactionSpec) => {
+    this.state = this.state.update(spec).state;
+  });
+
+  constructor(documentText: string) {
+    this.state = EditorState.create({ doc: documentText });
+  }
+}
+
+describe('RawTranscriptRecovery', () => {
+  it('overwrites the prior record and copies only the latest raw transcript', async () => {
+    const harness = createHarness('clean one');
+    harness.recovery.record(harness.receipt({ rawText: 'raw one' }));
+    harness.view.state = EditorState.create({ doc: 'clean two' });
+    harness.recovery.record(
+      harness.receipt({
+        documentText: 'clean two',
+        rawText: 'raw two',
+        to: 'clean two'.length,
+        transformedText: 'clean two',
+      }),
+    );
+
+    expect(await harness.recovery.copyRawTranscript()).toBe(true);
+
+    expect(harness.writeText).toHaveBeenCalledOnce();
+    expect(harness.writeText).toHaveBeenCalledWith('raw two');
+    expect(harness.feedback.show).toHaveBeenLastCalledWith({
+      intent: 'success',
+      key: 'raw-transcript-copied',
+      message: 'Copied the raw transcript.',
+    });
+    expect(harness.recovery.restoreRawTranscript()).toBe(true);
+    expect(harness.view.state.doc.toString()).toBe('raw two');
+  });
+
+  it('clears immediately when disabled and ignores records until re-enabled', () => {
+    const harness = createHarness('clean');
+    harness.recovery.record(harness.receipt({ rawText: 'private raw' }));
+
+    harness.recovery.setEnabled(false);
+    harness.recovery.record(harness.receipt({ rawText: 'must not persist' }));
+
+    expect(harness.recovery.hasRecovery()).toBe(false);
+
+    harness.recovery.setEnabled(true);
+    expect(harness.recovery.hasRecovery()).toBe(false);
+
+    harness.recovery.record(harness.receipt({ rawText: 'new raw' }));
+    expect(harness.recovery.hasRecovery()).toBe(true);
+  });
+
+  it('restores the exact range with one transaction and consumes the record', () => {
+    const harness = createHarness('before clean after', {
+      from: 'before '.length,
+      rawText: 'raw words',
+      to: 'before clean'.length,
+      transformedText: 'clean',
+    });
+    harness.recovery.record(harness.receipt());
+
+    expect(harness.recovery.restoreRawTranscript()).toBe(true);
+
+    expect(harness.view.dispatch).toHaveBeenCalledOnce();
+    expect(harness.view.dispatch).toHaveBeenCalledWith({
+      changes: {
+        from: 'before '.length,
+        insert: 'raw words',
+        to: 'before clean'.length,
+      },
+    });
+    expect(harness.view.state.doc.toString()).toBe('before raw words after');
+    expect(harness.recovery.hasRecovery()).toBe(false);
+  });
+
+  it('refuses restore after any document change without editing the note', () => {
+    const harness = createHarness('before clean after', {
+      from: 'before '.length,
+      rawText: 'raw words',
+      to: 'before clean'.length,
+      transformedText: 'clean',
+    });
+    harness.recovery.record(harness.receipt());
+    harness.view.state = harness.view.state.update({
+      changes: { from: 0, insert: 'changed ' },
+    }).state;
+
+    expect(harness.recovery.restoreRawTranscript()).toBe(false);
+
+    expect(harness.view.dispatch).not.toHaveBeenCalled();
+    expect(harness.feedback.show).toHaveBeenLastCalledWith({
+      intent: 'warning',
+      key: 'raw-transcript-restore-stale',
+      message: 'Could not restore the raw transcript because the note changed after cleanup.',
+    });
+  });
+
+  it('keeps recovery available when the editor filters out the restore edit', () => {
+    const harness = createHarness('clean');
+    harness.recovery.record(harness.receipt({ rawText: 'raw' }));
+    harness.view.dispatch.mockImplementationOnce((_spec) => {});
+
+    expect(harness.recovery.restoreRawTranscript()).toBe(false);
+
+    expect(harness.view.dispatch).toHaveBeenCalledOnce();
+    expect(harness.recovery.hasRecovery()).toBe(true);
+    expect(harness.feedback.show).toHaveBeenLastCalledWith({
+      intent: 'error',
+      key: 'raw-transcript-restore-failed',
+      message: 'Could not restore the raw transcript.',
+    });
+  });
+
+  it('refuses restore when the exact editor and file target is no longer open', () => {
+    const harness = createHarness('clean');
+    harness.recovery.record(harness.receipt({ rawText: 'raw' }));
+    harness.leaves.splice(0);
+
+    expect(harness.recovery.restoreRawTranscript()).toBe(false);
+
+    expect(harness.view.dispatch).not.toHaveBeenCalled();
+    expect(harness.feedback.show).toHaveBeenLastCalledWith({
+      intent: 'warning',
+      key: 'raw-transcript-target-unavailable',
+      message:
+        'Could not restore the raw transcript because its original note is no longer open in the same editor.',
+    });
+  });
+
+  it('clears explicitly and hides recovery availability', () => {
+    const harness = createHarness('clean');
+    harness.recovery.record(harness.receipt({ rawText: 'raw' }));
+
+    expect(harness.recovery.clearWithFeedback()).toBe(true);
+
+    expect(harness.recovery.hasRecovery()).toBe(false);
+    expect(harness.feedback.show).toHaveBeenLastCalledWith({
+      intent: 'success',
+      key: 'raw-transcript-recovery-cleared',
+      message: 'Cleared the raw transcript recovery.',
+    });
+  });
+
+  it('reports unavailable consistently when no recovery record exists', async () => {
+    const harness = createHarness('clean');
+
+    expect(harness.recovery.restoreRawTranscript()).toBe(false);
+    expect(await harness.recovery.copyRawTranscript()).toBe(false);
+    expect(harness.recovery.clearWithFeedback()).toBe(false);
+
+    expect(harness.feedback.show).toHaveBeenCalledTimes(3);
+    for (const [request] of harness.feedback.show.mock.calls) {
+      expect(request).toEqual({
+        intent: 'information',
+        key: 'raw-transcript-recovery-unavailable',
+        message: 'No raw transcript recovery is available.',
+      });
+    }
+  });
+
+  it('reports copy failure without leaking either transcript through feedback', async () => {
+    const rawText = 'private raw transcript';
+    const transformedText = 'private transformed transcript';
+    const harness = createHarness(transformedText, {
+      rawText,
+      to: transformedText.length,
+      transformedText,
+      writeText: vi.fn(async (text: string) => {
+        throw new Error(`clipboard rejected: ${text}`);
+      }),
+    });
+    harness.recovery.record(harness.receipt());
+
+    expect(await harness.recovery.copyRawTranscript()).toBe(false);
+
+    const serializedFeedback = JSON.stringify(harness.feedback.show.mock.calls);
+    expect(serializedFeedback).not.toContain(rawText);
+    expect(serializedFeedback).not.toContain(transformedText);
+    expect(harness.feedback.show).toHaveBeenLastCalledWith({
+      intent: 'error',
+      key: 'raw-transcript-copy-failed',
+      message: 'Could not copy the raw transcript.',
+    });
+  });
+});
+
+function createHarness(
+  documentText: string,
+  options: {
+    from?: number;
+    rawText?: string;
+    to?: number;
+    transformedText?: string;
+    writeText?: ReturnType<typeof vi.fn<(text: string) => Promise<void>>>;
+  } = {},
+) {
+  const file = { path: 'note.md' } as TFile;
+  const view = new StateBackedEditorView(documentText);
+  const leaves = [
+    {
+      view: {
+        editor: { cm: view as unknown as EditorView },
+        file,
+      },
+    },
+  ];
+  const feedback = { show: vi.fn() };
+  const writeText = options.writeText ?? vi.fn(async (_text: string) => {});
+  const recovery = new RawTranscriptRecovery({
+    feedback,
+    getClipboard: () => ({ writeText }),
+    workspace: { getLeavesOfType: () => leaves as never },
+  });
+  const defaults = {
+    documentText,
+    file,
+    filePath: file.path,
+    from: options.from ?? 0,
+    rawText: options.rawText ?? 'raw',
+    to: options.to ?? documentText.length,
+    transformedText: options.transformedText ?? documentText,
+    view: view as unknown as EditorView,
+  } satisfies RawTranscriptRecoveryReceipt;
+
+  return {
+    feedback,
+    leaves,
+    receipt: (overrides: Partial<RawTranscriptRecoveryReceipt> = {}) => ({
+      ...defaults,
+      ...overrides,
+    }),
+    recovery,
+    view,
+    writeText,
+  };
+}

--- a/test/register-commands.test.ts
+++ b/test/register-commands.test.ts
@@ -19,10 +19,14 @@ describe('registerCommands', () => {
     registerCommands({
       cancelDictation: vi.fn(async () => {}),
       clearLastUtterance,
+      clearRawTranscriptRecovery: vi.fn(),
       checkSidecarHealth: vi.fn(async () => {}),
+      copyRawTranscript: vi.fn(),
       hasLastUtterance: () => available,
+      hasRawTranscriptRecovery: () => false,
       plugin,
       reinsertLastUtterance,
+      restoreRawTranscript: vi.fn(),
       restartSidecar: vi.fn(async () => {}),
       startDictation: vi.fn(async () => {}),
       stopDictation: vi.fn(async () => {}),
@@ -53,5 +57,62 @@ describe('registerCommands', () => {
     expect(clearLastUtterance).toHaveBeenCalledOnce();
     expect(reinsertCommand?.editorCheckCallback?.(true, editor, {} as never)).toBe(false);
     expect(clearCommand?.checkCallback?.(true)).toBe(false);
+  });
+
+  it('gates raw transcript recovery commands on one shared availability source', () => {
+    const commands: Command[] = [];
+    const plugin = {
+      addCommand: vi.fn((command: Command) => {
+        commands.push(command);
+      }),
+    } as unknown as Plugin;
+    let available = false;
+    const clearRawTranscriptRecovery = vi.fn(() => {
+      available = false;
+    });
+    const copyRawTranscript = vi.fn();
+    const restoreRawTranscript = vi.fn();
+    registerCommands({
+      cancelDictation: vi.fn(async () => {}),
+      clearLastUtterance: vi.fn(),
+      clearRawTranscriptRecovery,
+      checkSidecarHealth: vi.fn(async () => {}),
+      copyRawTranscript,
+      hasLastUtterance: () => false,
+      hasRawTranscriptRecovery: () => available,
+      plugin,
+      reinsertLastUtterance: vi.fn(),
+      restoreRawTranscript,
+      restartSidecar: vi.fn(async () => {}),
+      startDictation: vi.fn(async () => {}),
+      stopDictation: vi.fn(async () => {}),
+      toggleDictation: vi.fn(async () => {}),
+    });
+    const restoreCommand = commands.find(({ id }) => id === 'restore-raw-transcript');
+    const copyCommand = commands.find(({ id }) => id === 'copy-raw-transcript');
+    const clearCommand = commands.find(({ id }) => id === 'clear-raw-transcript-recovery');
+
+    expect(restoreCommand?.name).toBe('Restore raw transcript');
+    expect(copyCommand?.name).toBe('Copy raw transcript');
+    expect(clearCommand?.name).toBe('Clear raw recovery');
+    expect(restoreCommand?.checkCallback?.(true)).toBe(false);
+    expect(copyCommand?.checkCallback?.(true)).toBe(false);
+    expect(clearCommand?.checkCallback?.(true)).toBe(false);
+
+    available = true;
+    expect(restoreCommand?.checkCallback?.(true)).toBe(true);
+    expect(copyCommand?.checkCallback?.(true)).toBe(true);
+    expect(clearCommand?.checkCallback?.(true)).toBe(true);
+    expect(restoreRawTranscript).not.toHaveBeenCalled();
+    expect(copyRawTranscript).not.toHaveBeenCalled();
+    expect(clearRawTranscriptRecovery).not.toHaveBeenCalled();
+
+    expect(restoreCommand?.checkCallback?.(false)).toBe(true);
+    expect(copyCommand?.checkCallback?.(false)).toBe(true);
+    expect(clearCommand?.checkCallback?.(false)).toBe(true);
+    expect(restoreRawTranscript).toHaveBeenCalledOnce();
+    expect(copyRawTranscript).toHaveBeenCalledOnce();
+    expect(clearRawTranscriptRecovery).toHaveBeenCalledOnce();
+    expect(restoreCommand?.checkCallback?.(true)).toBe(false);
   });
 });

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -141,6 +141,10 @@ class FakeSurface {
     return this.documentText.slice(range.from, range.to);
   }
 
+  readDocumentText(): string {
+    return this.documentText;
+  }
+
   rewriteRegion(
     range: RewriteRange,
     newText: string,
@@ -693,7 +697,7 @@ describe('Session', () => {
   });
 
   it('tracks transcript revisions through batch-cleaned range replacement', () => {
-    const { session, surface } = createSessionHarness();
+    const { lockedFile, session, surface, targetLeaf } = createSessionHarness();
 
     session.acceptTranscript(transcript({ revision: 0, text: 'rough', utteranceId: 'u1' }));
     session.acceptTranscript(transcript({ revision: 1, text: 'polished', utteranceId: 'u1' }));
@@ -701,7 +705,24 @@ describe('Session', () => {
 
     expect(surface.documentText).toBe('polished tail');
     expect(session.joinRawSessionText()).toBe('polished tail');
-    expect(session.replaceSessionRangeWithCleaned('Polished tail.')).toBe(true);
+    const replacement = session.replaceSessionRangeWithCleaned('Polished tail.');
+
+    expect(replacement).toMatchObject({
+      kind: 'replaced',
+      recovery: {
+        documentText: 'Polished tail.',
+        from: 0,
+        rawText: 'polished tail',
+        to: 'Polished tail.'.length,
+        transformedText: 'Polished tail.',
+      },
+    });
+    if (replacement.kind !== 'replaced') {
+      throw new Error('expected batch replacement receipt');
+    }
+    expect(replacement.recovery.file).toBe(lockedFile);
+    expect(replacement.recovery.filePath).toBe('note.md');
+    expect(replacement.recovery.view).toBe(targetLeaf.view.editor.cm);
 
     expect(surface.rewriteCalls).toEqual([
       {
@@ -732,7 +753,7 @@ describe('Session', () => {
     session.acceptTranscript(transcript({ text: 'raw words', utteranceId: 'u1' }));
     surface.documentText = 'raw words tail';
 
-    expect(session.replaceSessionRangeWithCleaned('Cleaned words.')).toBe(true);
+    expect(session.replaceSessionRangeWithCleaned('Cleaned words.').kind).toBe('replaced');
     expect(surface.rewriteCalls).toEqual([
       {
         newText: 'Cleaned words.',
@@ -751,8 +772,8 @@ describe('Session', () => {
     expect(
       session.replaceSessionRangeWithCleaned('Cleaned words.', {
         showRawBelow: true,
-      }),
-    ).toBe(true);
+      }).kind,
+    ).toBe('replaced');
     expect(surface.documentText).toBe('Cleaned words.\n\n> [!note]- raw\n> raw words');
   });
 
@@ -838,7 +859,7 @@ describe('Session', () => {
     session.acceptTranscript(transcript({ text: 'raw words', utteranceId: 'u1' }));
 
     expect(surface.documentText).toBe('Existing raw words');
-    expect(session.replaceSessionRangeWithCleaned('Cleaned words.')).toBe(true);
+    expect(session.replaceSessionRangeWithCleaned('Cleaned words.').kind).toBe('replaced');
     expect(surface.documentText).toBe('Existing Cleaned words.');
   });
 
@@ -853,7 +874,7 @@ describe('Session', () => {
 
     expect(surface.documentText).toBe('[2026-05-16 14:32]\n(0:00) raw words');
     expect(session.readCurrentSessionText()).toBe('[2026-05-16 14:32]\n(0:00) raw words');
-    expect(session.replaceSessionRangeWithCleaned('Cleaned words.')).toBe(true);
+    expect(session.replaceSessionRangeWithCleaned('Cleaned words.').kind).toBe('replaced');
     expect(surface.documentText).toBe('Cleaned words.');
   });
 


### PR DESCRIPTION
## Stacked dependency

This draft is stacked on #232 and targets `feat/reinsert-last-utterance` at `91e275d`. Review and merge #232 first; this PR contains only the raw batch-cleanup recovery follow-up.

Follow-up 1 of 5 in this improvement pass.

## Summary

- retain one short-lived, memory-only recovery receipt after a successful replace-style batch LLM cleanup
- expose `Restore raw transcript`, `Copy raw transcript`, and `Clear raw recovery` commands from one availability source
- reuse #232's persisted recovery-retention opt-out, clearing both recovery buffers immediately when disabled or unloaded
- overwrite the prior raw recovery receipt; additive transforms create no receipt because their raw transcript remains in the note

## Restore safety and privacy

- the receipt holds the exact raw and transformed range text, file and editor identity, file path, range, and post-cleanup full-document snapshot
- restore requires the same uniquely open file/editor, unchanged file path, exact full document, and exact transformed range
- restore uses one CodeMirror document transaction and verifies the resulting document before consuming the receipt
- stale or closed targets fail without an edit; clipboard and restore errors never attach transcript-bearing causes to feedback
- transcript and document content remain in memory only and are never persisted or logged

## Verification

- focused recovery/session/controller/command/settings suite: 178 tests passed before the final defensive checks
- `npm run check:frontend`: typecheck, Biome, Obsidian ESLint, 59 test files / 751 tests, and production frontend build passed
- final focused recovery suite: 9 tests passed

The existing Biome schema-version informational message and SettingsTab search warning remain unchanged.

## Behavioral caveat

Restore intentionally fails after any note edit, file rename, editor replacement, or target closure. Copy remains available so the user can recover the raw text manually without risking a stale overwrite.

Relates to #228.