### PR TITLE
Clarify phrase finalization timing for live models

### DIFF
--- a/src/settings/phrase-finalization-setting.ts
+++ b/src/settings/phrase-finalization-setting.ts
@@ -1,0 +1,17 @@
+import type { SpeakingStyle } from '../sidecar/protocol';
+
+const STYLE_DESCRIPTIONS: Record<SpeakingStyle, string> = {
+  responsive: 'Finalizes after shorter pauses for faster completed text.',
+  balanced: 'Uses the standard pause tolerance for everyday dictation.',
+  patient: 'Waits through longer pauses so a thought is less likely to be split.',
+};
+
+const SHARED_DESCRIPTION =
+  'Applies to every transcription model, including live models; live words can still update before the phrase is final.';
+
+export const PHRASE_FINALIZATION_TOOLTIP =
+  'This changes voice-activity boundaries, not writing style or model accuracy. Responsive favors speed; Patient favors keeping pauses inside one phrase.';
+
+export function phraseFinalizationDescription(style: SpeakingStyle): string {
+  return `${STYLE_DESCRIPTIONS[style]} ${SHARED_DESCRIPTION}`;
+}

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -21,6 +21,10 @@ import { renderActiveInstallCard } from './install-progress-row';
 import { renderMicrophonePicker } from './microphone-picker';
 import { renderModelSection } from './model-settings-section';
 import {
+  PHRASE_FINALIZATION_TOOLTIP,
+  phraseFinalizationDescription,
+} from './phrase-finalization-setting';
+import {
   type DictationAnchor,
   isDictationAnchor,
   isListeningMode,
@@ -40,6 +44,7 @@ import {
   addEnumSetting,
   addTextSetting,
   addToggleSetting,
+  appendInfoTooltip,
   createSettingGroup,
   type DropdownOption,
   type SettingAccess,
@@ -86,9 +91,9 @@ const TRANSCRIPT_FORMATTING_OPTIONS: ReadonlyArray<DropdownOption<TranscriptForm
 ];
 
 const SPEAKING_STYLE_OPTIONS: ReadonlyArray<DropdownOption<SpeakingStyle>> = [
-  { label: 'Responsive', value: 'responsive' },
-  { label: 'Balanced', value: 'balanced' },
-  { label: 'Patient', value: 'patient' },
+  { label: 'Responsive — short pauses', value: 'responsive' },
+  { label: 'Balanced — standard', value: 'balanced' },
+  { label: 'Patient — long pauses', value: 'patient' },
 ];
 
 const TIMESTAMP_CLOCK_OPTIONS: ReadonlyArray<DropdownOption<TimestampClock>> = [
@@ -206,15 +211,21 @@ export class LocalSttSettingTab extends PluginSettingTab {
       isValid: isListeningMode,
     });
 
-    addEnumSetting(captureCard, this.access, {
-      name: 'Speaking style',
-      desc: "How quickly the engine decides you've stopped speaking.",
-      tooltip:
-        'Responsive ends quickly. Balanced uses standard detection (default). Patient waits longer through pauses.',
-      key: 'speakingStyle',
-      options: SPEAKING_STYLE_OPTIONS,
-      isValid: isSpeakingStyle,
+    const phraseFinalizationSetting = new Setting(captureCard)
+      .setName('Phrase finalization')
+      .setDesc(phraseFinalizationDescription(settings.speakingStyle));
+    phraseFinalizationSetting.addDropdown((dropdown) => {
+      for (const option of SPEAKING_STYLE_OPTIONS) {
+        dropdown.addOption(option.value, option.label);
+      }
+      dropdown.setValue(settings.speakingStyle);
+      dropdown.onChange(async (value) => {
+        if (!isSpeakingStyle(value)) return;
+        await this.access.persistOne('speakingStyle', value);
+        phraseFinalizationSetting.setDesc(phraseFinalizationDescription(value));
+      });
     });
+    appendInfoTooltip(phraseFinalizationSetting, PHRASE_FINALIZATION_TOOLTIP);
 
     const outputCard = createSettingGroup(containerEl, 'Transcript output');
 

--- a/test/phrase-finalization-setting.test.ts
+++ b/test/phrase-finalization-setting.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { phraseFinalizationDescription } from '../src/settings/phrase-finalization-setting';
+
+describe('phraseFinalizationDescription', () => {
+  it.each([
+    ['responsive', 'shorter pauses', 'faster completed text'],
+    ['balanced', 'standard pause tolerance', 'everyday dictation'],
+    ['patient', 'longer pauses', 'less likely to be split'],
+  ] as const)('explains the %s trade-off', (style, timing, outcome) => {
+    const description = phraseFinalizationDescription(style);
+
+    expect(description).toContain(timing);
+    expect(description).toContain(outcome);
+  });
+
+  it.each([
+    'responsive',
+    'balanced',
+    'patient',
+  ] as const)('makes live-model behavior explicit for %s', (style) => {
+    expect(phraseFinalizationDescription(style)).toContain(
+      'every transcription model, including live models',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Rename the user-facing “Speaking style” control to **Phrase finalization** so its effect is clear.
- Explain the speed-versus-pause-tolerance trade-off for each option directly in the setting.
- State explicitly that the shared voice-activity boundary applies to batch and live models, including Moonshine.

## Why

The existing label implied writing style or model-specific behavior, while the implementation actually selects shared VAD timing for every session. That made it unclear whether the setting affected streaming models and what users were trading off.

The persisted `speakingStyle` values and native timing remain unchanged. This is intentionally a UX clarification rather than a risky retuning of tested speech-boundary behavior.

## User impact

Users can now choose between faster completed phrases and more tolerance for pauses without guessing whether the control changes accuracy, prose style, or only batch transcription. The description updates immediately when the dropdown changes.

Closes #246.

## Verification

- `npm run check:frontend`
- 63 Vitest files / 774 tests passed
- Production frontend build passed

## Manual gap

Interactive rendering in Obsidian was not exercised in this non-interactive environment.
