### PR TITLE
feat: add deterministic Markdown voice commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ _The first-run wizard installs the native engine and helps you choose between li
 | --- | --- | --- |
 | **Live dictation** | Provisional words appear and revise in place while you speak. | Moonshine streaming models |
 | **Selection re-dictation** | Select text and speak a replacement; the original stays untouched until the first final transcript is ready. | Any transcription model |
+| **Markdown voice commands** | Run an explicit command, speak one formatting phrase, and insert deterministic Markdown at the captured cursor. | Any transcription model |
 | **Notes and drafts** | Final text lands at your cursor after each pause. | Whisper or Cohere Transcribe batch models |
 | **Meetings and calls** | Add computer audio to microphone capture, then optionally label speakers and add timestamps. | Whisper or Cohere Transcribe batch models |
 
@@ -37,10 +38,13 @@ All transcription models in the current catalog run locally and support English.
 
 Selection re-dictation applies active replace-style AI cleanup. Presets that add summaries or action items above or below a transcript are skipped because this workflow has only the selected replacement target.
 
+Assign a hotkey to **Local Dictation: Apply Markdown by voice** for explicit formatting by voice. Supported phrases are **new line**, **new paragraph**, **bullet**, **numbered item**, **checkbox**, **heading one**, **heading two**, **heading three**, **callout**, **code block**, and **horizontal rule**. Say **literal** followed by text to insert content without interpreting it as a command. Unknown phrases leave the note unchanged. This one-shot mode is microphone-only and never runs AI cleanup; system audio and speaker labels are disabled for it.
+
 ## Features
 
 - **Live text.** Moonshine streaming models show provisional words and revise them in place until each utterance finalizes.
 - **Selection re-dictation.** Select one text range and run **Local Dictation: Re-dictate selection** to replace it with a single spoken utterance.
+- **Deterministic Markdown commands.** Run an explicit hotkey command to insert one recognized Markdown structure without ambient detection or AI interpretation.
 - **Meeting capture.** Include system audio from meetings, calls, or videos alongside your microphone on Windows, Linux, and macOS 14.2 or later.
 - **Speaker labels.** Optional on-device diarization assigns session-stable speaker labels. Speaker embeddings stay in memory and are discarded after the session.
 - **Timestamps.** Add elapsed or wall-clock timestamps at configurable intervals.

--- a/src/commands/register-commands.ts
+++ b/src/commands/register-commands.ts
@@ -4,15 +4,19 @@ const START_DICTATION_COMMAND_ID = 'start-dictation-session';
 const STOP_DICTATION_COMMAND_ID = 'stop-dictation-session';
 const CANCEL_DICTATION_COMMAND_ID = 'cancel-dictation-session';
 const TOGGLE_DICTATION_COMMAND_ID = 'toggle-dictation-session';
+const MARKDOWN_COMMAND_MODE_COMMAND_ID = 'markdown-command-mode';
 const REDICTATE_SELECTION_COMMAND_ID = 'redictate-selection';
 
 interface CommandDependencies {
   cancelDictation: () => Promise<void>;
+  canCaptureMarkdownCommand: (editor: Editor, file: TFile | null) => boolean;
   canRedictateSelection: (editor: Editor, file: TFile | null) => boolean;
   checkSidecarHealth: () => Promise<void>;
+  onMarkdownCommandError: (error: unknown) => void;
   onSelectionRedictationError: (error: unknown) => void;
   plugin: Plugin;
   restartSidecar: () => Promise<void>;
+  startMarkdownCommand: (editor: Editor, file: TFile | null) => Promise<void>;
   startSelectionRedictation: (editor: Editor, file: TFile | null) => Promise<void>;
   startDictation: () => Promise<void>;
   stopDictation: () => Promise<void>;
@@ -49,6 +53,22 @@ export function registerCommands(dependencies: CommandDependencies): void {
     name: 'Cancel dictation',
     callback: async () => {
       await dependencies.cancelDictation();
+    },
+  });
+
+  dependencies.plugin.addCommand({
+    id: MARKDOWN_COMMAND_MODE_COMMAND_ID,
+    name: 'Apply Markdown by voice',
+    editorCheckCallback: (checking, editor, context) => {
+      if (!dependencies.canCaptureMarkdownCommand(editor, context.file)) {
+        return false;
+      }
+      if (!checking) {
+        void dependencies
+          .startMarkdownCommand(editor, context.file)
+          .catch(dependencies.onMarkdownCommandError);
+      }
+      return true;
     },
   });
 

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -9,6 +9,7 @@ import {
   formatSystemAudioErrorMessage,
   formatSystemAudioSidecarErrorMessage,
 } from '../audio/system-audio-permission-message';
