### PR TITLE
Improve external model selection guidance and validation

### DIFF
--- a/native/catalog.json
+++ b/native/catalog.json
@@ -17,7 +17,7 @@
       "familyId": "whisper",
       "runtimeId": "whisper_cpp",
       "displayName": "Whisper",
-      "summary": "OpenAI Whisper architecture loaded via whisper.cpp-compatible GGML model files."
+      "summary": "Batch transcription after each pause. Start with Small for everyday English dictation; Tiny and Base prioritize speed, while Medium and Large prioritize accuracy."
     },
     {
       "familyId": "cohere_transcribe",
@@ -29,7 +29,7 @@
       "familyId": "moonshine",
       "runtimeId": "onnx_runtime",
       "displayName": "Moonshine",
-      "summary": "Moonshine v2 streaming models for live dictation (English, MIT) running on ONNX Runtime."
+      "summary": "Live English transcription while you speak. Start with Small for the recommended balance; Tiny uses fewer resources, while Medium is the most accurate and uses more CPU time and memory."
     }
   ],
   "collections": [

--- a/native/src/adapters/moonshine.rs
+++ b/native/src/adapters/moonshine.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 use ndarray::{Array, Array1, Array2, Array3, IxDyn};
@@ -169,6 +170,14 @@ struct ModelPaths {
 
 fn resolve_model_paths(path: &Path) -> Result<ModelPaths, TranscriptionError> {
     validate_model_path(path)?;
+
+    if path.file_name() != Some(OsStr::new(FRONTEND_FILENAME)) {
+        return Err(TranscriptionError::invalid_model_with_details(format!(
+            "Moonshine external models must be selected via {FRONTEND_FILENAME}; received {}",
+            path.display()
+        )));
+    }
+
     let model_dir = path.parent().ok_or_else(|| {
         TranscriptionError::invalid_model_with_details(
             "cannot determine model directory from artifact path".to_string(),
@@ -1134,6 +1143,25 @@ mod tests {
         let error = MoonshineAdapter.probe_model(&frontend).unwrap_err();
         assert_eq!(error.code, "invalid_model_file");
         assert!(error.details.unwrap_or_default().contains(ENCODER_FILENAME));
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn probe_requires_frontend_as_the_selected_artifact() {
+        let root = temp_dir("wrong-primary-artifact");
+        fs::create_dir_all(&root).unwrap();
+        let encoder = root.join(ENCODER_FILENAME);
+        fs::write(&encoder, b"not a graph").unwrap();
+
+        let error = MoonshineAdapter.probe_model(&encoder).unwrap_err();
+        assert_eq!(error.code, "invalid_model_file");
+        assert!(
+            error
+                .details
+                .unwrap_or_default()
+                .contains(FRONTEND_FILENAME)
+        );
 
         fs::remove_dir_all(root).unwrap();
     }

--- a/src/models/external-model-file.ts
+++ b/src/models/external-model-file.ts
@@ -1,0 +1,72 @@
+import { basename } from 'node:path';
+
+import { assertAbsoluteExistingFilePath } from '../filesystem/path-validation';
+import type { ExternalFileModelSelection } from './model-management-types';
+
+export interface ExternalFileEngineOption {
+  label: string;
+  placeholder: string;
+  requirements: string[];
+  selection: Pick<ExternalFileModelSelection, 'familyId' | 'runtimeId'>;
+}
+
+export const EXTERNAL_FILE_ENGINES: readonly ExternalFileEngineOption[] = [
+  {
+    label: 'Moonshine (ONNX Runtime)',
+    placeholder: '/absolute/path/to/moonshine/frontend.ort',
+    requirements: [
+      'Select frontend.ort from a Moonshine v2 streaming ORT model directory.',
+      'The same directory must contain encoder.ort, adapter.ort, cross_kv.ort, decoder_kv.ort, streaming_config.json, and tokenizer.bin.',
+      'Non-streaming Moonshine ONNX exports are not compatible.',
+    ],
+    selection: { familyId: 'moonshine', runtimeId: 'onnx_runtime' },
+  },
+  {
+    label: 'Whisper (whisper.cpp)',
+    placeholder: '/absolute/path/to/ggml-small.en-q5_1.bin',
+    requirements: [
+      'Select one whisper.cpp-compatible GGML or GGUF model file.',
+      'The loader validates the file contents; a filename extension alone does not establish compatibility.',
+      'Local Dictation currently runs Whisper models in English.',
+    ],
+    selection: { familyId: 'whisper', runtimeId: 'whisper_cpp' },
+  },
+];
+
+export function getExternalFileEngineOption(
+  selection: Pick<ExternalFileModelSelection, 'familyId' | 'runtimeId'>,
+): ExternalFileEngineOption | null {
+  return (
+    EXTERNAL_FILE_ENGINES.find(
+      (candidate) =>
+        candidate.selection.runtimeId === selection.runtimeId &&
+        candidate.selection.familyId === selection.familyId,
+    ) ?? null
+  );
+}
+
+export async function validateExternalModelFilePath(
+  filePath: string,
+  engine: Pick<ExternalFileModelSelection, 'familyId' | 'runtimeId'>,
+): Promise<string> {
+  const normalizedPath = await assertAbsoluteExistingFilePath(filePath, 'Model file path');
+
+  if (engine.familyId === 'moonshine' && basename(normalizedPath) !== 'frontend.ort') {
+    throw new Error(
+      'Moonshine requires its primary frontend.ort artifact. Select frontend.ort from the streaming model directory.',
+    );
+  }
+
+  return normalizedPath;
+}
+
+export function formatExternalModelValidationError(error: unknown): string {
+  if (error instanceof Error) {
+    const message = error.message.trim();
+    if (message.length > 0) {
+      return message;
+    }
+  }
+
+  return 'The speech engine could not validate this model.';
+}

--- a/src/models/manage-models-modal.ts
+++ b/src/models/manage-models-modal.ts
@@ -4,6 +4,7 @@ import { Modal, Setting, setIcon } from 'obsidian';
 import { formatBytes } from '../shared/format-utils';
 import type { UserFeedback } from '../shared/user-feedback';
 import { resolveEngineCapabilities } from './capability-view';
+import { formatModelTagLabel } from './model-guidance';
 import { isCancellingPhase, type ModelInstallManager } from './model-install-manager';
 import {
   createInstallProgressElement,
@@ -515,7 +516,7 @@ export class ManageModelsModal extends Modal {
     for (const tag of model.uxTags) {
       tagsContainer.createSpan({
         cls: 'local-stt-tag',
-        text: tag,
+        text: formatModelTagLabel(tag),
       });
     }
 

--- a/src/models/model-guidance.ts
+++ b/src/models/model-guidance.ts
@@ -1,0 +1,15 @@
+const MODEL_TAG_LABELS: Readonly<Record<string, string>> = {
+  cpu: 'CPU',
+  gpu: 'GPU',
+  starter: 'Recommended',
+};
+
+export function formatModelTagLabel(tag: string): string {
+  const knownLabel = MODEL_TAG_LABELS[tag];
+  if (knownLabel !== undefined) {
+    return knownLabel;
+  }
+
+  const firstCharacter = tag.at(0);
+  return firstCharacter === undefined ? tag : `${firstCharacter.toUpperCase()}${tag.slice(1)}`;
+}

--- a/src/models/model-install-manager.ts
+++ b/src/models/model-install-manager.ts
@@ -9,6 +9,7 @@ import type {
   SystemInfoEvent,
 } from '../sidecar/protocol';
 import type { SidecarConnection } from '../sidecar/sidecar-connection';
+import { validateExternalModelFilePath } from './external-model-file';
 import {
   type CatalogModelSelection,
   type ExternalFileModelSelection,
@@ -458,9 +459,10 @@ export class ModelInstallManager {
       runtimeId: 'whisper_cpp',
     },
   ): Promise<ModelProbeResultEvent> {
+    const validatedPath = await validateExternalModelFilePath(filePath, engine);
     const selection: SelectedModel = {
       familyId: engine.familyId,
-      filePath: filePath.trim(),
+      filePath: validatedPath,
       kind: 'external_file',
       runtimeId: engine.runtimeId,
     };

--- a/src/models/model-management-modals.ts
+++ b/src/models/model-management-modals.ts
@@ -4,6 +4,11 @@ import { Modal, Setting } from 'obsidian';
 import { formatBytes } from '../shared/format-utils';
 import type { UserFeedback } from '../shared/user-feedback';
 import { buildCapabilityLabels } from './capability-view';
+import {
+  EXTERNAL_FILE_ENGINES,
+  formatExternalModelValidationError,
+  getExternalFileEngineOption,
+} from './external-model-file';
 import type { ModelInstallManager } from './model-install-manager';
 import {
   type CatalogModelRecord,
@@ -18,22 +23,10 @@ interface ExternalModelFileModalDependencies {
   onChanged: () => Promise<void>;
 }
 
-const EXTERNAL_FILE_ENGINES: Array<{
-  label: string;
-  selection: Pick<ExternalFileModelSelection, 'familyId' | 'runtimeId'>;
-}> = [
-  {
-    label: 'Moonshine (ONNX Runtime)',
-    selection: { familyId: 'moonshine', runtimeId: 'onnx_runtime' },
-  },
-  {
-    label: 'Whisper (whisper.cpp)',
-    selection: { familyId: 'whisper', runtimeId: 'whisper_cpp' },
-  },
-];
-
 export class ExternalModelFileModal extends Modal {
   private engine: Pick<ExternalFileModelSelection, 'familyId' | 'runtimeId'>;
+  private errorEl: HTMLParagraphElement | null = null;
+  private guidanceEl: HTMLDivElement | null = null;
   private inputEl: HTMLInputElement | null = null;
 
   constructor(
@@ -49,12 +42,14 @@ export class ExternalModelFileModal extends Modal {
     this.titleEl.setText('Use external file');
     this.contentEl.empty();
     this.contentEl.createEl('p', {
-      text: 'Validate an absolute model file path. External files bypass managed downloads and managed updates.',
+      text: 'External models are for advanced use. Local Dictation does not download, update, or checksum-verify these files.',
     });
 
     new Setting(this.contentEl)
       .setName('Model family')
-      .setDesc('Choose the runtime and graph format for the external model.')
+      .setDesc(
+        'Choose the loader that matches the model. The family is not inferred from its filename.',
+      )
       .addDropdown((dropdown) => {
         for (const option of EXTERNAL_FILE_ENGINES) {
           dropdown.addOption(engineKey(option.selection), option.label);
@@ -66,26 +61,51 @@ export class ExternalModelFileModal extends Modal {
           );
           if (option !== undefined) {
             this.engine = option.selection;
+            this.renderGuidance();
+            this.inputEl?.setAttr('placeholder', option.placeholder);
+            this.setValidationError(null);
           }
         });
       });
 
+    this.guidanceEl = this.contentEl.createDiv({ cls: 'local-stt-external-model-guidance' });
+    this.renderGuidance();
+
     new Setting(this.contentEl)
       .setName('Model file path')
-      .setDesc('Enter the absolute path to the primary model artifact.')
+      .setDesc(
+        'Enter the absolute path to the primary model artifact. It is validated before this selection is saved.',
+      )
       .addText((text) => {
-        text.setPlaceholder('/absolute/path/to/ggml-small.en-q5_1.bin');
+        const option = getExternalFileEngineOption(this.engine);
+        text.setPlaceholder(option?.placeholder ?? '/absolute/path/to/model');
         text.setValue(this.currentPath);
         this.inputEl = text.inputEl;
+        this.inputEl.addEventListener('input', () => {
+          this.setValidationError(null);
+        });
       });
 
     this.inputEl?.focus();
 
+    this.errorEl = this.contentEl.createEl('p', {
+      attr: { 'aria-live': 'polite' },
+      cls: 'local-stt-external-model-error local-stt-hidden',
+    });
+
+    let validating = false;
     new Setting(this.contentEl).addButton((button) => {
       button
         .setCta()
         .setButtonText('Validate and use')
         .onClick(async () => {
+          if (validating) {
+            return;
+          }
+
+          validating = true;
+          button.setDisabled(true).setButtonText('Validating…');
+          this.setValidationError(null);
           const nextPath = this.inputEl?.value.trim() ?? '';
 
           try {
@@ -97,25 +117,53 @@ export class ExternalModelFileModal extends Modal {
             });
             this.close();
           } catch (error) {
+            const message = formatExternalModelValidationError(error);
+            this.setValidationError(message);
             this.dependencies.feedback.show({
               cause: error,
               intent: 'error',
-              message:
-                'Could not validate the external model file. Check the file path and model family, then try again.',
+              message,
             });
+          } finally {
+            validating = false;
+            button.setDisabled(false).setButtonText('Validate and use');
           }
         });
     });
   }
 
+  private renderGuidance(): void {
+    if (this.guidanceEl === null) {
+      return;
+    }
+
+    this.guidanceEl.empty();
+    const option = getExternalFileEngineOption(this.engine);
+    if (option === null) {
+      return;
+    }
+
+    this.guidanceEl.createEl('strong', { text: 'File requirements' });
+    const requirements = this.guidanceEl.createEl('ul');
+    for (const requirement of option.requirements) {
+      requirements.createEl('li', { text: requirement });
+    }
+  }
+
+  private setValidationError(message: string | null): void {
+    if (this.errorEl === null) {
+      return;
+    }
+
+    this.errorEl.setText(message ?? '');
+    this.errorEl.toggleClass('local-stt-hidden', message === null);
+  }
+
   private initialEngine(): Pick<ExternalFileModelSelection, 'familyId' | 'runtimeId'> {
     const selected = this.dependencies.manager.getState().selectedModel;
     if (selected?.kind === 'external_file') {
-      const selectedKey = engineKey(selected);
-      const option = EXTERNAL_FILE_ENGINES.find(
-        (candidate) => engineKey(candidate.selection) === selectedKey,
-      );
-      if (option !== undefined) {
+      const option = getExternalFileEngineOption(selected);
+      if (option !== null) {
         return option.selection;
       }
     }

--- a/src/models/model-row-state.ts
+++ b/src/models/model-row-state.ts
@@ -183,6 +183,8 @@ export function deriveCurrentModelDisplay(state: ModelManagerState): CurrentMode
   }
 
   if (selectedModel.kind === 'external_file') {
+    const capabilities = state.selectedModelCapabilities;
+    const status = deriveExternalModelStatus(capabilities);
     return {
       displayName: basename(selectedModel.filePath),
       engineLabel: resolveFamilyDisplayName(
@@ -190,8 +192,8 @@ export function deriveCurrentModelDisplay(state: ModelManagerState): CurrentMode
         selectedModel.runtimeId,
         selectedModel.familyId,
       ),
-      detail: 'The selected external file has not been validated yet.',
-      installedLabel: 'External file',
+      detail: status.detail,
+      installedLabel: status.installedLabel,
       sourceLabel: 'External file',
       sizeBytes: null,
       installLocation: null,
@@ -234,6 +236,35 @@ export function deriveCurrentModelDisplay(state: ModelManagerState): CurrentMode
     installLocation: installedModel?.installPath ?? null,
     resolvedPath: installedModel?.runtimePath ?? null,
   };
+}
+
+function deriveExternalModelStatus(
+  capabilities: ModelManagerState['selectedModelCapabilities'],
+): Pick<CurrentModelDisplay, 'detail' | 'installedLabel'> {
+  switch (capabilities.status) {
+    case 'ready':
+      return {
+        detail: 'External model passed its most recent validation.',
+        installedLabel: 'External validated',
+      };
+    case 'pending':
+      return {
+        detail: 'Checking the external model file.',
+        installedLabel: 'Checking',
+      };
+    case 'unavailable':
+      return {
+        detail:
+          capabilities.details ??
+          'The external model is unavailable. Validate the file again to see details.',
+        installedLabel: 'Unavailable',
+      };
+    case 'none':
+      return {
+        detail: 'Validate the external model file before dictating.',
+        installedLabel: 'External file',
+      };
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/settings/model-settings-section.ts
+++ b/src/settings/model-settings-section.ts
@@ -15,8 +15,14 @@ function getBadgeInfo(installedLabel: string): { modifier: string; text: string 
       return { modifier: 'ready', text: 'Ready' };
     case 'Not installed':
       return { modifier: 'missing', text: 'Not installed' };
+    case 'External validated':
+      return { modifier: 'ready', text: 'Validated · external' };
     case 'External file':
-      return { modifier: 'external', text: 'Unverified' };
+      return { modifier: 'external', text: 'External' };
+    case 'Checking':
+      return { modifier: 'external', text: 'Checking…' };
+    case 'Unavailable':
+      return { modifier: 'missing', text: 'Unavailable' };
     default:
       return { modifier: 'none', text: 'No model' };
   }
@@ -71,6 +77,8 @@ export function renderModelSection(
       cls: `local-stt-badge local-stt-badge--${badge.modifier}`,
       text: badge.text,
     });
+    descFragment.createEl('br');
+    descFragment.createSpan({ text: currentModel.detail });
 
     const cardSetting = new Setting(container)
       .setName(currentModel.displayName)

--- a/styles.css
+++ b/styles.css
@@ -315,6 +315,28 @@
   width: min(600px, 90vw);
 }
 
+.local-stt-external-model-guidance {
+  margin: 12px 0;
+  padding: 10px 12px;
+  border: 1px solid var(--background-modifier-border, rgba(128, 128, 128, 0.18));
+  border-radius: var(--radius-s, 6px);
+  background: var(--background-secondary-alt, rgba(128, 128, 128, 0.06));
+  color: var(--text-muted);
+  font-size: var(--font-ui-small);
+}
+
+.local-stt-external-model-guidance ul {
+  margin: 6px 0 0;
+  padding-inline-start: 20px;
+}
+
+.local-stt-external-model-error {
+  margin: 8px 0 0;
+  color: var(--text-error);
+  font-size: var(--font-ui-small);
+  white-space: pre-wrap;
+}
+
 /* --- Ribbon icon animations --------------------------------------- */
 
 /* Opacity chase: one spoke bright at a time, cycling clockwise */

--- a/test/external-model-file.test.ts
+++ b/test/external-model-file.test.ts
@@ -1,0 +1,97 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  formatExternalModelValidationError,
+  getExternalFileEngineOption,
+  validateExternalModelFilePath,
+} from '../src/models/external-model-file';
+
+let modelDirectory: string;
+let frontendPath: string;
+let whisperPath: string;
+
+beforeAll(async () => {
+  modelDirectory = await mkdtemp(join(tmpdir(), 'external-model-file-test-'));
+  frontendPath = join(modelDirectory, 'frontend.ort');
+  whisperPath = join(modelDirectory, 'ggml-small.en-q5_1.bin');
+  await Promise.all([
+    writeFile(frontendPath, 'frontend fixture', 'utf8'),
+    writeFile(whisperPath, 'whisper fixture', 'utf8'),
+  ]);
+});
+
+afterAll(async () => {
+  await rm(modelDirectory, { force: true, recursive: true });
+});
+
+describe('validateExternalModelFilePath', () => {
+  it('returns a trimmed absolute path for an existing Whisper model file', async () => {
+    await expect(
+      validateExternalModelFilePath(`  ${whisperPath}  `, {
+        familyId: 'whisper',
+        runtimeId: 'whisper_cpp',
+      }),
+    ).resolves.toBe(whisperPath);
+  });
+
+  it('requires frontend.ort as the selected Moonshine artifact', async () => {
+    await expect(
+      validateExternalModelFilePath(whisperPath, {
+        familyId: 'moonshine',
+        runtimeId: 'onnx_runtime',
+      }),
+    ).rejects.toThrow(/requires its primary frontend\.ort artifact/);
+  });
+
+  it('accepts frontend.ort for authoritative sidecar layout validation', async () => {
+    await expect(
+      validateExternalModelFilePath(frontendPath, {
+        familyId: 'moonshine',
+        runtimeId: 'onnx_runtime',
+      }),
+    ).resolves.toBe(frontendPath);
+  });
+});
+
+describe('external model guidance', () => {
+  it('documents the exact Moonshine entry artifact and companion set', () => {
+    const option = getExternalFileEngineOption({
+      familyId: 'moonshine',
+      runtimeId: 'onnx_runtime',
+    });
+    const guidance = option?.requirements.join(' ') ?? '';
+
+    expect(guidance).toContain('frontend.ort');
+    expect(guidance).toContain('encoder.ort');
+    expect(guidance).toContain('adapter.ort');
+    expect(guidance).toContain('cross_kv.ort');
+    expect(guidance).toContain('decoder_kv.ort');
+    expect(guidance).toContain('streaming_config.json');
+    expect(guidance).toContain('tokenizer.bin');
+    expect(guidance).toContain('Non-streaming');
+  });
+
+  it('documents both formats declared by the Whisper runtime', () => {
+    const option = getExternalFileEngineOption({
+      familyId: 'whisper',
+      runtimeId: 'whisper_cpp',
+    });
+    const guidance = option?.requirements.join(' ') ?? '';
+
+    expect(guidance).toContain('GGML');
+    expect(guidance).toContain('GGUF');
+  });
+
+  it('preserves an actionable probe error for display', () => {
+    expect(formatExternalModelValidationError(new Error('required asset missing'))).toBe(
+      'required asset missing',
+    );
+    expect(formatExternalModelValidationError('not an Error')).toBe(
+      'The speech engine could not validate this model.',
+    );
+  });
+});

--- a/test/model-guidance.test.ts
+++ b/test/model-guidance.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatModelTagLabel } from '../src/models/model-guidance';
+
+describe('formatModelTagLabel', () => {
+  it('turns the catalog starter convention into an explicit recommendation', () => {
+    expect(formatModelTagLabel('starter')).toBe('Recommended');
+  });
+
+  it('formats hardware abbreviations and readable fallback labels', () => {
+    expect(formatModelTagLabel('cpu')).toBe('CPU');
+    expect(formatModelTagLabel('gpu')).toBe('GPU');
+    expect(formatModelTagLabel('balanced')).toBe('Balanced');
+  });
+});

--- a/test/model-install-manager.test.ts
+++ b/test/model-install-manager.test.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createInstallLifecycleLogMessage,
@@ -439,9 +443,12 @@ describe('ModelInstallManager', () => {
     });
 
     it('validates and selects Moonshine through the external-file path', async () => {
+      const modelDirectory = await mkdtemp(join(tmpdir(), 'manager-external-model-test-'));
+      const frontendPath = join(modelDirectory, 'frontend.ort');
+      await writeFile(frontendPath, 'fixture', 'utf8');
       const selection = {
         familyId: 'moonshine' as const,
-        filePath: '/models/moonshine/frontend.ort',
+        filePath: frontendPath,
         kind: 'external_file' as const,
         runtimeId: 'onnx_runtime' as const,
       };
@@ -465,12 +472,25 @@ describe('ModelInstallManager', () => {
         selection,
       });
 
-      await harness.manager.validateAndSelectExternalFile(selection.filePath, selection);
+      try {
+        await harness.manager.validateAndSelectExternalFile(selection.filePath, selection);
+      } finally {
+        await rm(modelDirectory, { force: true, recursive: true });
+      }
 
       expect(harness.sidecarConnection.probeModelSelection).toHaveBeenCalledWith(
         expect.objectContaining({ modelSelection: selection }),
       );
       expect(harness.getSettings().selectedModel).toEqual(selection);
+    });
+
+    it('rejects an invalid external path before contacting the sidecar', async () => {
+      await expect(
+        harness.manager.validateAndSelectExternalFile('relative/model.bin'),
+      ).rejects.toThrow('Model file path must be an absolute path.');
+
+      expect(harness.sidecarConnection.probeModelSelection).not.toHaveBeenCalled();
+      expect(harness.getSettings().selectedModel).toBeNull();
     });
 
     it('refuses to persist when the probe reports the model as unavailable', async () => {

--- a/test/model-row-state.test.ts
+++ b/test/model-row-state.test.ts
@@ -389,4 +389,58 @@ describe('deriveCurrentModelDisplay', () => {
       sourceLabel: 'External file',
     });
   });
+
+  it('reports a successfully probed external model as ready', () => {
+    const selection = {
+      familyId: 'whisper' as const,
+      filePath: '/tmp/models/custom-model.bin',
+      kind: 'external_file' as const,
+      runtimeId: 'whisper_cpp' as const,
+    };
+    const state = buildState({
+      selectedModel: selection,
+      selectedModelCapabilities: {
+        capabilities: {
+          family: compiledAdapter('whisper', 'whisper_cpp').familyCapabilities,
+          familyId: 'whisper',
+          runtime: {
+            acceleratorDetails: {},
+            availableAccelerators: ['cpu'],
+            supportedModelFormats: ['ggml', 'gguf'],
+          },
+          runtimeId: 'whisper_cpp',
+        },
+        selection,
+        status: 'ready',
+      },
+    });
+
+    expect(deriveCurrentModelDisplay(state)).toMatchObject({
+      detail: 'External model passed its most recent validation.',
+      installedLabel: 'External validated',
+    });
+  });
+
+  it('surfaces the external probe failure details in the current-model status', () => {
+    const selection = {
+      familyId: 'moonshine' as const,
+      filePath: '/models/moonshine/frontend.ort',
+      kind: 'external_file' as const,
+      runtimeId: 'onnx_runtime' as const,
+    };
+    const state = buildState({
+      selectedModel: selection,
+      selectedModelCapabilities: {
+        details: 'required Moonshine asset missing: encoder.ort',
+        reason: 'invalid',
+        selection,
+        status: 'unavailable',
+      },
+    });
+
+    expect(deriveCurrentModelDisplay(state)).toMatchObject({
+      detail: 'required Moonshine asset missing: encoder.ort',
+      installedLabel: 'Unavailable',
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Explain the exact external-model shapes Local Dictation currently exposes: a single whisper.cpp-compatible GGML/GGUF file, or the fixed seven-file Moonshine v2 streaming ORT layout selected through `frontend.ort`.
- Validate absolute/existing/regular file paths before a sidecar round trip, require `frontend.ort` consistently in both plugin and native Moonshine validation, and keep the sidecar probe authoritative for model contents and companion assets.
- Preserve actionable probe errors in the modal and current-model card, with explicit validating/validated/unavailable states instead of the generic failure notice and perpetual “Unverified” badge.
- Turn the catalog’s existing `starter` convention into a visible **Recommended** tag and make Whisper/Moonshine family summaries explain the evidence-backed speed/accuracy/resource trade-offs.

Closes #245.

## Root causes and decisions

1. The sidecar already returned useful errors such as a missing Moonshine sibling or an unsupported graph, but the modal logged the cause and showed users only “check the path and family.” The modal now keeps the exact message inline and in feedback.
2. Moonshine resolved every graph from the selected file’s parent directory and always loaded `frontend.ort`. Selecting `encoder.ort` could therefore appear valid while silently choosing a different artifact. Both layers now require the actual entry artifact.
3. External selections can only be persisted after a real sidecar probe, yet Settings always labeled them “Unverified.” The card now describes the most recent validation without claiming managed installation or checksum coverage.
4. This PR does not add speculative catalog entries or advertise internal Cohere path resolution as a supported custom-model workflow. The current external selector remains Whisper + Moonshine; additional exports need compatibility and quality evidence first.

## Supported external model shapes

- **Whisper:** one absolute path to a whisper.cpp-compatible GGML or GGUF file. Local Dictation currently runs the Whisper family in English. File contents, not the extension, determine compatibility.
- **Moonshine:** an absolute path ending in `frontend.ort`, beside `encoder.ort`, `adapter.ort`, `cross_kv.ort`, `decoder_kv.ort`, `streaming_config.json`, and `tokenizer.bin`. These are the Moonshine v2 streaming assets; non-streaming Moonshine ONNX exports do not match the adapter contract.
- External files are not downloaded, updated, or checksum-verified by Local Dictation. Validation loads/checks them locally before saving the selection.

## User impact

- Invalid text paths and directories fail immediately with specific guidance.
- Missing companion assets and incompatible models remain visible in the dialog instead of disappearing into logs.
- Model Manager now tells users to start with Moonshine Small for the recommended balance, use Tiny for constrained hardware, or choose Medium for the most accuracy at higher CPU/memory cost. Whisper guidance similarly distinguishes the everyday Small recommendation from speed- and accuracy-oriented tiers.

## Verification

- `npm run check:frontend` — TypeScript, Biome, Obsidian ESLint, 64 test files / 779 tests, and production frontend build passed. The repository’s existing settings-search warning remains informational.
- `npm run check:rust` — Rust formatting, all-target/all-engine clippy with warnings denied, unit and integration tests passed; real-model ignored tests remain opt-in.
- `npm test -- --run test/external-model-file.test.ts test/model-guidance.test.ts test/model-install-manager.test.ts test/model-row-state.test.ts` — 88 focused tests passed.
- `cargo test --manifest-path native/Cargo.toml --features engine-moonshine adapters::moonshine::tests::probe_` — both Moonshine external-path regression probes passed.

## Manual gap

- Interactive rendering and file entry in Obsidian were not exercised in this non-interactive environment.
