### PR TITLE
Improve LLM sidebar hierarchy and scaling

### DIFF
--- a/src/ui/llm-sidebar-presentation.ts
+++ b/src/ui/llm-sidebar-presentation.ts
@@ -1,0 +1,74 @@
+import { describePresetTiming, resolveActivePresetEntry } from '../llm/presets';
+import type { PluginSettings } from '../settings/plugin-settings';
+
+type LlmSidebarSettings = Pick<
+  PluginSettings,
+  | 'llmFeaturesEnabled'
+  | 'llmPostprocessActivePresetRef'
+  | 'llmPostprocessMode'
+  | 'llmPostprocessUserPresets'
+>;
+
+interface ActiveLlmSidebarPresentation {
+  emptyState: null;
+  state: 'active';
+  statusLabel: 'On';
+  summary: string;
+}
+
+interface InactiveLlmSidebarPresentation {
+  emptyState: {
+    description: string;
+    icon: string;
+    title: string;
+  };
+  state: 'off' | 'unavailable';
+  statusLabel: 'Off' | 'Unavailable';
+  summary: string;
+}
+
+export type LlmSidebarPresentation = ActiveLlmSidebarPresentation | InactiveLlmSidebarPresentation;
+
+export function resolveLlmSidebarPresentation(
+  settings: LlmSidebarSettings,
+): LlmSidebarPresentation {
+  if (!settings.llmFeaturesEnabled) {
+    return {
+      emptyState: {
+        description: 'Enable LLM features in Local Dictation settings to configure transforms.',
+        icon: 'settings-2',
+        title: 'LLM features are unavailable',
+      },
+      state: 'unavailable',
+      statusLabel: 'Unavailable',
+      summary: 'Enable LLM features in settings',
+    };
+  }
+
+  if (settings.llmPostprocessMode === 'off') {
+    return {
+      emptyState: {
+        description:
+          'Dictation inserts the raw Whisper transcript. Turn on Transform when you want cleanup, rewriting, or summaries.',
+        icon: 'file-text',
+        title: 'Raw transcript mode',
+      },
+      state: 'off',
+      statusLabel: 'Off',
+      summary: 'Raw Whisper transcript',
+    };
+  }
+
+  const { preset } = resolveActivePresetEntry(
+    settings.llmPostprocessActivePresetRef,
+    settings.llmPostprocessUserPresets,
+  );
+  const timing = preset.timing ?? settings.llmPostprocessMode;
+
+  return {
+    emptyState: null,
+    state: 'active',
+    statusLabel: 'On',
+    summary: `${preset.label} · ${describePresetTiming(timing)}`,
+  };
+}

--- a/src/ui/llm-sidebar-presentation.ts
+++ b/src/ui/llm-sidebar-presentation.ts
@@ -49,13 +49,13 @@ export function resolveLlmSidebarPresentation(
     return {
       emptyState: {
         description:
-          'Dictation inserts the raw Whisper transcript. Turn on Transform when you want cleanup, rewriting, or summaries.',
+          'Dictation inserts the raw local transcript. Turn on Transform when you want cleanup, rewriting, or summaries.',
         icon: 'file-text',
         title: 'Raw transcript mode',
       },
       state: 'off',
       statusLabel: 'Off',
-      summary: 'Raw Whisper transcript',
+      summary: 'Raw transcript',
     };
   }
 

--- a/src/ui/local-dictation-view.ts
+++ b/src/ui/local-dictation-view.ts
@@ -24,6 +24,10 @@ import { ConfirmModal } from './confirm-modal';
 import { FocusRefreshController } from './focus-refresh-controller';
 import { formatCleanupFailureBanner } from './llm-provider-ui';
 import { LlmRoutingControls } from './llm-routing-controls';
+import {
+  type LlmSidebarPresentation,
+  resolveLlmSidebarPresentation,
+} from './llm-sidebar-presentation';
 import { INLINE_STATUS_PRESENTATION } from './llm-status';
 import { PresetManagerModal } from './preset-manager-modal';
 
