### PR TITLE
Improve timestamp settings UX and capability guidance

### DIFF
--- a/src/settings/plugin-settings.ts
+++ b/src/settings/plugin-settings.ts
@@ -51,6 +51,31 @@ export const DEFAULT_TIMESTAMP_SPARSE_INTERVAL_MS = 30_000;
 export const MIN_TIMESTAMP_SPARSE_INTERVAL_MS = 10_000;
 export const MAX_TIMESTAMP_SPARSE_INTERVAL_MS = 600_000;
 
+export type TimestampIntervalValidation =
+  | { milliseconds: number; valid: true }
+  | { message: string; valid: false };
+
+export function validateTimestampIntervalSeconds(value: string): TimestampIntervalValidation {
+  const trimmed = value.trim();
+  const seconds = Number(trimmed);
+  const minSeconds = MIN_TIMESTAMP_SPARSE_INTERVAL_MS / 1000;
+  const maxSeconds = MAX_TIMESTAMP_SPARSE_INTERVAL_MS / 1000;
+
+  if (
+    !/^\d+$/u.test(trimmed) ||
+    !Number.isInteger(seconds) ||
+    seconds < minSeconds ||
+    seconds > maxSeconds
+  ) {
+    return {
+      message: `Enter a whole number from ${minSeconds} to ${maxSeconds} seconds.`,
+      valid: false,
+    };
+  }
+
+  return { milliseconds: seconds * 1000, valid: true };
+}
+
 export const DEFAULT_SMART_PARAGRAPH_PAUSE_MS = 3_000;
 export const MIN_SMART_PARAGRAPH_PAUSE_MS = 500;
 export const MAX_SMART_PARAGRAPH_PAUSE_MS = 30_000;

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -26,14 +26,8 @@ import {
   isListeningMode,
   isRemoteLlmEffectivelyEnabled,
   isSpeakingStyle,
-  isTimestampClock,
-  isTimestampDensity,
   isTranscriptFormattingMode,
-  MAX_TIMESTAMP_SPARSE_INTERVAL_MS,
-  MIN_TIMESTAMP_SPARSE_INTERVAL_MS,
   type PluginSettings,
-  type TimestampClock,
-  type TimestampDensity,
   type TranscriptFormattingMode,
 } from './plugin-settings';
 import {
@@ -51,6 +45,7 @@ import {
 } from './sidecar-settings-section';
 import { SmartParagraphSettingsModal } from './smart-paragraph-settings-modal';
 import { isSystemAudioSupportedOnCurrentPlatform } from './system-audio-support';
+import { TimestampSettingsModal } from './timestamp-settings-modal';
 
 interface SettingsTabDependencies {
   feedback: Pick<UserFeedback, 'show'>;
@@ -89,16 +84,6 @@ const SPEAKING_STYLE_OPTIONS: ReadonlyArray<DropdownOption<SpeakingStyle>> = [
   { label: 'Responsive', value: 'responsive' },
   { label: 'Balanced', value: 'balanced' },
   { label: 'Patient', value: 'patient' },
-];
-
-const TIMESTAMP_CLOCK_OPTIONS: ReadonlyArray<DropdownOption<TimestampClock>> = [
-  { label: 'Elapsed', value: 'elapsed' },
-  { label: 'Wall clock', value: 'wallclock' },
-];
-
-const TIMESTAMP_DENSITY_OPTIONS: ReadonlyArray<DropdownOption<TimestampDensity>> = [
-  { label: 'Sparse', value: 'sparse' },
-  { label: 'Every phrase', value: 'every_utterance' },
 ];
 
 export class LocalSttSettingTab extends PluginSettingTab {
@@ -407,59 +392,34 @@ export class LocalSttSettingTab extends PluginSettingTab {
   }
 
   private renderTimestampSettings(parent: HTMLElement, settings: PluginSettings): void {
-    new Setting(parent)
+    const setting = new Setting(parent)
       .setName('Use timestamps')
-      .setDesc('Stamp each phrase with the time it was spoken.')
+      .setDesc(
+        'Add timestamps at voice-detected phrase boundaries. Works with every model; word-level timing is not available yet.',
+      )
       .addToggle((toggle) => {
         toggle.setValue(settings.timestampsEnabled);
         toggle.onChange(async (value) => {
           await this.access.persistOne('timestampsEnabled', value);
-          this.display();
         });
       });
 
-    if (!settings.timestampsEnabled) return;
-
-    addToggleSetting(parent, this.access, {
-      name: 'Session header',
-      desc: 'Insert [YYYY-MM-DD HH:MM] at the top of the session.',
-      key: 'timestampSessionHeader',
-    });
-
-    addEnumSetting(parent, this.access, {
-      name: 'Reference clock',
-      desc: 'Elapsed time, or wall-clock time.',
-      key: 'timestampClock',
-      options: TIMESTAMP_CLOCK_OPTIONS,
-      isValid: isTimestampClock,
-    });
-
-    addEnumSetting(parent, this.access, {
-      name: 'Density',
-      desc: 'Stamp every phrase, or at fixed intervals.',
-      key: 'timestampDensity',
-      options: TIMESTAMP_DENSITY_OPTIONS,
-      isValid: isTimestampDensity,
-    });
-
-    const minSeconds = MIN_TIMESTAMP_SPARSE_INTERVAL_MS / 1000;
-    const maxSeconds = MAX_TIMESTAMP_SPARSE_INTERVAL_MS / 1000;
-    new Setting(parent)
-      .setName('Sparse interval')
-      .setDesc(`Seconds between landmarks (${minSeconds}-${maxSeconds}).`)
-      .addText((text) => {
-        text.inputEl.type = 'number';
-        text.inputEl.min = String(minSeconds);
-        text.inputEl.max = String(maxSeconds);
-        text.inputEl.step = '1';
-        text.setValue(String(Math.round(settings.timestampSparseIntervalMs / 1000)));
-        text.onChange(async (value) => {
-          const parsed = Number.parseInt(value, 10);
-          if (!Number.isInteger(parsed)) return;
-          const clamped = Math.min(maxSeconds, Math.max(minSeconds, parsed));
-          await this.access.persistOne('timestampSparseIntervalMs', clamped * 1000);
+    setting.addExtraButton((button) => {
+      button
+        .setIcon('sliders-horizontal')
+        .setTooltip('Timestamp settings')
+        .onClick(() => {
+          new TimestampSettingsModal(this.app, {
+            getSettings: () => this.dependencies.getSettings(),
+            onSave: () => {
+              this.display();
+            },
+            saveSettings: async (nextSettings) => {
+              await this.dependencies.saveSettings(nextSettings);
+            },
+          }).open();
         });
-      });
+    });
   }
 
   private buildModelInfoCallback(

--- a/src/settings/timestamp-settings-modal.ts
+++ b/src/settings/timestamp-settings-modal.ts
@@ -1,0 +1,208 @@
+import type { App, ButtonComponent, TextComponent } from 'obsidian';
+import { Modal, Setting } from 'obsidian';
+
+import {
+  DEFAULT_PLUGIN_SETTINGS,
+  isTimestampClock,
+  isTimestampDensity,
+  MAX_TIMESTAMP_SPARSE_INTERVAL_MS,
+  MIN_TIMESTAMP_SPARSE_INTERVAL_MS,
+  type PluginSettings,
+  type TimestampClock,
+  type TimestampDensity,
+  validateTimestampIntervalSeconds,
+} from './plugin-settings';
+import type { DropdownOption } from './setting-helpers';
+
+interface TimestampSettingsModalDependencies {
+  getSettings: () => PluginSettings;
+  onSave?: () => void;
+  saveSettings: (settings: PluginSettings) => Promise<void>;
+}
+
+interface TimestampSettingsDraft {
+  clock: TimestampClock;
+  density: TimestampDensity;
+  sessionHeader: boolean;
+  sparseIntervalSeconds: string;
+}
+
+const TIMESTAMP_CLOCK_OPTIONS: ReadonlyArray<DropdownOption<TimestampClock>> = [
+  { label: 'Elapsed', value: 'elapsed' },
+  { label: 'Wall clock', value: 'wallclock' },
+];
+
+const TIMESTAMP_DENSITY_OPTIONS: ReadonlyArray<DropdownOption<TimestampDensity>> = [
+  { label: 'At intervals', value: 'sparse' },
+  { label: 'Every phrase', value: 'every_utterance' },
+];
+
+const MIN_INTERVAL_SECONDS = MIN_TIMESTAMP_SPARSE_INTERVAL_MS / 1000;
+const MAX_INTERVAL_SECONDS = MAX_TIMESTAMP_SPARSE_INTERVAL_MS / 1000;
+const INTERVAL_DESCRIPTION = `Seconds between timestamp landmarks (${MIN_INTERVAL_SECONDS}-${MAX_INTERVAL_SECONDS}).`;
+
+export class TimestampSettingsModal extends Modal {
+  private draft: TimestampSettingsDraft;
+  private intervalInput: TextComponent | null = null;
+  private intervalSetting: Setting | null = null;
+  private saveButton: ButtonComponent | null = null;
+
+  constructor(
+    app: App,
+    private readonly deps: TimestampSettingsModalDependencies,
+  ) {
+    super(app);
+    this.draft = draftFromSettings(deps.getSettings());
+  }
+
+  override onOpen(): void {
+    this.titleEl.setText('Timestamp settings');
+    this.render();
+  }
+
+  override onClose(): void {
+    this.contentEl.empty();
+    this.intervalInput = null;
+    this.intervalSetting = null;
+    this.saveButton = null;
+  }
+
+  private render(): void {
+    this.contentEl.empty();
+    this.intervalInput = null;
+    this.intervalSetting = null;
+    this.saveButton = null;
+
+    this.contentEl.createEl('p', {
+      cls: 'setting-item-description',
+      text: 'Timestamps use phrase start times from voice activity detection, not model-provided word timing. This makes them available with every transcription model.',
+    });
+
+    new Setting(this.contentEl)
+      .setName('Session header')
+      .setDesc('Start each timestamped session with [YYYY-MM-DD HH:MM].')
+      .addToggle((toggle) => {
+        toggle.setValue(this.draft.sessionHeader);
+        toggle.onChange((value) => {
+          this.draft = { ...this.draft, sessionHeader: value };
+        });
+      });
+
+    new Setting(this.contentEl)
+      .setName('Reference clock')
+      .setDesc('Elapsed time since dictation started, or local wall-clock time.')
+      .addDropdown((dropdown) => {
+        for (const option of TIMESTAMP_CLOCK_OPTIONS) {
+          dropdown.addOption(option.value, option.label);
+        }
+        dropdown.setValue(this.draft.clock);
+        dropdown.onChange((value) => {
+          if (!isTimestampClock(value)) return;
+          this.draft = { ...this.draft, clock: value };
+        });
+      });
+
+    new Setting(this.contentEl)
+      .setName('Frequency')
+      .setDesc('Add a timestamp at intervals, or at every voice-detected phrase boundary.')
+      .addDropdown((dropdown) => {
+        for (const option of TIMESTAMP_DENSITY_OPTIONS) {
+          dropdown.addOption(option.value, option.label);
+        }
+        dropdown.setValue(this.draft.density);
+        dropdown.onChange((value) => {
+          if (!isTimestampDensity(value)) return;
+          this.draft = { ...this.draft, density: value };
+          this.refreshIntervalState();
+        });
+      });
+
+    this.intervalSetting = new Setting(this.contentEl)
+      .setName('Interval')
+      .setDesc(INTERVAL_DESCRIPTION)
+      .addText((text) => {
+        this.intervalInput = text;
+        text.inputEl.type = 'number';
+        text.inputEl.min = String(MIN_INTERVAL_SECONDS);
+        text.inputEl.max = String(MAX_INTERVAL_SECONDS);
+        text.inputEl.step = '1';
+        text.setValue(this.draft.sparseIntervalSeconds);
+        text.onChange((value) => {
+          this.draft = { ...this.draft, sparseIntervalSeconds: value };
+          this.refreshIntervalState();
+        });
+      });
+
+    new Setting(this.contentEl)
+      .addButton((button) => {
+        button.setButtonText('Reset').onClick(() => {
+          this.draft = draftFromSettings(DEFAULT_PLUGIN_SETTINGS);
+          this.render();
+        });
+      })
+      .addButton((button) => {
+        button.setButtonText('Cancel').onClick(() => {
+          this.close();
+        });
+      })
+      .addButton((button) => {
+        this.saveButton = button;
+        button
+          .setCta()
+          .setButtonText('Save')
+          .onClick(() => {
+            void this.handleSave();
+          });
+      });
+
+    this.refreshIntervalState();
+  }
+
+  private refreshIntervalState(): void {
+    const intervalIsActive = this.draft.density === 'sparse';
+    const validation = validateTimestampIntervalSeconds(this.draft.sparseIntervalSeconds);
+
+    this.intervalInput?.setDisabled(!intervalIsActive);
+    this.intervalInput?.inputEl.setCustomValidity(
+      intervalIsActive && !validation.valid ? validation.message : '',
+    );
+    this.intervalSetting?.setDesc(
+      intervalIsActive && !validation.valid
+        ? validation.message
+        : intervalIsActive
+          ? INTERVAL_DESCRIPTION
+          : 'Used only when frequency is set to At intervals.',
+    );
+    this.saveButton?.setDisabled(intervalIsActive && !validation.valid);
+  }
+
+  private async handleSave(): Promise<void> {
+    const currentSettings = this.deps.getSettings();
+    const interval = validateTimestampIntervalSeconds(this.draft.sparseIntervalSeconds);
+    if (this.draft.density === 'sparse' && !interval.valid) {
+      this.refreshIntervalState();
+      return;
+    }
+
+    await this.deps.saveSettings({
+      ...currentSettings,
+      timestampClock: this.draft.clock,
+      timestampDensity: this.draft.density,
+      timestampSessionHeader: this.draft.sessionHeader,
+      timestampSparseIntervalMs: interval.valid
+        ? interval.milliseconds
+        : currentSettings.timestampSparseIntervalMs,
+    });
+    this.deps.onSave?.();
+    this.close();
+  }
+}
+
+function draftFromSettings(settings: PluginSettings): TimestampSettingsDraft {
+  return {
+    clock: settings.timestampClock,
+    density: settings.timestampDensity,
+    sessionHeader: settings.timestampSessionHeader,
+    sparseIntervalSeconds: String(Math.round(settings.timestampSparseIntervalMs / 1000)),
+  };
+}

--- a/test/plugin-settings.test.ts
+++ b/test/plugin-settings.test.ts
@@ -17,6 +17,7 @@ import {
   resetLlmPostprocessDefaults,
   resolvePluginSettings,
   shouldRefreshLlmSidebar,
+  validateTimestampIntervalSeconds,
 } from '../src/settings/plugin-settings';
 
 function makeUserPreset(overrides: Partial<LlmPreset> & { id: string }): LlmPreset {
@@ -333,6 +334,30 @@ describe('resolvePluginSettings', () => {
     expect(
       resolvePluginSettings({ timestampSparseIntervalMs: 999_999 }).timestampSparseIntervalMs,
     ).toBe(600_000);
+  });
+
+  it.each([
+    ['10', 10_000],
+    [' 30 ', 30_000],
+    ['600', 600_000],
+  ])('validates a whole-number timestamp interval of %s seconds', (value, milliseconds) => {
+    expect(validateTimestampIntervalSeconds(value)).toEqual({ milliseconds, valid: true });
+  });
+
+  it.each([
+    '',
+    'ten',
+    'NaN',
+    '9',
+    '10.5',
+    '601',
+    '1e2',
+    '0x10',
+  ])('rejects timestamp interval %j', (value) => {
+    expect(validateTimestampIntervalSeconds(value)).toEqual({
+      message: 'Enter a whole number from 10 to 600 seconds.',
+      valid: false,
+    });
   });
 
   it('defaults smart paragraph thresholds to the legacy meaningful pause threshold', () => {


### PR DESCRIPTION
## Summary

- Moves timestamp configuration behind the same sliders-modal pattern used by smart paragraphs, leaving one clear enable toggle in the main settings tab.
- Describes the current capability accurately: timestamps come from VAD phrase boundaries and work with every model; Local Dictation does not yet consume model-provided word timing.
- Makes interval entry explicit and safe by rejecting invalid, fractional, scientific-notation, or out-of-range values before save.

Relates to #241. This intentionally addresses the settings UX portion without claiming to complete word-level engine timestamp support.

## Key changes

- **Plugin settings UI:** adds a dedicated `TimestampSettingsModal` for the session header, reference clock, frequency, and interval controls.
- **User impact:** advanced choices can be reviewed and saved together; Cancel discards the draft, Reset restores current defaults, and the interval control is disabled when `Every phrase` makes it irrelevant.
- **Validation:** accepts whole-second intervals from 10 through 600, shows the validation requirement inline, uses native input validity, and disables Save while an active interval is invalid.
- **Compatibility:** preserves all existing settings keys, defaults, timestamp formats, density semantics, renderer behavior, and native protocol behavior. There is no settings-schema migration.

## Scope and tradeoffs

This PR keeps the universally available VAD timestamp path as the only rendered timestamp source. It does not expose an engine-specific control before the transcription pipeline can honor one, which avoids presenting Whisper-only capability as if it worked across the current model catalog.

The modal is reachable while timestamps are disabled so users can configure output before enabling it. The main toggle no longer rebuilds the full settings tab because there are no conditionally rendered inline rows after this change.

PR #233 also edits `src/settings/settings-tab.ts` to add personal-correction controls. The changes are functionally independent, although Git may require a small import/layout conflict resolution if both branches land concurrently.

## What remains for word-level timestamps

True word-level support still requires engine adapters to produce word timing where available, the sidecar/plugin boundary to carry that timing without implying support for engines that lack it, and renderer policy for selecting or falling back from word timing. Whisper capability should be enabled only after that end-to-end path is implemented and tested; Cohere Transcribe and Moonshine need explicit capability/fallback behavior rather than inferred support.

## Test plan

- [x] `npm run check` (release metadata, TypeScript typecheck, Biome, Obsidian ESLint, 779 Vitest tests, frontend build, sidecar build/output verification, Rust fmt/clippy/tests)
- [x] `npm test -- --run test/plugin-settings.test.ts` (84 settings tests, including interval boundary and malformed-input coverage)
- [ ] Manual Obsidian interaction (not available in this environment; production bundle compilation verifies the modal wiring)

Known pre-existing diagnostics: Biome reports the checked-in schema URL is for 2.5.0 while the lockfile uses 2.5.2, and Obsidian ESLint warns that the existing settings tab has not adopted the future declarative search API. Both checks complete successfully and neither diagnostic is introduced here.
