### PR TITLE
Define and troubleshoot Linux support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -25,7 +25,7 @@ body:
       description: Minimal steps to trigger the bug.
       placeholder: |
         1. Open Obsidian
-        2. Enable Local STT plugin
+        2. Enable Local Dictation
         3. ...
     validations:
       required: true
@@ -39,12 +39,46 @@ body:
       required: true
 
   - type: input
+    id: architecture
+    attributes:
+      label: CPU architecture
+      description: On Linux or macOS, `uname -m` reports this value.
+      placeholder: "e.g., x86_64, arm64"
+    validations:
+      required: true
+
+  - type: input
+    id: installation-source
+    attributes:
+      label: Obsidian installation source
+      placeholder: "e.g., official installer, AppImage, Debian package, tarball, Flatpak"
+    validations:
+      required: true
+
+  - type: input
     id: obsidian-version
     attributes:
       label: Obsidian version
       placeholder: "e.g., 1.8.0"
     validations:
       required: true
+
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Local Dictation version
+      placeholder: "e.g., 2026.7.5"
+    validations:
+      required: true
+
+  - type: input
+    id: linux-audio
+    attributes:
+      label: Linux desktop and audio stack (Linux only)
+      description: Include the desktop session and the server name from `pactl info` when the problem involves audio.
+      placeholder: "e.g., KDE Plasma 6 on Wayland; PulseAudio (on PipeWire 1.4)"
+    validations:
+      required: false
 
   - type: dropdown
     id: sidecar-build

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ Published sidecar builds currently target Apple silicon on macOS and x86-64 on W
 | **Windows (x86-64)** | Supported | Optional CUDA on a recent NVIDIA GPU | Supported |
 | **Linux (x86-64)** | Supported | Optional CUDA on a recent NVIDIA GPU | Supported through PulseAudio/PipeWire |
 