@@ -156,36 +160,48 @@ export class LocalDictationView extends ItemView {
     contentEl.empty();
     contentEl.addClass('local-dictation-sidebar');
 
+    const presentation = resolveLlmSidebarPresentation(settings);
+    this.renderOverview(contentEl, presentation);
+
     if (!settings.llmFeaturesEnabled) {
+      this.renderEmptyState(contentEl, presentation);
       return;
     }
 
-    const headerGroup = createSettingGroup(contentEl, 'LLM transformation', HEADING_TOOLTIP);
+    const headerGroup = createSettingGroup(contentEl, 'Transform', HEADING_TOOLTIP);
     this.renderCleanupToggle(headerGroup, settings);
 
     if (settings.llmPostprocessMode === 'off') {
-      headerGroup.createEl('p', {
-        cls: 'local-dictation-muted',
-        text: 'Raw Whisper text is inserted as-is. Turn on to clean, rewrite, or summarize the transcript with an LLM.',
-      });
+      this.renderEmptyState(contentEl, presentation);
       return;
     }
 
     this.renderRuntimeFailureBanner(headerGroup);
 
-    const whereGroup = createSettingGroup(contentEl, 'Where it runs');
-    this.routingControls.render(whereGroup, settings);
-
-    const styleGroup = createSettingGroup(contentEl, 'Style');
+    const styleGroup = createSettingGroup(contentEl, 'Preset');
     this.renderPresetPicker(styleGroup, settings);
     this.renderCleanupMode(styleGroup, settings);
+
+    const whereGroup = createSettingGroup(contentEl, 'Provider');
+    this.routingControls.render(whereGroup, settings);
 
     const contextGroup = createSettingGroup(contentEl, 'Context');
     this.renderUseNoteContextToggle(contextGroup, settings);
     this.renderNoteContextChars(contextGroup, settings);
 
     const advanced = contentEl.createEl('details', { cls: 'local-dictation-advanced' });
-    advanced.createEl('summary', { text: 'Advanced' });
+    const advancedSummary = advanced.createEl('summary');
+    const advancedSummaryText = advancedSummary.createSpan({
+      cls: 'local-dictation-advanced__summary',
+    });
+    advancedSummaryText.createSpan({
+      cls: 'local-dictation-advanced__title',
+      text: 'Advanced settings',
+    });
+    advancedSummaryText.createSpan({
+      cls: 'local-dictation-advanced__description',
+      text: 'Limits, generation, and diagnostics',
+    });
     advanced.open = this.advancedOpen;
     advanced.addEventListener('toggle', () => {
       this.advancedOpen = advanced.open;
@@ -200,11 +216,48 @@ export class LocalDictationView extends ItemView {
     this.scheduleRender();
   }
 
+  private renderOverview(parent: HTMLElement, presentation: LlmSidebarPresentation): void {
+    const header = parent.createEl('header', { cls: 'local-dictation-sidebar__header' });
+    header.createDiv({ cls: 'local-dictation-sidebar__eyebrow', text: 'Transcript workflow' });
+    header.createEl('h2', {
+      cls: 'local-dictation-sidebar__title',
+      text: 'Transform dictation',
+    });
+    header.createEl('p', {
+      cls: 'local-dictation-sidebar__description',
+      text: 'Choose how spoken text is shaped before it reaches your note.',
+    });
+
+    const status = header.createDiv({ cls: 'local-dictation-sidebar__summary' });
+    status.createSpan({
+      cls: `local-dictation-sidebar__badge local-dictation-sidebar__badge--${presentation.state}`,
+      text: presentation.statusLabel,
+    });
+    status.createSpan({
+      cls: 'local-dictation-sidebar__summary-text',
+      text: presentation.summary,
+      title: presentation.summary,
+    });
+  }
+
+  private renderEmptyState(parent: HTMLElement, presentation: LlmSidebarPresentation): void {
+    if (presentation.emptyState === null) {
+      return;
+    }
+
+    const emptyState = parent.createDiv({ cls: 'local-dictation-sidebar__empty' });
+    const icon = emptyState.createDiv({ cls: 'local-dictation-sidebar__empty-icon' });
+    icon.setAttribute('aria-hidden', 'true');
+    setIcon(icon, presentation.emptyState.icon);
+    emptyState.createEl('h3', { text: presentation.emptyState.title });
+    emptyState.createEl('p', { text: presentation.emptyState.description });
+  }
+
   private renderCleanupToggle(parent: HTMLElement, settings: PluginSettings): void {
     const enabled = settings.llmPostprocessMode !== 'off';
     new Setting(parent)
-      .setName('Transform')
-      .setDesc('')
+      .setName('Enabled')
+      .setDesc('Apply the active preset to new dictated text.')
       .addToggle((toggle) => {
         toggle.setValue(enabled);
         toggle.onChange(async (value) => {
@@ -231,7 +284,7 @@ export class LocalDictationView extends ItemView {
     const pinned = preset.timing;
 
     new Setting(parent)
-      .setName('Mode')
+      .setName('Run transform')
       .setDesc(
         pinned !== undefined
           ? `Set by ${preset.label} — ${describePresetTiming(pinned).toLowerCase()}.`
@@ -263,14 +316,17 @@ export class LocalDictationView extends ItemView {
       settings.llmPostprocessUserPresets,
     );
 
+    const description = active.preset.description ?? describePresetBehavior(active.preset);
+    const activeLabel = formatPresetOptionLabel(active.preset);
     const setting = new Setting(parent)
-      .setName('Preset')
-      .setDesc(active.preset.description ?? describePresetBehavior(active.preset))
+      .setName('Active preset')
+      .setDesc(description)
       .addDropdown((dropdown) => {
         for (const entry of entries) {
           dropdown.addOption(entry.ref, formatPresetOptionLabel(entry.preset));
         }
         dropdown.setValue(active.ref);
+        dropdown.selectEl.setAttribute('title', activeLabel);
         dropdown.onChange(async (value) => {
           await this.mutatePresetState((state) => ({
             ...state,
@@ -278,10 +334,12 @@ export class LocalDictationView extends ItemView {
           }));
         });
       });
+    setting.settingEl.addClass('local-dictation-preset-setting');
+    setting.descEl.setAttribute('title', description);
     appendInfoTooltip(setting, STYLE_PICKER_TOOLTIP);
 
-    setting.addExtraButton((button) => {
-      button.setIcon('sliders-horizontal');
+    setting.addButton((button) => {
+      button.setButtonText('Manage presets');
       button.setTooltip('Manage presets');
       button.onClick(() => {
         void this.openPresetManager();

--- a/styles.css
+++ b/styles.css
@@ -641,9 +641,132 @@
   }
 }
 
-/* --- LLM sidebar narrow-width --------------------------------------
-   When the sidebar is dragged narrow, stack setting rows vertically so
-   labels and controls don't get squeezed onto a single short line. */
+/* --- LLM sidebar shell and responsive layout ---------------------- */
+
+.local-dictation-sidebar {
+  padding-bottom: var(--size-4-6);
+}
+
+.local-dictation-sidebar__header {
+  padding: var(--size-4-3) var(--size-4-3) var(--size-4-4);
+}
+
+.local-dictation-sidebar__eyebrow {
+  margin-bottom: var(--size-4-1);
+  color: var(--text-faint);
+  font-size: var(--font-ui-smaller);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.local-dictation-sidebar__title {
+  margin: 0;
+  color: var(--text-normal);
+  font-size: var(--font-ui-large);
+}
+
+.local-dictation-sidebar__description {
+  margin: var(--size-4-1) 0 var(--size-4-3);
+  color: var(--text-muted);
+  font-size: var(--font-ui-small);
+  line-height: var(--line-height-tight);
+}
+
+.local-dictation-sidebar__summary {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: var(--size-4-2);
+}
+
+.local-dictation-sidebar__badge {
+  flex: 0 0 auto;
+  padding: 2px var(--size-4-2);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-s);
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+  font-weight: 600;
+}
+
+.local-dictation-sidebar__badge--active {
+  border-color: var(--background-modifier-success, var(--background-modifier-border));
+  color: var(--text-success);
+}
+
+.local-dictation-sidebar__summary-text {
+  display: -webkit-box;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.local-dictation-sidebar__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: var(--size-4-5) var(--size-4-3) 0;
+  padding: var(--size-4-6) var(--size-4-4);
+  border: 1px dashed var(--background-modifier-border);
+  border-radius: var(--radius-m);
+  text-align: center;
+}
+
+.local-dictation-sidebar__empty-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  margin-bottom: var(--size-4-2);
+  border-radius: 50%;
+  background: var(--background-secondary-alt);
+  color: var(--text-muted);
+}
+
+.local-dictation-sidebar__empty-icon svg {
+  width: 17px;
+  height: 17px;
+}
+
+.local-dictation-sidebar__empty h3 {
+  margin: 0;
+  font-size: var(--font-ui-medium);
+}
+
+.local-dictation-sidebar__empty p {
+  max-width: 32em;
+  margin: var(--size-4-1) 0 0;
+  color: var(--text-muted);
+  font-size: var(--font-ui-small);
+}
+
+.local-dictation-sidebar .setting-item,
+.local-dictation-sidebar .setting-item-info,
+.local-dictation-sidebar .setting-item-control {
+  min-width: 0;
+}
+
+.local-dictation-sidebar .setting-item-info,
+.local-dictation-sidebar__summary-text {
+  overflow-wrap: anywhere;
+}
+
+.local-dictation-sidebar .setting-item-control {
+  max-width: 100%;
+}
+
+.local-dictation-sidebar .setting-item-control select {
+  min-width: 0;
+  max-width: 100%;
+}
+
+/* When the sidebar is dragged narrow, stack setting rows vertically so labels
+   and controls don't get squeezed onto a single short line. */
 
 .local-dictation-sidebar--narrow .setting-item {
   flex-direction: column;
@@ -665,6 +788,10 @@
 .local-dictation-sidebar--narrow .setting-item-control input[type="number"] {
   width: 100%;
   min-width: 0;
+}
+
+.local-dictation-sidebar--narrow .local-dictation-preset-setting .setting-item-control > select {
+  flex-basis: 100%;
 }
 
 /* Truncate preset description to one line; full text in title attr on hover. */
@@ -699,6 +826,24 @@
   display: flex;
   align-items: center;
   gap: var(--size-4-2);
+}
+
+.local-dictation-advanced__summary {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 1px;
+}
+
+.local-dictation-advanced__title {
+  color: var(--text-muted);
+  font-size: var(--font-ui-small);
+}
+
+.local-dictation-advanced__description {
+  color: var(--text-faint);
+  font-size: var(--font-ui-smaller);
+  font-weight: 400;
 }
 
 .local-dictation-advanced > summary::-webkit-details-marker {

--- a/test/llm-sidebar-presentation.test.ts
+++ b/test/llm-sidebar-presentation.test.ts
@@ -29,7 +29,7 @@ describe('LLM sidebar presentation', () => {
       emptyState: { title: 'Raw transcript mode' },
       state: 'off',
       statusLabel: 'Off',
-      summary: 'Raw Whisper transcript',
+      summary: 'Raw transcript',
     });
   });
 

--- a/test/llm-sidebar-presentation.test.ts
+++ b/test/llm-sidebar-presentation.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_PLUGIN_SETTINGS } from '../src/settings/plugin-settings';
+import { resolveLlmSidebarPresentation } from '../src/ui/llm-sidebar-presentation';
+import { createUserPreset } from './fixtures/llm';
+
+describe('LLM sidebar presentation', () => {
+  it('explains the unavailable state instead of leaving a detached view blank', () => {
+    const presentation = resolveLlmSidebarPresentation({
+      ...DEFAULT_PLUGIN_SETTINGS,
+      llmFeaturesEnabled: false,
+    });
+
+    expect(presentation).toMatchObject({
+      emptyState: { title: 'LLM features are unavailable' },
+      state: 'unavailable',
+      statusLabel: 'Unavailable',
+    });
+  });
+
+  it('identifies raw transcript behavior when transformation is off', () => {
+    const presentation = resolveLlmSidebarPresentation({
+      ...DEFAULT_PLUGIN_SETTINGS,
+      llmFeaturesEnabled: true,
+      llmPostprocessMode: 'off',
+    });
+
+    expect(presentation).toMatchObject({
+      emptyState: { title: 'Raw transcript mode' },
+      state: 'off',
+      statusLabel: 'Off',
+      summary: 'Raw Whisper transcript',
+    });
+  });
+
+  it('summarizes the active preset with the selected transform timing', () => {
+    const preset = createUserPreset({ label: 'Concise meeting notes' });
+    const presentation = resolveLlmSidebarPresentation({
+      ...DEFAULT_PLUGIN_SETTINGS,
+      llmFeaturesEnabled: true,
+      llmPostprocessActivePresetRef: `user:${preset.id}`,
+      llmPostprocessMode: 'per_utterance',
+      llmPostprocessUserPresets: [preset],
+    });
+
+    expect(presentation).toEqual({
+      emptyState: null,
+      state: 'active',
+      statusLabel: 'On',
+      summary: 'Concise meeting notes · Runs after each phrase',
+    });
+  });
+
+  it('reports preset-pinned timing instead of the stored global mode', () => {
+    const preset = createUserPreset({ label: 'Session summary', timing: 'batch' });
+    const presentation = resolveLlmSidebarPresentation({
+      ...DEFAULT_PLUGIN_SETTINGS,
+      llmFeaturesEnabled: true,
+      llmPostprocessActivePresetRef: `user:${preset.id}`,
+      llmPostprocessMode: 'per_utterance',
+      llmPostprocessUserPresets: [preset],
+    });
+
+    expect(presentation.summary).toBe('Session summary · Runs once on stop');
+  });
+});


### PR DESCRIPTION
## Summary

- Give the Local Dictation sidebar a stable transcript-workflow header with an at-a-glance transform status, active preset, and effective timing.
- Reorganize the main path into **Transform**, **Preset**, **Provider**, and **Context**, while keeping limits, generation, and diagnostics behind the existing advanced disclosure.
- Replace the icon-only preset manager control with a labeled **Manage presets** action that continues to open the existing modal.
- Add explicit raw-transcript and unavailable states instead of leaving the surface sparse or blank.
- Harden narrow layouts and long user-authored preset content against horizontal overflow while retaining hover access to truncated descriptions and selections.

Relates to #247.

## Design decisions

- **Outcome first:** the header answers whether transformation is active and what will run before exposing configuration rows.
- **One level of primary controls:** frequently changed transform, preset, provider, and context choices remain visible; low-frequency limits and diagnostics stay collapsed.
- **Modal philosophy preserved:** preset creation/editing remains in the existing management modal. The sidebar only makes that action discoverable.
- **State derived once:** a pure presentation model resolves unavailable, raw, and active states, including preset-pinned timing, so the summary cannot drift from runtime settings.
- **Responsive by construction:** setting labels and controls can shrink, long text can wrap, selects are bounded, and the preset control gets a full-width select at the existing narrow breakpoint.

## User impact

Users can scan the sidebar to understand the current transcript behavior, find preset management without learning an unlabeled icon, and resize the Obsidian side pane without losing controls to overflow. Turning transformation off now produces a deliberate raw-transcript state rather than a mostly empty settings card.

## Media import scope

This PR deliberately does **not** add audio/video upload, drag-and-drop, YouTube transcription, source placeholders, or source-specific settings. Those features need their own interaction and lifecycle decisions (target note, progress, cancellation, validation, failure recovery, and privacy messaging). Bundling them here would mix a navigation/information-hierarchy change with a new transcription workflow and make both harder to review. The clearer transcript-workflow shell is intended to give future source actions a coherent surface without prematurely specifying those behaviors.

## Verification

- `npm run check:frontend`
  - TypeScript typecheck
  - Biome
  - Obsidian ESLint
  - 63 Vitest files / 772 tests
  - production frontend build
- Focused sidebar/status/routing suite: 19 tests passed.
- `git diff --check`

## Manual gap

Interactive visual inspection inside Obsidian was not available in this non-interactive environment. Styling uses existing Obsidian setting groups, theme variables, and the sidebar's established resize breakpoint.