+import type { MarkdownCommandSnapshot } from '../editor/markdown-command-mode';
 import type { NotePlacementOptions } from '../editor/note-surface';
 import type { SelectionRedictationSnapshot } from '../editor/selection-redictation';
 import {
@@ -100,7 +101,12 @@ type SessionPhase = 'starting' | 'active' | 'stopping' | 'cancelling' | 'stopped
 type TerminalArbitrationState = 'open' | 'feedback-claimed' | 'cancelled';
 type ManagedSessionMode =
   | { kind: 'dictation' }
-  | { finalClaimed: boolean; kind: 'selection_redictation' };
+  | { finalClaimed: boolean; kind: 'markdown_command' | 'selection_redictation' };
+
+type SessionStartRequest =
+  | { kind: 'dictation' }
+  | { command: MarkdownCommandSnapshot; kind: 'markdown_command' }
+  | { kind: 'selection_redictation'; selection: SelectionRedictationSnapshot };
 
 interface ManagedSession {
   anchorTimerId: number | null;
@@ -124,6 +130,11 @@ function rejectsTranscriptWork(entry: ManagedSession): boolean {
 interface DictationSessionControllerDependencies {
   audioLevelMeter: Pick<SidecarAudioLevelMeter, 'bindSession' | 'clearSession' | 'update'>;
   captureStream: Pick<AudioCaptureStream, 'isCapturing' | 'start' | 'stop'>;
+  createMarkdownCommandSession: (options: {
+    callbacks: SessionLifecycleCallbacks;
+    command: MarkdownCommandSnapshot;
+    sessionId: string;
+  }) => ControllerSession;
   createSession: (options: {
     callbacks: SessionLifecycleCallbacks;
     placement: NotePlacementOptions;
@@ -138,6 +149,7 @@ interface DictationSessionControllerDependencies {
   createLlmRouter: (settings: PluginSettings) => LlmRouter;
   feedback: Pick<UserFeedback, 'show'>;
   getSettings: () => PluginSettings;
+  isMarkdownCommandSnapshotCurrent: (command: MarkdownCommandSnapshot) => boolean;
   isSelectionRedictationSnapshotCurrent: (selection: SelectionRedictationSnapshot) => boolean;
   logger?: PluginLogger;
   onLlmCleanupFailure?: (failure: LlmCleanupFailure) => void;
@@ -283,15 +295,15 @@ export class DictationSessionController {
     await this.startSession({ kind: 'dictation' });
   }
 
+  async startMarkdownCommand(command: MarkdownCommandSnapshot): Promise<void> {
+    await this.startSession({ command, kind: 'markdown_command' });
+  }
+
   async startSelectionRedictation(selection: SelectionRedictationSnapshot): Promise<void> {
     await this.startSession({ kind: 'selection_redictation', selection });
   }
 
-  private async startSession(
-    request:
-      | { kind: 'dictation' }
-      | { kind: 'selection_redictation'; selection: SelectionRedictationSnapshot },
-  ): Promise<void> {
+  private async startSession(request: SessionStartRequest): Promise<void> {
     if (this.activeSessionId !== null || this.sessions.size >= MAX_CONTROLLER_SESSIONS) {
       return;
     }
@@ -326,17 +338,7 @@ export class DictationSessionController {
       return;
     }
 
-    if (
-      request.kind === 'selection_redictation' &&
-      !this.dependencies.isSelectionRedictationSnapshotCurrent(request.selection)
-    ) {
-      this.applyUiState('idle');
-      this.dependencies.feedback.show({
-        intent: 'warning',
-        key: 'selection-redictation-start-stale',
-        message:
-          'Re-dictation did not start because the selected note changed or closed. No audio was captured. Select the text again and retry.',
-      });
+    if (!this.validateEditorCommandTarget(request)) {
       return;
     }
 
@@ -346,10 +348,7 @@ export class DictationSessionController {
       settings.selectedModel,
       this.dependencies.createLlmRouter(settings),
     );
-    const snapshot =
-      request.kind === 'selection_redictation'
-        ? applySelectionRedictationPolicy(baseSnapshot)
-        : baseSnapshot;
+    const snapshot = applySessionPolicy(baseSnapshot, request.kind);
     let session: ControllerSession;
 
     try {
@@ -368,23 +367,30 @@ export class DictationSessionController {
           );
         },
       };
-      session =
-        request.kind === 'selection_redictation'
-          ? this.dependencies.createSelectionRedictationSession({
-              callbacks,
-              selection: request.selection,
-              sessionId,
-            })
-          : this.dependencies.createSession({
-              callbacks,
-              placement: { anchor: snapshot.dictationAnchor },
-              rendererOptions: {
-                smartParagraphPauses: snapshot.smartParagraphPauses,
-                timestamps: snapshot.timestamps,
-                transcriptFormatting: snapshot.transcriptFormatting,
-              },
-              sessionId,
-            });
+      if (request.kind === 'selection_redictation') {
+        session = this.dependencies.createSelectionRedictationSession({
+          callbacks,
+          selection: request.selection,
+          sessionId,
+        });
+      } else if (request.kind === 'markdown_command') {
+        session = this.dependencies.createMarkdownCommandSession({
+          callbacks,
+          command: request.command,
+          sessionId,
+        });
+      } else {
+        session = this.dependencies.createSession({
+          callbacks,
+          placement: { anchor: snapshot.dictationAnchor },
+          rendererOptions: {
+            smartParagraphPauses: snapshot.smartParagraphPauses,
+            timestamps: snapshot.timestamps,
+            transcriptFormatting: snapshot.transcriptFormatting,
+          },
+          sessionId,
+        });
+      }
     } catch (error) {
       this.handleError(FEEDBACK_FAILURES.startDictation, error);
       return;
@@ -396,9 +402,9 @@ export class DictationSessionController {
       cleanupAbortControllers: new Set(),
       llmFailureLogged: false,
       mode:
-        request.kind === 'selection_redictation'
-          ? { finalClaimed: false, kind: 'selection_redictation' }
-          : { kind: 'dictation' },
+        request.kind === 'dictation'
+          ? { kind: 'dictation' }
+          : { finalClaimed: false, kind: request.kind },
       pendingTranscriptWork: new Set(),
       phase: 'starting',
       session,
@@ -483,6 +489,38 @@ export class DictationSessionController {
     }
 
     await this.requestSessionStop(sessionId, this.sessions.get(sessionId));
+  }
+
+  private validateEditorCommandTarget(request: SessionStartRequest): boolean {
+    if (request.kind === 'dictation') {
+      return true;
+    }
+
+    const current =
+      request.kind === 'selection_redictation'
+        ? this.dependencies.isSelectionRedictationSnapshotCurrent(request.selection)
+        : this.dependencies.isMarkdownCommandSnapshotCurrent(request.command);
+    if (current) {
+      return true;
+    }
+
+    this.applyUiState('idle');
+    this.dependencies.feedback.show(
+      request.kind === 'selection_redictation'
+        ? {
+            intent: 'warning',
+            key: 'selection-redictation-start-stale',
+            message:
+              'Re-dictation did not start because the selected note changed or closed. No audio was captured. Select the text again and retry.',
+          }
+        : {
+            intent: 'warning',
+            key: 'markdown-command-start-stale',
+            message:
+              'The Markdown command did not start because the note changed or closed. No audio was captured. Run the command again.',
+          },
+    );
+    return false;
   }
 
   private async requestSessionStop(
@@ -841,7 +879,7 @@ export class DictationSessionController {
     entry: ManagedSession,
     event: TranscriptReadyEvent,
   ): Promise<void> {
-    if (entry.mode.kind === 'selection_redictation') {
+    if (entry.mode.kind !== 'dictation') {
       if (entry.mode.finalClaimed) {
         return;
       }
@@ -1634,6 +1672,32 @@ function applySelectionRedictationPolicy(snapshot: ActiveSessionSnapshot): Activ
     includeSystemAudio: false,
     llmPostprocessMode,
   };
+}
+
+function applyMarkdownCommandPolicy(snapshot: ActiveSessionSnapshot): ActiveSessionSnapshot {
+  return {
+    ...snapshot,
+    diarizationEnabled: false,
+    includeSystemAudio: false,
+    llmFeaturesEnabled: false,
+    llmPostprocessMode: 'off',
+    llmPostprocessNoteContextChars: 0,
+    llmPostprocessPriorUtterancesN: 0,
+    useNoteAsContext: false,
+  };
+}
+
+function applySessionPolicy(
+  snapshot: ActiveSessionSnapshot,
+  kind: SessionStartRequest['kind'],
+): ActiveSessionSnapshot {
+  if (kind === 'selection_redictation') {
+    return applySelectionRedictationPolicy(snapshot);
+  }
+  if (kind === 'markdown_command') {
+    return applyMarkdownCommandPolicy(snapshot);
+  }
+  return snapshot;
 }
 
 function shouldRunBatchCleanup(

--- a/src/editor/markdown-command-mode.ts
+++ b/src/editor/markdown-command-mode.ts
@@ -203,9 +203,10 @@ export class MarkdownCommandSession extends SingleFinalEditorSession {
         key: 'markdown-command-complete',
         message: 'Applied the Markdown voice command.',
       });
-    } catch (error) {
+    } catch {
+      // Do not forward the editor error as feedback cause: an implementation
+      // may echo the transaction payload, which contains the spoken text.
       this.dependencies.feedback.show({
-        cause: error,
         intent: 'error',
         key: 'markdown-command-failed',
         message: 'Could not apply the Markdown command. Run the command and try again.',

--- a/src/editor/markdown-command-mode.ts
+++ b/src/editor/markdown-command-mode.ts
@@ -87,6 +87,7 @@ export function captureMarkdownCommand(
       documentText: editor.getValue(),
       editor,
       file,
+      filePath: file.path,
     },
   };
 }

--- a/src/editor/markdown-command-mode.ts
+++ b/src/editor/markdown-command-mode.ts
@@ -1,0 +1,324 @@
+import type { App, Editor, EditorPosition, TFile } from 'obsidian';
+
+import type { SessionLifecycleCallbacks } from '../session/session';
+import type { UserFeedback } from '../shared/user-feedback';
+import {
+  isSingleFinalEditorSnapshotCurrent,
+  SingleFinalEditorSession,
+  type SingleFinalEditorSnapshot,
+} from './single-final-editor-session';
+
+type MarkdownCommandEditor = Pick<Editor, 'getCursor' | 'getValue' | 'transaction'>;
+
+type MarkdownStructuralCommand =
+  | 'bullet'
+  | 'callout'
+  | 'checkbox'
+  | 'code_block'
+  | 'heading_one'
+  | 'heading_three'
+  | 'heading_two'
+  | 'horizontal_rule'
+  | 'new_line'
+  | 'new_paragraph'
+  | 'numbered_item';
+
+export type MarkdownVoiceCommand =
+  | { kind: MarkdownStructuralCommand }
+  | { kind: 'literal'; text: string }
+  | { kind: 'unrecognized'; reason: 'empty' | 'literal_missing_text' | 'unknown' };
+
+type RecognizedMarkdownVoiceCommand = Exclude<MarkdownVoiceCommand, { kind: 'unrecognized' }>;
+
+export interface MarkdownCommandSnapshot extends SingleFinalEditorSnapshot {
+  readonly cursor: EditorPosition;
+  readonly editor: MarkdownCommandEditor;
+}
+
+export interface MarkdownInsertionPlan {
+  readonly cursor: EditorPosition;
+  readonly text: string;
+}
+
+export type MarkdownCommandCaptureResult =
+  | { kind: 'captured'; snapshot: MarkdownCommandSnapshot }
+  | { kind: 'no_file' };
+
+interface MarkdownCommandSessionDependencies {
+  app: Pick<App, 'vault' | 'workspace'>;
+  callbacks: SessionLifecycleCallbacks;
+  feedback: Pick<UserFeedback, 'show'>;
+  snapshot: MarkdownCommandSnapshot;
+}
+
+const STRUCTURAL_COMMANDS = new Map<string, MarkdownStructuralCommand>([
+  ['bullet', 'bullet'],
+  ['callout', 'callout'],
+  ['checkbox', 'checkbox'],
+  ['code block', 'code_block'],
+  ['heading one', 'heading_one'],
+  ['heading three', 'heading_three'],
+  ['heading two', 'heading_two'],
+  ['horizontal rule', 'horizontal_rule'],
+  ['new line', 'new_line'],
+  ['new paragraph', 'new_paragraph'],
+  ['numbered item', 'numbered_item'],
+]);
+
+export function canCaptureMarkdownCommand(
+  _editor: MarkdownCommandEditor,
+  file: TFile | null,
+): boolean {
+  return file !== null;
+}
+
+export function captureMarkdownCommand(
+  editor: MarkdownCommandEditor,
+  file: TFile | null,
+): MarkdownCommandCaptureResult {
+  if (file === null) {
+    return { kind: 'no_file' };
+  }
+
+  return {
+    kind: 'captured',
+    snapshot: {
+      cursor: { ...editor.getCursor() },
+      documentText: editor.getValue(),
+      editor,
+      file,
+    },
+  };
+}
+
+export function isMarkdownCommandSnapshotCurrent(
+  app: Pick<App, 'workspace'>,
+  snapshot: MarkdownCommandSnapshot,
+): boolean {
+  return isSingleFinalEditorSnapshotCurrent(app, snapshot);
+}
+
+export function parseMarkdownVoiceCommand(text: string): MarkdownVoiceCommand {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) {
+    return { kind: 'unrecognized', reason: 'empty' };
+  }
+
+  const literalMatch = /^literal(?:\s+([\s\S]+))?$/iu.exec(trimmed);
+  if (literalMatch !== null) {
+    const literalText = literalMatch[1]?.trim() ?? '';
+    return literalText.length > 0
+      ? { kind: 'literal', text: literalText }
+      : { kind: 'unrecognized', reason: 'literal_missing_text' };
+  }
+
+  const normalized = trimmed
+    .toLocaleLowerCase('en-US')
+    .replace(/\s+/gu, ' ')
+    .replace(/[!,.?:;]+$/gu, '')
+    .trim();
+  const command = STRUCTURAL_COMMANDS.get(normalized);
+  return command === undefined ? { kind: 'unrecognized', reason: 'unknown' } : { kind: command };
+}
+
+export function buildMarkdownInsertionPlan(
+  documentText: string,
+  cursor: EditorPosition,
+  command: RecognizedMarkdownVoiceCommand,
+): MarkdownInsertionPlan | null {
+  const insertionOffset = positionToOffset(documentText, cursor);
+  if (insertionOffset === null) {
+    return null;
+  }
+
+  switch (command.kind) {
+    case 'literal':
+      return buildDirectInsertionPlan(documentText, insertionOffset, command.text);
+    case 'new_line':
+      return buildDirectInsertionPlan(documentText, insertionOffset, '\n');
+    case 'new_paragraph':
+      return buildDirectInsertionPlan(documentText, insertionOffset, '\n\n');
+    case 'bullet':
+      return buildLineBlockPlan(documentText, insertionOffset, '- ', 2);
+    case 'numbered_item':
+      return buildLineBlockPlan(documentText, insertionOffset, '1. ', 3);
+    case 'checkbox':
+      return buildLineBlockPlan(documentText, insertionOffset, '- [ ] ', 6);
+    case 'heading_one':
+      return buildLineBlockPlan(documentText, insertionOffset, '# ', 2);
+    case 'heading_two':
+      return buildLineBlockPlan(documentText, insertionOffset, '## ', 3);
+    case 'heading_three':
+      return buildLineBlockPlan(documentText, insertionOffset, '### ', 4);
+    case 'callout': {
+      const block = '> [!NOTE]\n> ';
+      return buildLineBlockPlan(documentText, insertionOffset, block, block.length);
+    }
+    case 'code_block':
+      return buildLineBlockPlan(documentText, insertionOffset, '```\n\n```', 4);
+    case 'horizontal_rule':
+      return buildLineBlockPlan(documentText, insertionOffset, '---', 3, true);
+  }
+}
+
+export class MarkdownCommandSession extends SingleFinalEditorSession {
+  constructor(private readonly dependencies: MarkdownCommandSessionDependencies) {
+    super({
+      app: dependencies.app,
+      callbacks: dependencies.callbacks,
+      disposedReason: 'Markdown voice command session is disposed.',
+      snapshot: dependencies.snapshot,
+    });
+  }
+
+  protected handleFinalText(text: string): void {
+    const command = parseMarkdownVoiceCommand(text);
+    if (command.kind === 'unrecognized') {
+      this.reportUnrecognizedCommand(command.reason);
+      return;
+    }
+
+    const { cursor, documentText, editor } = this.dependencies.snapshot;
+    const plan = buildMarkdownInsertionPlan(documentText, cursor, command);
+    if (plan === null) {
+      this.dependencies.feedback.show({
+        intent: 'error',
+        key: 'markdown-command-invalid-cursor',
+        message: 'The captured cursor is no longer valid. No Markdown was inserted.',
+      });
+      return;
+    }
+
+    try {
+      editor.transaction(
+        {
+          changes: [{ from: cursor, text: plan.text, to: cursor }],
+          selection: { from: plan.cursor },
+        },
+        'local-dictation-markdown-command',
+      );
+      this.dependencies.feedback.show({
+        intent: 'success',
+        key: 'markdown-command-complete',
+        message: 'Applied the Markdown voice command.',
+      });
+    } catch (error) {
+      this.dependencies.feedback.show({
+        cause: error,
+        intent: 'error',
+        key: 'markdown-command-failed',
+        message: 'Could not apply the Markdown command. Run the command and try again.',
+      });
+    }
+  }
+
+  protected reportCancellation(): void {
+    this.dependencies.feedback.show({
+      intent: 'information',
+      key: 'markdown-command-cancelled',
+      message: 'Markdown voice command cancelled. The note was left unchanged.',
+    });
+  }
+
+  protected reportStaleTarget(): void {
+    this.dependencies.feedback.show({
+      intent: 'warning',
+      key: 'markdown-command-stale',
+      message:
+        'The note changed while listening. No Markdown command was applied. Run the command again.',
+    });
+  }
+
+  private reportUnrecognizedCommand(
+    reason: Extract<MarkdownVoiceCommand, { kind: 'unrecognized' }>['reason'],
+  ): void {
+    const message =
+      reason === 'literal_missing_text'
+        ? 'Say “literal” followed by the exact text to insert.'
+        : reason === 'empty'
+          ? 'No Markdown command was recognized. Try “new paragraph”, “bullet”, or “literal” followed by text.'
+          : 'Unknown Markdown command. Try “new paragraph”, “bullet”, “heading two”, or “literal” followed by text.';
+    this.dependencies.feedback.show({
+      intent: 'warning',
+      key: 'markdown-command-unrecognized',
+      message,
+    });
+  }
+}
+
+function buildDirectInsertionPlan(
+  documentText: string,
+  insertionOffset: number,
+  text: string,
+): MarkdownInsertionPlan {
+  const nextDocument = insertAt(documentText, insertionOffset, text);
+  return {
+    cursor: offsetToPosition(nextDocument, insertionOffset + text.length),
+    text,
+  };
+}
+
+function buildLineBlockPlan(
+  documentText: string,
+  insertionOffset: number,
+  block: string,
+  caretOffsetInBlock: number,
+  moveToNextLine = false,
+): MarkdownInsertionPlan {
+  const startsLine = insertionOffset === 0 || documentText[insertionOffset - 1] === '\n';
+  const endsLine =
+    insertionOffset === documentText.length || documentText[insertionOffset] === '\n';
+  const prefix = startsLine ? '' : '\n';
+  let suffix = endsLine ? '' : '\n';
+  let text = `${prefix}${block}${suffix}`;
+  let caretOffset = insertionOffset + prefix.length + caretOffsetInBlock;
+
+  if (moveToNextLine) {
+    if (insertionOffset === documentText.length) {
+      suffix = '\n';
+      text = `${prefix}${block}${suffix}`;
+      caretOffset = insertionOffset + text.length;
+    } else if (endsLine) {
+      caretOffset = insertionOffset + text.length + 1;
+    } else {
+      caretOffset = insertionOffset + text.length;
+    }
+  }
+
+  const nextDocument = insertAt(documentText, insertionOffset, text);
+  return { cursor: offsetToPosition(nextDocument, caretOffset), text };
+}
+
+function insertAt(text: string, offset: number, insertion: string): string {
+  return `${text.slice(0, offset)}${insertion}${text.slice(offset)}`;
+}
+
+function positionToOffset(documentText: string, position: EditorPosition): number | null {
+  if (!Number.isInteger(position.line) || !Number.isInteger(position.ch) || position.line < 0) {
+    return null;
+  }
+
+  const lines = documentText.split('\n');
+  const line = lines[position.line];
+  if (line === undefined || position.ch < 0 || position.ch > line.length) {
+    return null;
+  }
+
+  let offset = position.ch;
+  for (let index = 0; index < position.line; index += 1) {
+    offset += (lines[index]?.length ?? 0) + 1;
+  }
+  return offset;
+}
+
+function offsetToPosition(documentText: string, offset: number): EditorPosition {
+  let line = 0;
+  let lineStart = 0;
+  for (let index = 0; index < offset; index += 1) {
+    if (documentText[index] === '\n') {
+      line += 1;
+      lineStart = index + 1;
+    }
+  }
+  return { ch: offset - lineStart, line };
+}

--- a/src/editor/selection-redictation.ts
+++ b/src/editor/selection-redictation.ts
@@ -72,6 +72,7 @@ export function captureSelectionRedictation(
       documentText: editor.getValue(),
       editor,
       file,
+      filePath: file.path,
       from: { ...from },
       to: { ...to },
     },

--- a/src/editor/selection-redictation.ts
+++ b/src/editor/selection-redictation.ts
@@ -1,17 +1,18 @@
-import type { App, Editor, EditorPosition, EventRef, TAbstractFile, TFile } from 'obsidian';
-
-import type { SessionAcceptResult, SessionLifecycleCallbacks } from '../session/session';
-import type { TranscriptRevision } from '../session/session-journal';
+import type { App, Editor, EditorPosition, TFile } from 'obsidian';
+import type { SessionLifecycleCallbacks } from '../session/session';
 import { truncateTrailingText } from '../shared/text-truncation';
 import type { UserFeedback } from '../shared/user-feedback';
 import { buildNoteGlossary } from './note-surface';
+import {
+  isSingleFinalEditorSnapshotCurrent,
+  SingleFinalEditorSession,
+  type SingleFinalEditorSnapshot,
+} from './single-final-editor-session';
 
 type SelectionEditor = Pick<Editor, 'getRange' | 'getValue' | 'listSelections' | 'transaction'>;
 
-export interface SelectionRedictationSnapshot {
-  readonly documentText: string;
+export interface SelectionRedictationSnapshot extends SingleFinalEditorSnapshot {
   readonly editor: SelectionEditor;
-  readonly file: TFile;
   readonly from: EditorPosition;
   readonly to: EditorPosition;
 }
@@ -27,11 +28,6 @@ interface SelectionRedictationSessionDependencies {
   callbacks: SessionLifecycleCallbacks;
   feedback: Pick<UserFeedback, 'show'>;
   snapshot: SelectionRedictationSnapshot;
-}
-
-interface MarkdownEditorViewLike {
-  editor?: Editor;
-  file: TFile | null;
 }
 
 export function canCaptureSelectionRedictation(
@@ -86,83 +82,21 @@ export function isSelectionRedictationSnapshotCurrent(
   app: Pick<App, 'workspace'>,
   snapshot: SelectionRedictationSnapshot,
 ): boolean {
-  if (!isSelectionRedictationTargetOpen(app, snapshot)) {
-    return false;
-  }
-
-  try {
-    return snapshot.editor.getValue() === snapshot.documentText;
-  } catch {
-    return false;
-  }
+  return isSingleFinalEditorSnapshotCurrent(app, snapshot);
 }
 
-export class SelectionRedictationSession {
-  private cancelled = false;
-  private disposed = false;
-  private finalHandled = false;
-  private readonly refs: Array<{ offref: (ref: EventRef) => void; ref: EventRef }> = [];
-  private targetUnavailable = false;
-
+export class SelectionRedictationSession extends SingleFinalEditorSession {
   constructor(private readonly dependencies: SelectionRedictationSessionDependencies) {
-    this.registerLifecycleSubscriptions();
-  }
-
-  acceptTranscript(revision: TranscriptRevision): SessionAcceptResult {
-    if (this.disposed) {
-      return { kind: 'rejected', reason: 'Selection re-dictation session is disposed.' };
-    }
-    if (this.cancelled) {
-      return { kind: 'stale' };
-    }
-    if (!revision.isFinal) {
-      return { kind: 'accepted' };
-    }
-    if (this.finalHandled) {
-      return { kind: 'duplicate' };
-    }
-
-    this.finalHandled = true;
-    this.applyFinalReplacement(revision.text.trim());
-    return { kind: 'accepted' };
-  }
-
-  clearSessionProcessingMark(): void {}
-
-  dispose(): void {
-    if (this.disposed) {
-      return;
-    }
-    this.disposed = true;
-    this.releaseSubscriptions();
-  }
-
-  insertAdjacentToSessionRange(_blockText: string, _placement: 'above' | 'below'): boolean {
-    return false;
-  }
-
-  markSessionRangeAsProcessing(): boolean {
-    return false;
-  }
-
-  onUserCancellation(): void {
-    if (this.cancelled || this.finalHandled) {
-      return;
-    }
-    this.cancelled = true;
-    this.dependencies.feedback.show({
-      intent: 'information',
-      key: 'selection-redictation-cancelled',
-      message: 'Re-dictation cancelled. The selected text was left unchanged.',
+    super({
+      app: dependencies.app,
+      callbacks: dependencies.callbacks,
+      disposedReason: 'Selection re-dictation session is disposed.',
+      snapshot: dependencies.snapshot,
     });
   }
 
-  readCurrentSessionText(): string {
-    return '';
-  }
-
-  readNoteGlossary(maxChars: number): { text: string; truncated: boolean } | null {
-    if (!this.canReadTarget() || maxChars <= 0) {
+  override readNoteGlossary(maxChars: number): { text: string; truncated: boolean } | null {
+    if (!this.isTargetCurrent() || maxChars <= 0) {
       return null;
     }
 
@@ -173,8 +107,8 @@ export class SelectionRedictationSession {
     }
   }
 
-  readNoteText(maxChars: number): { text: string; truncated: boolean } | null {
-    if (!this.canReadTarget() || maxChars <= 0) {
+  override readNoteText(maxChars: number): { text: string; truncated: boolean } | null {
+    if (!this.isTargetCurrent() || maxChars <= 0) {
       return null;
     }
 
@@ -190,23 +124,7 @@ export class SelectionRedictationSession {
     }
   }
 
-  readPriorUtterances(
-    _maxCount: number,
-    _maxCharsPerUtterance: number,
-  ): Array<{ text: string; truncated: boolean }> {
-    return [];
-  }
-
-  replaceSessionRangeWithCleaned(
-    _cleanText: string,
-    _options?: { rawTextForCallout?: string; showRawBelow?: boolean },
-  ): boolean {
-    return false;
-  }
-
-  setAnchorMode(_mode: 'hidden' | 'visible'): void {}
-
-  private applyFinalReplacement(text: string): void {
+  protected handleFinalText(text: string): void {
     if (text.length === 0) {
       this.dependencies.feedback.show({
         intent: 'warning',
@@ -217,11 +135,6 @@ export class SelectionRedictationSession {
     }
 
     const { editor, from, to } = this.dependencies.snapshot;
-    if (!this.canReadTarget()) {
-      this.reportStaleSelection();
-      return;
-    }
-
     try {
       editor.transaction(
         {
@@ -245,19 +158,15 @@ export class SelectionRedictationSession {
     }
   }
 
-  private canReadTarget(): boolean {
-    return (
-      !this.disposed &&
-      !this.targetUnavailable &&
-      isSelectionRedictationSnapshotCurrent(this.dependencies.app, this.dependencies.snapshot)
-    );
+  protected reportCancellation(): void {
+    this.dependencies.feedback.show({
+      intent: 'information',
+      key: 'selection-redictation-cancelled',
+      message: 'Re-dictation cancelled. The selected text was left unchanged.',
+    });
   }
 
-  private isTargetOpen(): boolean {
-    return isSelectionRedictationTargetOpen(this.dependencies.app, this.dependencies.snapshot);
-  }
-
-  private reportStaleSelection(): void {
+  protected reportStaleTarget(): void {
     this.dependencies.feedback.show({
       intent: 'warning',
       key: 'selection-redictation-stale',
@@ -265,52 +174,6 @@ export class SelectionRedictationSession {
         'The note changed while re-dictating. No text was replaced. Select the text again and retry.',
     });
   }
-
-  private registerLifecycleSubscriptions(): void {
-    const { vault, workspace } = this.dependencies.app;
-    this.refs.push({
-      offref: (ref) => workspace.offref(ref),
-      ref: workspace.on('layout-change', () => {
-        if (!this.disposed && !this.targetUnavailable && !this.isTargetOpen()) {
-          this.targetUnavailable = true;
-          this.dependencies.callbacks.onLockedNoteClosed();
-        }
-      }),
-    });
-    this.refs.push({
-      offref: (ref) => vault.offref(ref),
-      ref: vault.on('delete', (file) => {
-        this.handleDelete(file);
-      }),
-    });
-  }
-
-  private handleDelete(file: TAbstractFile): void {
-    if (this.disposed || this.targetUnavailable || file !== this.dependencies.snapshot.file) {
-      return;
-    }
-    this.targetUnavailable = true;
-    this.dependencies.callbacks.onLockedNoteDeleted();
-  }
-
-  private releaseSubscriptions(): void {
-    while (this.refs.length > 0) {
-      const subscription = this.refs.pop();
-      if (subscription !== undefined) {
-        subscription.offref(subscription.ref);
-      }
-    }
-  }
-}
-
-function isSelectionRedictationTargetOpen(
-  app: Pick<App, 'workspace'>,
-  snapshot: SelectionRedictationSnapshot,
-): boolean {
-  return app.workspace.getLeavesOfType('markdown').some((leaf) => {
-    const view = leaf.view as unknown as MarkdownEditorViewLike;
-    return view.editor === snapshot.editor && view.file === snapshot.file;
-  });
 }
 
 function orderPositions(

--- a/src/editor/selection-redictation.ts
+++ b/src/editor/selection-redictation.ts
@@ -149,9 +149,10 @@ export class SelectionRedictationSession extends SingleFinalEditorSession {
         key: 'selection-redictation-complete',
         message: 'Replaced the selected text.',
       });
-    } catch (error) {
+    } catch {
+      // Do not forward the editor error as feedback cause: an implementation
+      // may echo the transaction payload, which contains the spoken text.
       this.dependencies.feedback.show({
-        cause: error,
         intent: 'error',
         key: 'selection-redictation-failed',
         message: 'Could not replace the selected text. Select it again and retry.',

--- a/src/editor/single-final-editor-session.ts
+++ b/src/editor/single-final-editor-session.ts
@@ -9,6 +9,7 @@ export interface SingleFinalEditorSnapshot {
   readonly documentText: string;
   readonly editor: SingleFinalEditor;
   readonly file: TFile;
+  readonly filePath: string;
 }
 
 interface SingleFinalEditorSessionDependencies {
@@ -28,7 +29,11 @@ export function isSingleFinalEditorSnapshotCurrent(
   snapshot: SingleFinalEditorSnapshot,
 ): boolean {
   try {
-    return isTargetOpen(app, snapshot) && snapshot.editor.getValue() === snapshot.documentText;
+    return (
+      snapshot.file.path === snapshot.filePath &&
+      isTargetOpen(app, snapshot) &&
+      snapshot.editor.getValue() === snapshot.documentText
+    );
   } catch {
     return false;
   }

--- a/src/editor/single-final-editor-session.ts
+++ b/src/editor/single-final-editor-session.ts
@@ -1,0 +1,192 @@
+import type { App, Editor, EventRef, TAbstractFile, TFile } from 'obsidian';
+
+import type { SessionAcceptResult, SessionLifecycleCallbacks } from '../session/session';
+import type { TranscriptRevision } from '../session/session-journal';
+
+type SingleFinalEditor = Pick<Editor, 'getValue'>;
+
+export interface SingleFinalEditorSnapshot {
+  readonly documentText: string;
+  readonly editor: SingleFinalEditor;
+  readonly file: TFile;
+}
+
+interface SingleFinalEditorSessionDependencies {
+  app: Pick<App, 'vault' | 'workspace'>;
+  callbacks: SessionLifecycleCallbacks;
+  disposedReason: string;
+  snapshot: SingleFinalEditorSnapshot;
+}
+
+interface MarkdownEditorViewLike {
+  editor?: Editor;
+  file: TFile | null;
+}
+
+export function isSingleFinalEditorSnapshotCurrent(
+  app: Pick<App, 'workspace'>,
+  snapshot: SingleFinalEditorSnapshot,
+): boolean {
+  try {
+    return isTargetOpen(app, snapshot) && snapshot.editor.getValue() === snapshot.documentText;
+  } catch {
+    return false;
+  }
+}
+
+export abstract class SingleFinalEditorSession {
+  private cancelled = false;
+  private disposed = false;
+  private finalHandled = false;
+  private readonly refs: Array<{ offref: (ref: EventRef) => void; ref: EventRef }> = [];
+  private targetUnavailable = false;
+
+  protected constructor(
+    private readonly sessionDependencies: SingleFinalEditorSessionDependencies,
+  ) {
+    this.registerLifecycleSubscriptions();
+  }
+
+  acceptTranscript(revision: TranscriptRevision): SessionAcceptResult {
+    if (this.disposed) {
+      return { kind: 'rejected', reason: this.sessionDependencies.disposedReason };
+    }
+    if (this.cancelled) {
+      return { kind: 'stale' };
+    }
+    if (!revision.isFinal) {
+      return { kind: 'accepted' };
+    }
+    if (this.finalHandled) {
+      return { kind: 'duplicate' };
+    }
+
+    this.finalHandled = true;
+    if (!this.isTargetCurrent()) {
+      this.reportStaleTarget();
+      return { kind: 'accepted' };
+    }
+
+    this.handleFinalText(revision.text.trim());
+    return { kind: 'accepted' };
+  }
+
+  clearSessionProcessingMark(): void {}
+
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.releaseSubscriptions();
+  }
+
+  insertAdjacentToSessionRange(_blockText: string, _placement: 'above' | 'below'): boolean {
+    return false;
+  }
+
+  markSessionRangeAsProcessing(): boolean {
+    return false;
+  }
+
+  onUserCancellation(): void {
+    if (this.cancelled || this.finalHandled) {
+      return;
+    }
+    this.cancelled = true;
+    this.reportCancellation();
+  }
+
+  readCurrentSessionText(): string {
+    return '';
+  }
+
+  readNoteGlossary(_maxChars: number): { text: string; truncated: boolean } | null {
+    return null;
+  }
+
+  readNoteText(_maxChars: number): { text: string; truncated: boolean } | null {
+    return null;
+  }
+
+  readPriorUtterances(
+    _maxCount: number,
+    _maxCharsPerUtterance: number,
+  ): Array<{ text: string; truncated: boolean }> {
+    return [];
+  }
+
+  replaceSessionRangeWithCleaned(
+    _cleanText: string,
+    _options?: { rawTextForCallout?: string; showRawBelow?: boolean },
+  ): boolean {
+    return false;
+  }
+
+  setAnchorMode(_mode: 'hidden' | 'visible'): void {}
+
+  protected abstract handleFinalText(text: string): void;
+
+  protected isTargetCurrent(): boolean {
+    return (
+      !this.disposed &&
+      !this.targetUnavailable &&
+      isSingleFinalEditorSnapshotCurrent(
+        this.sessionDependencies.app,
+        this.sessionDependencies.snapshot,
+      )
+    );
+  }
+
+  protected abstract reportCancellation(): void;
+
+  protected abstract reportStaleTarget(): void;
+
+  private registerLifecycleSubscriptions(): void {
+    const { snapshot } = this.sessionDependencies;
+    const { vault, workspace } = this.sessionDependencies.app;
+    this.refs.push({
+      offref: (ref) => workspace.offref(ref),
+      ref: workspace.on('layout-change', () => {
+        if (!this.disposed && !this.targetUnavailable && !isTargetOpen({ workspace }, snapshot)) {
+          this.targetUnavailable = true;
+          this.sessionDependencies.callbacks.onLockedNoteClosed();
+        }
+      }),
+    });
+    this.refs.push({
+      offref: (ref) => vault.offref(ref),
+      ref: vault.on('delete', (file) => {
+        this.handleDelete(file);
+      }),
+    });
+  }
+
+  private handleDelete(file: TAbstractFile): void {
+    if (
+      this.disposed ||
+      this.targetUnavailable ||
+      file !== this.sessionDependencies.snapshot.file
+    ) {
+      return;
+    }
+    this.targetUnavailable = true;
+    this.sessionDependencies.callbacks.onLockedNoteDeleted();
+  }
+
+  private releaseSubscriptions(): void {
+    while (this.refs.length > 0) {
+      const subscription = this.refs.pop();
+      if (subscription !== undefined) {
+        subscription.offref(subscription.ref);
+      }
+    }
+  }
+}
+
+function isTargetOpen(app: Pick<App, 'workspace'>, snapshot: SingleFinalEditorSnapshot): boolean {
+  return app.workspace.getLeavesOfType('markdown').some((leaf) => {
+    const view = leaf.view as unknown as MarkdownEditorViewLike;
+    return view.editor === snapshot.editor && view.file === snapshot.file;
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,12 @@ import { SidecarAudioLevelMeter } from './audio/sidecar-audio-level-meter';
 import { registerCommands } from './commands/register-commands';
 import { DictationSessionController } from './dictation/dictation-session-controller';
 import { dictationAnchorExtension } from './editor/dictation-anchor-extension';
+import {
+  canCaptureMarkdownCommand,
+  captureMarkdownCommand,
+  isMarkdownCommandSnapshotCurrent,
+  MarkdownCommandSession,
+} from './editor/markdown-command-mode';
 import { noteSurfaceUpdateListenerExtension } from './editor/note-surface';
 import { provisionalTranscriptExtension } from './editor/provisional-transcript-extension';
 import {
@@ -166,6 +172,13 @@ export default class LocalSttPlugin extends Plugin {
     this.dictationController = new DictationSessionController({
       audioLevelMeter: this.audioLevelMeter,
       captureStream: this.audioCaptureStream,
+      createMarkdownCommandSession: ({ callbacks, command }) =>
+        new MarkdownCommandSession({
+          app: this.app,
+          callbacks,
+          feedback: this.feedback,
+          snapshot: command,
+        }),
       createSession: ({ callbacks, placement, rendererOptions, sessionId }) =>
         Session.createFromActiveEditor(this.app, {
           callbacks,
@@ -190,6 +203,8 @@ export default class LocalSttPlugin extends Plugin {
           () => this.getOpenRouterApiKey(),
         ),
       getSettings: () => this.settings,
+      isMarkdownCommandSnapshotCurrent: (command) =>
+        isMarkdownCommandSnapshotCurrent(this.app, command),
       isSelectionRedictationSnapshotCurrent: (selection) =>
         isSelectionRedictationSnapshotCurrent(this.app, selection),
       feedback: this.feedback,
@@ -245,9 +260,20 @@ export default class LocalSttPlugin extends Plugin {
 
     registerCommands({
       cancelDictation: async () => this.requireDictationController().cancelDictation(),
+      canCaptureMarkdownCommand: (editor, file) =>
+        !this.requireDictationController().isBusy() && canCaptureMarkdownCommand(editor, file),
       canRedictateSelection: (editor, file) =>
         !this.requireDictationController().isBusy() && canCaptureSelectionRedictation(editor, file),
       checkSidecarHealth: async () => this.checkSidecarHealth(),
+      onMarkdownCommandError: (error) => {
+        this.logger.error('session', 'Markdown voice command failed', error);
+        this.feedback.show({
+          cause: error,
+          intent: 'error',
+          key: 'markdown-command-start-failed',
+          message: 'Could not start the Markdown voice command. Run the command and try again.',
+        });
+      },
       onSelectionRedictationError: (error) => {
         this.logger.error('session', 'selection re-dictation command failed', error);
         this.feedback.show({
@@ -260,6 +286,29 @@ export default class LocalSttPlugin extends Plugin {
       plugin: this,
       restartSidecar: async () => this.restartSidecar(),
       startDictation: async () => this.requireDictationController().startDictation(),
+      startMarkdownCommand: async (editor, file) => {
+        const controller = this.requireDictationController();
+        if (controller.isBusy()) {
+          this.feedback.show({
+            intent: 'information',
+            key: 'markdown-command-busy',
+            message: 'Finish or cancel the current dictation before running a Markdown command.',
+          });
+          return;
+        }
+
+        const capture = captureMarkdownCommand(editor, file);
+        if (capture.kind !== 'captured') {
+          this.feedback.show({
+            intent: 'information',
+            key: 'markdown-command-unavailable',
+            message: 'Open a Markdown note, place the cursor, and try again.',
+          });
+          return;
+        }
+
+        await controller.startMarkdownCommand(capture.snapshot);
+      },
       startSelectionRedictation: async (editor, file) => {
         const controller = this.requireDictationController();
         if (controller.isBusy()) {

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -2782,6 +2782,7 @@ function createSelectionSnapshot(): SelectionRedictationSnapshot {
     documentText: 'original',
     editor: {},
     file: { path: 'note.md' },
+    filePath: 'note.md',
     from: { ch: 0, line: 0 },
     to: { ch: 8, line: 0 },
   } as unknown as SelectionRedictationSnapshot;
@@ -2793,6 +2794,7 @@ function createMarkdownCommandSnapshot(): MarkdownCommandSnapshot {
     documentText: '',
     editor: {},
     file: { path: 'note.md' },
+    filePath: 'note.md',
   } as unknown as MarkdownCommandSnapshot;
 }
 

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -4,6 +4,7 @@ import {
   type DictationControllerState,
   DictationSessionController,
 } from '../src/dictation/dictation-session-controller';
+import type { MarkdownCommandSnapshot } from '../src/editor/markdown-command-mode';
 import type { NotePlacementOptions, SurfaceDesynchronization } from '../src/editor/note-surface';
 import type { SelectionRedictationSnapshot } from '../src/editor/selection-redictation';
 import { type LlmCleanupFailure, ProviderError } from '../src/llm/provider';
@@ -234,6 +235,122 @@ describe('DictationSessionController', () => {
         includeSystemAudio: false,
       }),
     );
+  });
+
+  it('does not start a Markdown command when its target becomes stale during preflight', async () => {
+    const captureStream = new FakeCaptureStream();
+    const feedback = { show: vi.fn() };
+    const sidecarConnection = new FakeSidecarConnection();
+    const preflight: { finish?: () => void } = {};
+    sidecarConnection.ensureStarted.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          preflight.finish = resolve;
+        }),
+    );
+    let targetCurrent = true;
+    const isMarkdownCommandSnapshotCurrent = vi.fn(() => targetCurrent);
+    const createMarkdownCommandSession = vi.fn();
+    const controller = createController({
+      captureStream,
+      createMarkdownCommandSession,
+      feedback,
+      isMarkdownCommandSnapshotCurrent,
+      sidecarConnection,
+    });
+    const command = createMarkdownCommandSnapshot();
+
+    const start = controller.startMarkdownCommand(command);
+    await vi.waitFor(() => {
+      expect(sidecarConnection.ensureStarted).toHaveBeenCalledOnce();
+    });
+    targetCurrent = false;
+    const finishPreflight = preflight.finish;
+    if (finishPreflight === undefined) {
+      throw new Error('sidecar preflight did not start');
+    }
+    finishPreflight();
+    await start;
+
+    expect(isMarkdownCommandSnapshotCurrent).toHaveBeenCalledWith(command);
+    expect(createMarkdownCommandSession).not.toHaveBeenCalled();
+    expect(sidecarConnection.startSession).not.toHaveBeenCalled();
+    expect(captureStream.start).not.toHaveBeenCalled();
+    expect(controller.getState()).toBe('idle');
+    expect(feedback.show).toHaveBeenCalledWith({
+      intent: 'warning',
+      key: 'markdown-command-start-stale',
+      message:
+        'The Markdown command did not start because the note changed or closed. No audio was captured. Run the command again.',
+    });
+  });
+
+  it('runs one microphone-only Markdown command without context or provider cleanup', async () => {
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const cleanup = vi.fn(
+      async (): Promise<LlmRouterCleanupResult> => ({
+        model: 'remote-model',
+        providerId: 'openrouter',
+        text: 'provider output',
+      }),
+    );
+    const llmRouter = createFakeLlmRouter({ cleanup, providerId: 'openrouter' });
+    const controller = createController({
+      createMarkdownCommandSession: (session) => {
+        sessions.push(session);
+      },
+      getSettings: () =>
+        createSettings({
+          diarizationEnabled: true,
+          includeSystemAudio: true,
+          llmFeaturesEnabled: true,
+          llmPostprocessActivePresetRef: 'builtin:markdown-formatting',
+          llmPostprocessMode: 'batch',
+          llmPostprocessSkipMinWords: 0,
+          llmRemoteFeaturesEnabled: true,
+          llmRouting: 'remote',
+          selectedModel: createExternalModelSelection(),
+          useLlmNoteContext: true,
+          useNoteAsContext: true,
+        }),
+      llmRouter,
+      sidecarConnection,
+    });
+
+    await controller.startMarkdownCommand(createMarkdownCommandSnapshot());
+    const startPayload = sidecarConnection.startSession.mock.calls[0]?.[0];
+    const sessionId = startPayload?.sessionId ?? '';
+    expect(startPayload).toEqual(
+      expect.objectContaining({
+        diarizationEnabled: false,
+        includeSystemAudio: false,
+      }),
+    );
+
+    sidecarConnection.emit({
+      budgetChars: 200,
+      correlationId: 'markdown-context',
+      sessionId,
+      type: 'context_request',
+      utteranceId: crypto.randomUUID(),
+    });
+    expect(sidecarConnection.sendContextResponse).toHaveBeenCalledWith('markdown-context', null);
+    expect(sessions[0]?.readNoteGlossary).not.toHaveBeenCalled();
+
+    sidecarConnection.emit(transcriptReady(sessionId, 'bull', { isFinal: false }));
+    sidecarConnection.emit(transcriptReady(sessionId, 'bullet'));
+    sidecarConnection.emit(transcriptReady(sessionId, 'horizontal rule', { revision: 1 }));
+
+    await vi.waitFor(() => {
+      expect(sidecarConnection.requestStopSession).toHaveBeenCalledWith(sessionId);
+      expect(sessions[0]?.acceptTranscript).toHaveBeenCalledWith(
+        expect.objectContaining({ isFinal: true, text: 'bullet' }),
+      );
+    });
+    expect(sessions[0]?.acceptedTexts).toEqual(['bull', 'bullet']);
+    expect(cleanup).not.toHaveBeenCalled();
+    expect(llmRouter.selectProviderId).not.toHaveBeenCalled();
   });
 
   it('stops capture on the first selection final and ignores every later revision', async () => {
@@ -2551,10 +2668,12 @@ function createController({
   audioLevelMeter = new FakeAudioLevelMeter(),
   captureStream = new FakeCaptureStream(),
   countAudioInputDevices,
+  createMarkdownCommandSession,
   createSession,
   createSelectionRedictationSession,
   llmRouter = createFakeLlmRouter(),
   getSettings = () => createSettings({ selectedModel: createExternalModelSelection() }),
+  isMarkdownCommandSnapshotCurrent = () => true,
   isSelectionRedictationSnapshotCurrent = () => true,
   logger = new FakeLogger(),
   feedback = { show: vi.fn() },
@@ -2565,12 +2684,17 @@ function createController({
   audioLevelMeter?: FakeAudioLevelMeter;
   captureStream?: FakeCaptureStream;
   countAudioInputDevices?: () => Promise<number | null>;
+  createMarkdownCommandSession?: (
+    session: FakeSession,
+    options: CreateMarkdownCommandSessionOptions,
+  ) => void;
   createSession?: (session: FakeSession, options: CreateSessionOptions) => void;
   createSelectionRedictationSession?: (
     session: FakeSession,
     options: CreateSelectionRedictationSessionOptions,
   ) => void;
   getSettings?: () => PluginSettings;
+  isMarkdownCommandSnapshotCurrent?: (command: MarkdownCommandSnapshot) => boolean;
   isSelectionRedictationSnapshotCurrent?: (selection: SelectionRedictationSnapshot) => boolean;
   llmRouter?: LlmRouter;
   logger?: FakeLogger;
@@ -2583,6 +2707,11 @@ function createController({
     captureStream,
     audioLevelMeter,
     ...(countAudioInputDevices !== undefined ? { countAudioInputDevices } : {}),
+    createMarkdownCommandSession: (_options: CreateMarkdownCommandSessionOptions) => {
+      const session = new FakeSession();
+      createMarkdownCommandSession?.(session, _options);
+      return session;
+    },
     createSession: (_options: CreateSessionOptions) => {
       const session = new FakeSession();
       createSession?.(session, _options);
@@ -2596,6 +2725,7 @@ function createController({
     createLlmRouter: () => llmRouter,
     feedback,
     getSettings,
+    isMarkdownCommandSnapshotCurrent,
     isSelectionRedictationSnapshotCurrent,
     logger,
     ...(onLlmCleanupFailure !== undefined ? { onLlmCleanupFailure } : {}),
@@ -2616,6 +2746,12 @@ interface CreateSessionOptions {
   };
   placement: NotePlacementOptions;
   rendererOptions: TranscriptRenderOptions;
+  sessionId: string;
+}
+
+interface CreateMarkdownCommandSessionOptions {
+  callbacks: CreateSessionOptions['callbacks'];
+  command: MarkdownCommandSnapshot;
   sessionId: string;
 }
 
@@ -2649,6 +2785,15 @@ function createSelectionSnapshot(): SelectionRedictationSnapshot {
     from: { ch: 0, line: 0 },
     to: { ch: 8, line: 0 },
   } as unknown as SelectionRedictationSnapshot;
+}
+
+function createMarkdownCommandSnapshot(): MarkdownCommandSnapshot {
+  return {
+    cursor: { ch: 0, line: 0 },
+    documentText: '',
+    editor: {},
+    file: { path: 'note.md' },
+  } as unknown as MarkdownCommandSnapshot;
 }
 
 function transcriptReady(

--- a/test/markdown-command-mode.test.ts
+++ b/test/markdown-command-mode.test.ts
@@ -1,0 +1,293 @@
+import type { App, Editor, EditorPosition, EventRef, TFile } from 'obsidian';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildMarkdownInsertionPlan,
+  captureMarkdownCommand,
+  MarkdownCommandSession,
+  type MarkdownCommandSnapshot,
+  parseMarkdownVoiceCommand,
+} from '../src/editor/markdown-command-mode';
+import { transcript } from './fixtures/transcript';
+
+const STRUCTURAL_CASES = [
+  { cursor: { ch: 0, line: 1 }, kind: 'new_line', phrase: 'new line', text: '\n' },
+  { cursor: { ch: 0, line: 2 }, kind: 'new_paragraph', phrase: 'new paragraph', text: '\n\n' },
+  { cursor: { ch: 2, line: 0 }, kind: 'bullet', phrase: 'bullet', text: '- ' },
+  { cursor: { ch: 3, line: 0 }, kind: 'numbered_item', phrase: 'numbered item', text: '1. ' },
+  { cursor: { ch: 6, line: 0 }, kind: 'checkbox', phrase: 'checkbox', text: '- [ ] ' },
+  { cursor: { ch: 2, line: 0 }, kind: 'heading_one', phrase: 'heading one', text: '# ' },
+  { cursor: { ch: 3, line: 0 }, kind: 'heading_two', phrase: 'heading two', text: '## ' },
+  { cursor: { ch: 4, line: 0 }, kind: 'heading_three', phrase: 'heading three', text: '### ' },
+  { cursor: { ch: 2, line: 1 }, kind: 'callout', phrase: 'callout', text: '> [!NOTE]\n> ' },
+  { cursor: { ch: 0, line: 1 }, kind: 'code_block', phrase: 'code block', text: '```\n\n```' },
+  {
+    cursor: { ch: 0, line: 1 },
+    kind: 'horizontal_rule',
+    phrase: 'horizontal rule',
+    text: '---\n',
+  },
+] as const;
+
+describe('Markdown voice command parser and insertion planner', () => {
+  it.each(STRUCTURAL_CASES)('parses and plans "$phrase"', ({ cursor, kind, phrase, text }) => {
+    const command = parseMarkdownVoiceCommand(phrase);
+
+    expect(command).toEqual({ kind });
+    if (command.kind === 'unrecognized') {
+      throw new Error(`expected ${phrase} to parse`);
+    }
+    expect(buildMarkdownInsertionPlan('', { ch: 0, line: 0 }, command)).toEqual({
+      cursor,
+      text,
+    });
+  });
+
+  it('normalizes case, whitespace, and terminal punctuation for command phrases', () => {
+    expect(parseMarkdownVoiceCommand('  HeAdInG   TwO!!!  ')).toEqual({ kind: 'heading_two' });
+    expect(parseMarkdownVoiceCommand('NEW\nPARAGRAPH.')).toEqual({ kind: 'new_paragraph' });
+  });
+
+  it('preserves literal content while rejecting a missing or unknown command', () => {
+    expect(parseMarkdownVoiceCommand('Literal Keep  CASE, punctuation!')).toEqual({
+      kind: 'literal',
+      text: 'Keep  CASE, punctuation!',
+    });
+    expect(parseMarkdownVoiceCommand('literal')).toEqual({
+      kind: 'unrecognized',
+      reason: 'literal_missing_text',
+    });
+    expect(parseMarkdownVoiceCommand('make this fancy')).toEqual({
+      kind: 'unrecognized',
+      reason: 'unknown',
+    });
+    expect(parseMarkdownVoiceCommand('  ')).toEqual({
+      kind: 'unrecognized',
+      reason: 'empty',
+    });
+  });
+
+  it('isolates line-based Markdown without overwriting surrounding text', () => {
+    expect(buildMarkdownInsertionPlan('alphabeta', { ch: 5, line: 0 }, { kind: 'bullet' })).toEqual(
+      {
+        cursor: { ch: 2, line: 1 },
+        text: '\n- \n',
+      },
+    );
+    expect(
+      buildMarkdownInsertionPlan('alpha\nbeta', { ch: 5, line: 0 }, { kind: 'horizontal_rule' }),
+    ).toEqual({
+      cursor: { ch: 0, line: 2 },
+      text: '\n---',
+    });
+  });
+
+  it('rejects an invalid captured cursor', () => {
+    expect(
+      buildMarkdownInsertionPlan('one line', { ch: 0, line: 2 }, { kind: 'new_line' }),
+    ).toBeNull();
+  });
+});
+
+describe('Markdown command capture and session', () => {
+  it('captures the exact editor, file, document, and cursor without mutation', () => {
+    const editor = createEditor('alpha', { ch: 3, line: 0 });
+    const file = { path: 'note.md' } as TFile;
+
+    expect(captureMarkdownCommand(editor.editor, file)).toEqual({
+      kind: 'captured',
+      snapshot: {
+        cursor: { ch: 3, line: 0 },
+        documentText: 'alpha',
+        editor: editor.editor,
+        file,
+      },
+    });
+    expect(editor.transaction).not.toHaveBeenCalled();
+    expect(captureMarkdownCommand(editor.editor, null)).toEqual({ kind: 'no_file' });
+  });
+
+  it('applies one final command in one undoable transaction with the caret at its content', () => {
+    const harness = createSessionHarness({
+      cursor: { ch: 5, line: 0 },
+      documentText: 'alphabeta',
+    });
+
+    expect(
+      harness.session.acceptTranscript(
+        transcript({ isFinal: false, text: 'bull', utteranceId: 'command-1' }),
+      ),
+    ).toEqual({ kind: 'accepted' });
+    expect(harness.editor.transaction).not.toHaveBeenCalled();
+
+    expect(
+      harness.session.acceptTranscript(transcript({ text: 'bullet', utteranceId: 'command-1' })),
+    ).toEqual({ kind: 'accepted' });
+
+    expect(harness.editor.transaction).toHaveBeenCalledWith(
+      {
+        changes: [
+          {
+            from: { ch: 5, line: 0 },
+            text: '\n- \n',
+            to: { ch: 5, line: 0 },
+          },
+        ],
+        selection: { from: { ch: 2, line: 1 } },
+      },
+      'local-dictation-markdown-command',
+    );
+
+    expect(
+      harness.session.acceptTranscript(
+        transcript({ revision: 1, text: 'horizontal rule', utteranceId: 'command-2' }),
+      ),
+    ).toEqual({ kind: 'duplicate' });
+    expect(harness.editor.transaction).toHaveBeenCalledOnce();
+  });
+
+  it('inserts literal content without command interpretation', () => {
+    const harness = createSessionHarness({ cursor: { ch: 5, line: 0 }, documentText: 'alpha' });
+
+    harness.session.acceptTranscript(
+      transcript({ text: 'literal # Keep This!', utteranceId: 'command-1' }),
+    );
+
+    expect(harness.editor.transaction).toHaveBeenCalledWith(
+      {
+        changes: [
+          {
+            from: { ch: 5, line: 0 },
+            text: '# Keep This!',
+            to: { ch: 5, line: 0 },
+          },
+        ],
+        selection: { from: { ch: 17, line: 0 } },
+      },
+      'local-dictation-markdown-command',
+    );
+  });
+
+  it('does not mutate for an unknown command and gives actionable feedback', () => {
+    const harness = createSessionHarness();
+
+    harness.session.acceptTranscript(
+      transcript({ text: 'make this fancy', utteranceId: 'command-1' }),
+    );
+
+    expect(harness.editor.transaction).not.toHaveBeenCalled();
+    expect(harness.feedback.show).toHaveBeenCalledWith({
+      intent: 'warning',
+      key: 'markdown-command-unrecognized',
+      message:
+        'Unknown Markdown command. Try “new paragraph”, “bullet”, “heading two”, or “literal” followed by text.',
+    });
+  });
+
+  it('explains how to use a literal command that has no content', () => {
+    const harness = createSessionHarness();
+
+    harness.session.acceptTranscript(transcript({ text: 'literal', utteranceId: 'command-1' }));
+
+    expect(harness.editor.transaction).not.toHaveBeenCalled();
+    expect(harness.feedback.show).toHaveBeenCalledWith({
+      intent: 'warning',
+      key: 'markdown-command-unrecognized',
+      message: 'Say “literal” followed by the exact text to insert.',
+    });
+  });
+
+  it('fails closed when the document changes after capture', () => {
+    const harness = createSessionHarness();
+    harness.setDocumentText('changed document');
+
+    harness.session.acceptTranscript(transcript({ text: 'bullet', utteranceId: 'command-1' }));
+
+    expect(harness.editor.transaction).not.toHaveBeenCalled();
+    expect(harness.feedback.show).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'markdown-command-stale' }),
+    );
+  });
+
+  it('fails closed when the captured editor or file is no longer open', () => {
+    const harness = createSessionHarness();
+    harness.setTargetOpen(false);
+
+    harness.session.acceptTranscript(transcript({ text: 'bullet', utteranceId: 'command-1' }));
+
+    expect(harness.editor.getValue).not.toHaveBeenCalled();
+    expect(harness.editor.transaction).not.toHaveBeenCalled();
+    expect(harness.feedback.show).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'markdown-command-stale' }),
+    );
+  });
+});
+
+function createSessionHarness({
+  cursor = { ch: 0, line: 0 },
+  documentText = '',
+}: {
+  cursor?: EditorPosition;
+  documentText?: string;
+} = {}) {
+  let currentDocumentText = documentText;
+  const editor = createEditor(documentText, cursor, () => currentDocumentText);
+  const file = { path: 'note.md' } as TFile;
+  let targetOpen = true;
+  const workspace = {
+    getLeavesOfType: vi.fn(() =>
+      targetOpen ? [{ view: { editor: editor.editor as unknown as Editor, file } }] : [],
+    ),
+    offref: vi.fn(),
+    on: vi.fn((_event: string, _callback: () => void) => ({}) as EventRef),
+  };
+  const vault = {
+    offref: vi.fn(),
+    on: vi.fn((_event: string, _callback: (target: TFile) => void) => ({}) as EventRef),
+  };
+  const feedback = { show: vi.fn() };
+  const snapshot: MarkdownCommandSnapshot = {
+    cursor,
+    documentText,
+    editor: editor.editor,
+    file,
+  };
+  const session = new MarkdownCommandSession({
+    app: { vault, workspace } as unknown as Pick<App, 'vault' | 'workspace'>,
+    callbacks: {
+      onLockedNoteClosed: vi.fn(),
+      onLockedNoteDeleted: vi.fn(),
+      onSurfaceDesynchronized: vi.fn(),
+    },
+    feedback,
+    snapshot,
+  });
+
+  return {
+    editor,
+    feedback,
+    session,
+    setDocumentText: (text: string) => {
+      currentDocumentText = text;
+    },
+    setTargetOpen: (open: boolean) => {
+      targetOpen = open;
+    },
+  };
+}
+
+function createEditor(
+  documentText: string,
+  cursor: EditorPosition,
+  readDocument: () => string = () => documentText,
+) {
+  const getCursor = vi.fn(() => cursor);
+  const getValue = vi.fn(readDocument);
+  const transaction = vi.fn();
+  const editor = {
+    getCursor,
+    getValue,
+    transaction,
+  } as unknown as MarkdownCommandSnapshot['editor'];
+  return { editor, getCursor, getValue, transaction };
+}

--- a/test/markdown-command-mode.test.ts
+++ b/test/markdown-command-mode.test.ts
@@ -169,6 +169,23 @@ describe('Markdown command capture and session', () => {
     );
   });
 
+  it('does not forward a content-bearing editor error to feedback', () => {
+    const harness = createSessionHarness();
+    harness.editor.transaction.mockImplementationOnce(() => {
+      throw new Error('transaction rejected: literal private transcript');
+    });
+
+    harness.session.acceptTranscript(
+      transcript({ text: 'literal private transcript', utteranceId: 'command-1' }),
+    );
+
+    expect(harness.feedback.show).toHaveBeenCalledWith({
+      intent: 'error',
+      key: 'markdown-command-failed',
+      message: 'Could not apply the Markdown command. Run the command and try again.',
+    });
+  });
+
   it('does not mutate for an unknown command and gives actionable feedback', () => {
     const harness = createSessionHarness();
 

--- a/test/markdown-command-mode.test.ts
+++ b/test/markdown-command-mode.test.ts
@@ -101,6 +101,7 @@ describe('Markdown command capture and session', () => {
         documentText: 'alpha',
         editor: editor.editor,
         file,
+        filePath: 'note.md',
       },
     });
     expect(editor.transaction).not.toHaveBeenCalled();
@@ -221,6 +222,19 @@ describe('Markdown command capture and session', () => {
       expect.objectContaining({ key: 'markdown-command-stale' }),
     );
   });
+
+  it('fails closed when the captured file is renamed', () => {
+    const harness = createSessionHarness();
+    harness.renameFile('renamed.md');
+
+    harness.session.acceptTranscript(transcript({ text: 'bullet', utteranceId: 'command-1' }));
+
+    expect(harness.editor.getValue).not.toHaveBeenCalled();
+    expect(harness.editor.transaction).not.toHaveBeenCalled();
+    expect(harness.feedback.show).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'markdown-command-stale' }),
+    );
+  });
 });
 
 function createSessionHarness({
@@ -251,6 +265,7 @@ function createSessionHarness({
     documentText,
     editor: editor.editor,
     file,
+    filePath: 'note.md',
   };
   const session = new MarkdownCommandSession({
     app: { vault, workspace } as unknown as Pick<App, 'vault' | 'workspace'>,
@@ -266,6 +281,9 @@ function createSessionHarness({
   return {
     editor,
     feedback,
+    renameFile: (path: string) => {
+      Object.assign(file, { path });
+    },
     session,
     setDocumentText: (text: string) => {
       currentDocumentText = text;

--- a/test/register-commands.test.ts
+++ b/test/register-commands.test.ts
@@ -20,12 +20,15 @@ describe('registerCommands', () => {
     const onSelectionRedictationError = vi.fn();
     registerCommands({
       cancelDictation: vi.fn(async () => {}),
+      canCaptureMarkdownCommand: vi.fn(() => false),
       canRedictateSelection,
       checkSidecarHealth: vi.fn(async () => {}),
+      onMarkdownCommandError: vi.fn(),
       onSelectionRedictationError,
       plugin,
       restartSidecar: vi.fn(async () => {}),
       startDictation: vi.fn(async () => {}),
+      startMarkdownCommand: vi.fn(async () => {}),
       startSelectionRedictation,
       stopDictation: vi.fn(async () => {}),
       toggleDictation: vi.fn(async () => {}),
@@ -48,6 +51,55 @@ describe('registerCommands', () => {
     expect(startSelectionRedictation).toHaveBeenCalledWith(editor, file);
     await vi.waitFor(() => {
       expect(onSelectionRedictationError).toHaveBeenCalledWith(startError);
+    });
+  });
+
+  it('registers Markdown command mode and contains an unexpected startup rejection', async () => {
+    const commands: Command[] = [];
+    const plugin = {
+      addCommand: vi.fn((command: Command) => {
+        commands.push(command);
+      }),
+    } as unknown as Plugin;
+    let available = false;
+    const canCaptureMarkdownCommand = vi.fn(() => available);
+    const startError = new Error('unexpected Markdown command failure');
+    const startMarkdownCommand = vi.fn(async () => {
+      throw startError;
+    });
+    const onMarkdownCommandError = vi.fn();
+    registerCommands({
+      cancelDictation: vi.fn(async () => {}),
+      canCaptureMarkdownCommand,
+      canRedictateSelection: vi.fn(() => false),
+      checkSidecarHealth: vi.fn(async () => {}),
+      onMarkdownCommandError,
+      onSelectionRedictationError: vi.fn(),
+      plugin,
+      restartSidecar: vi.fn(async () => {}),
+      startDictation: vi.fn(async () => {}),
+      startMarkdownCommand,
+      startSelectionRedictation: vi.fn(async () => {}),
+      stopDictation: vi.fn(async () => {}),
+      toggleDictation: vi.fn(async () => {}),
+    });
+    const command = commands.find(({ id }) => id === 'markdown-command-mode');
+    const editor = {} as Editor;
+    const file = { path: 'note.md' } as TFile;
+    const context = { file } as never;
+
+    expect(command?.name).toBe('Apply Markdown by voice');
+    expect(command?.editorCheckCallback?.(true, editor, context)).toBe(false);
+    expect(startMarkdownCommand).not.toHaveBeenCalled();
+
+    available = true;
+    expect(command?.editorCheckCallback?.(true, editor, context)).toBe(true);
+    expect(startMarkdownCommand).not.toHaveBeenCalled();
+
+    expect(command?.editorCheckCallback?.(false, editor, context)).toBe(true);
+    expect(startMarkdownCommand).toHaveBeenCalledWith(editor, file);
+    await vi.waitFor(() => {
+      expect(onMarkdownCommandError).toHaveBeenCalledWith(startError);
     });
   });
 });

--- a/test/selection-redictation.test.ts
+++ b/test/selection-redictation.test.ts
@@ -125,6 +125,23 @@ describe('SelectionRedictationSession', () => {
     expect(harness.editor.transaction).toHaveBeenCalledOnce();
   });
 
+  it('does not forward a content-bearing editor error to feedback', () => {
+    const harness = createSessionHarness();
+    harness.editor.transaction.mockImplementationOnce(() => {
+      throw new Error('transaction rejected: private replacement transcript');
+    });
+
+    harness.session.acceptTranscript(
+      transcript({ text: 'private replacement transcript', utteranceId: 'selection-1' }),
+    );
+
+    expect(harness.feedback.show).toHaveBeenCalledWith({
+      intent: 'error',
+      key: 'selection-redictation-failed',
+      message: 'Could not replace the selected text. Select it again and retry.',
+    });
+  });
+
   it('leaves the note unchanged when its captured document changes', () => {
     const harness = createSessionHarness();
     harness.editor.getValue.mockReturnValue('user-edited document');

--- a/test/selection-redictation.test.ts
+++ b/test/selection-redictation.test.ts
@@ -28,6 +28,7 @@ describe('selection re-dictation capture', () => {
         documentText: 'Context before selection original',
         editor: editor.editor,
         file,
+        filePath: 'note.md',
         from: { ch: 4, line: 2 },
         to: { ch: 12, line: 2 },
       },
@@ -188,6 +189,21 @@ describe('SelectionRedictationSession', () => {
     );
   });
 
+  it('leaves the note unchanged when the captured file is renamed', () => {
+    const harness = createSessionHarness();
+    harness.renameFile('renamed.md');
+
+    harness.session.acceptTranscript(
+      transcript({ text: 'replacement text', utteranceId: 'selection-1' }),
+    );
+
+    expect(harness.editor.getValue).not.toHaveBeenCalled();
+    expect(harness.editor.transaction).not.toHaveBeenCalled();
+    expect(harness.feedback.show).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'selection-redictation-stale' }),
+    );
+  });
+
   it('keeps the original selection when the first final is empty', () => {
     const harness = createSessionHarness();
 
@@ -312,6 +328,7 @@ function createSessionHarness() {
     documentText: 'Context before selection original',
     editor: editor.editor,
     file,
+    filePath: 'note.md',
     from: { ch: 4, line: 1 },
     to: { ch: 12, line: 1 },
   };
@@ -328,6 +345,9 @@ function createSessionHarness() {
     emitDelete: (deletedFile: TFile = file) => deleted?.(deletedFile),
     emitLayoutChange: () => layoutChange?.(),
     feedback,
+    renameFile: (path: string) => {
+      Object.assign(file, { path });
+    },
     session,
     snapshot,
     setOpenFile: (nextFile: TFile) => {


### PR DESCRIPTION
## Stacked dependency

- Base branch: `feat/redictate-selection`
- Depends on #236 and should be reviewed/landed after that PR.
- This PR contains only the command-mode delta above the updated #236 head.
- Follow-up 3 of 5 in this improvement pass.

## Summary

- Add **Local Dictation: Apply Markdown by voice**, an explicit editor command suitable for a user-assigned hotkey.
- Capture one finalized microphone utterance and deterministically parse a fixed Markdown command vocabulary.
- Support new line, new paragraph, bullet, numbered item, checkbox, heading one/two/three, callout, code block, horizontal rule, and `literal <text>`.
- Leave the note unchanged with actionable feedback for empty, incomplete-literal, or unknown phrases.

## Safety and privacy

- Bind the session to the exact editor, file object, immutable file path, document text, and cursor captured at invocation.
- Revalidate after asynchronous preflight and again before the single editor transaction; any note, path, or target change fails closed.
- Force microphone-only capture with system audio and diarization disabled.
- Disable note context and every LLM cleanup path; no provider selection or request occurs.
- Do not forward editor exceptions that could echo spoken replacement text into feedback logs.
- Stop on the first final transcript and ignore every later revision.

## Design

- Keep parsing and insertion planning as pure helpers with no new dependency.
- Isolate line-based structures at Markdown-safe boundaries and place the caret at the next meaningful input position.
- Extract the lifecycle/final-only editor surface shared with selection re-dictation, removing duplicated dummy controller capabilities.

## Verification

- `npm test -- --run test/markdown-command-mode.test.ts test/selection-redictation.test.ts test/dictation-session-controller.test.ts test/register-commands.test.ts` — 102 tests passed.
- `npm run check:frontend` — typecheck, Biome, Obsidian ESLint, 59 files / 776 tests, and production frontend build passed.
- GitHub CI — frontend plus Linux, macOS, and Windows sidecar jobs passed.
- No native or wire files changed, so the local Rust/full release gate was not required.

## Manual gap

- Interactive microphone/hotkey behavior in Obsidian was not run in this non-interactive environment.