-macOS and Windows are the primary tested targets. On Linux, the plugin is used daily on Fedora (native and Flatpak); other distributions should work but are not routinely verified.
+macOS and Windows are the primary tested targets. On Linux, the plugin is used daily on Fedora (native and Flatpak); other x86-64 glibc distributions are compatibility targets rather than distro-specific guarantees. See the [Linux support guide](docs/guides/linux-support.md) for package, audio-stack, Flatpak, and troubleshooting details.
 
 If something breaks on your distribution, [open an issue](https://github.com/brittain9/local-dictation-obsidian-plugin/issues).
 
-For CUDA requirements and Flatpak-specific setup, see the [CUDA setup guide](docs/guides/cuda-setup.md).
+For GPU requirements and sandbox-specific setup, see the [CUDA setup guide](docs/guides/cuda-setup.md).
 
 ## Privacy
 

--- a/docs/guides/linux-support.md
+++ b/docs/guides/linux-support.md
@@ -1,0 +1,92 @@
+# Linux support
+
+Local Dictation supports desktop Obsidian on x86-64 GNU/Linux. The plugin UI runs inside Obsidian, while transcription runs in a native sidecar built for the `x86_64-unknown-linux-gnu` target.
+
+## What is supported
+
+| Area | Support boundary |
+| --- | --- |
+| CPU transcription | x86-64, glibc-based distributions with a new enough runtime for the current release build |
+| NVIDIA acceleration | x86-64 with a Turing-or-newer GPU and a CUDA 13-compatible driver; see [CUDA setup](cuda-setup.md) |
+| Microphone capture | Obsidian/Electron's audio input through PulseAudio or PipeWire |
+| System audio | The default output monitor through PulseAudio, or PipeWire's PulseAudio compatibility service |
+| Obsidian packages | Native packages and the Flathub build; sandbox changes are needed only when permissions were restricted or CUDA needs host libraries |
+
+ARM64, 32-bit Linux, musl-only systems such as Alpine, and mobile Obsidian are not release targets. The project does not yet publish a frozen minimum glibc version. NixOS and other distributions that do not run ordinary glibc binaries are best-effort rather than first-class until the project has a tested packaging path for them.
+
+## Current test coverage
+
+- Fedora 44 KDE is used for day-to-day native testing and has also been exercised through Flatpak.
+- Ubuntu has been exercised in a standard virtual-machine install.
+- Every change builds and tests the sidecar on GitHub's current Ubuntu runner.
+- Linux system-audio integration tests are available, but hardware-dependent cases are not part of routine pull-request CI.
+
+Other x86-64 glibc distributions should work when their audio service exposes the same interfaces, but they are compatibility targets rather than a claim of distro-specific verification. A useful Linux bug report includes the distribution, architecture, Obsidian package, desktop session, audio server, and whether microphone-only dictation works.
+
+## Native Obsidian packages
+
+AppImage, Debian-package, and tarball installs all run outside a Flatpak sandbox. Install Local Dictation normally, complete its setup wizard, and start with the CPU sidecar. The published sidecar loads `libpulse-simple.so.0` only when system audio is enabled, so microphone dictation does not require that library.
+
+For system audio, verify that the PulseAudio-compatible service is available and exposes a monitor source:
+
+```sh
+pactl info
+pactl get-default-sink
+pactl list short sources | grep '\.monitor'
+```
+
+On a PipeWire desktop, `pactl info` should identify the PulseAudio compatibility server. Package names differ across distributions; install or enable the distribution's `pipewire-pulse` equivalent rather than replacing a working PipeWire setup with a second audio server.
+
+## Flatpak Obsidian
+
+The [Flathub package](https://github.com/flathub/md.obsidian.Obsidian) is verified by the Obsidian team but maintained outside Obsidian's supported installers. Its default permissions include home-directory and PulseAudio access, which are the permissions Local Dictation normally needs for a vault and audio capture. Flatpak's [`pulseaudio` socket permission](https://docs.flatpak.org/en/latest/sandbox-permissions.html) covers microphone, playback, and audio-device access.
+
+If those permissions were tightened with Flatseal or `flatpak override`, inspect the effective configuration:
+
+```sh
+flatpak info --show-permissions md.obsidian.Obsidian
+```
+
+Restore PulseAudio access only when it is missing:
+
+```sh
+flatpak override --user --socket=pulseaudio md.obsidian.Obsidian
+```
+
+The CPU sidecar does not need broad host filesystem or device access. CUDA is different because the sandbox must expose host driver libraries and GPU devices; follow the [Flatpak CUDA steps](cuda-setup.md#linux-flatpak) instead of adding global environment overrides.
+
+Do not set a global `LD_LIBRARY_PATH` Flatpak override. Electron can load incompatible host audio libraries and then fail to open the microphone. The plugin's **CUDA library path** setting scopes that environment change to the sidecar process.
+
+## Troubleshooting
+
+### No microphone is detected
+
+Local Dictation obtains microphone audio through Obsidian/Electron, not through the sidecar. Confirm that the device is enabled in the desktop sound settings, then fully restart Obsidian after permission changes. For Flatpak, confirm that the `pulseaudio` socket has not been removed.
+
+If the error is `NotReadableError`, close other applications using the device and remove any global Flatpak `LD_LIBRARY_PATH` override before retrying.
+
+### System audio is unavailable
+
+First turn off **Include system audio**. If microphone-only dictation works, the model and sidecar are healthy and the failure is limited to the output-monitor path.
+
+Then check `pactl info` and the monitor-source command above. Local Dictation records `@DEFAULT_MONITOR@`; a missing default sink, missing `libpulse-simple.so.0`, stopped PulseAudio compatibility service, or removed Flatpak audio permission will prevent that source from opening.
+
+### The sidecar does not start
+
+Run **Local Dictation: Check sidecar health** from the command palette. On an unsupported architecture, use a supported x86-64 machine; selecting a different model cannot change the sidecar architecture.
+
+For a sandboxed install, avoid pointing **Sidecar path override** at a host path that is not visible inside the sandbox. The managed CPU sidecar is installed inside the plugin directory and should not need an override.
+
+### Reporting a Linux problem
+
+Open a bug report and include:
+
+- Local Dictation and Obsidian versions
+- distribution and version, CPU architecture, and kernel
+- Obsidian package source (AppImage, Debian package, tarball, Flatpak, or other)
+- desktop and session (for example, KDE Plasma 6 on Wayland)
+- `pactl info` server name when the problem involves audio
+- CPU or CUDA sidecar, selected model, and the exact error
+- whether microphone-only dictation works with system audio disabled
+
+Enable **Developer mode** in Local Dictation settings for verbose diagnostics. Review logs before posting them and remove unrelated local paths or note content.


### PR DESCRIPTION
## Summary

- Add a dedicated Linux support guide covering the actual release target, tested environments, native packages, Flatpak, audio-stack requirements, and failure isolation.
- Replace the README’s broad distro claim with an explicit compatibility boundary.
- Expand the bug-report form with the architecture, install source, plugin version, and optional Linux desktop/audio stack needed to diagnose distro-specific failures.

## Decisions

The project ships one `x86_64-unknown-linux-gnu` sidecar, not per-distribution packages. The guide therefore distinguishes verified environments from compatible-but-unverified distributions and explicitly names unsupported architecture/runtime classes.

Flatpak CPU use does not receive blanket host/device override instructions. The documented recovery is limited to permissions the current Flathub manifest normally provides; broader `host-os` and device access stays confined to the existing CUDA guide.

Microphone capture and system-audio capture are documented separately because they cross different boundaries: Electron owns microphone input, while the sidecar dynamically loads `libpulse-simple` and opens `@DEFAULT_MONITOR@` for system audio.

## User impact

Linux users get a short path to identify whether a failure is the microphone, PulseAudio/PipeWire monitor, Flatpak permission, sidecar architecture, or CUDA setup. Maintainers receive the environment details needed to reproduce a report without a long clarification loop.

Relates to #244.

## Verification

- `git diff --check`
- Parsed `.github/ISSUE_TEMPLATE/bug-report.yml` with Ruby YAML and verified 11 unique field IDs
- Verified all repository-relative guide links resolve locally

## Scope

This PR documents and supports the current binary boundary. It does not claim first-class ARM64, musl, NixOS, or per-distro packaging, and it does not add new release targets.
