### PR TITLE
Let users cap automatic speaker labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ All transcription models in the current catalog run locally and support English.
 
 - **Live text.** Moonshine streaming models show provisional words and revise them in place until each utterance finalizes.
 - **Meeting capture.** Include system audio from meetings, calls, or videos alongside your microphone on Windows, Linux, and macOS 14.2 or later.
-- **Speaker labels.** Optional on-device diarization assigns session-stable speaker labels. Speaker embeddings stay in memory and are discarded after the session.
+- **Speaker labels.** Optional on-device diarization assigns session-stable speaker labels. Set an expected maximum when automatic detection creates extra labels. Speaker embeddings stay in memory and are discarded after the session.
 - **Timestamps.** Add elapsed or wall-clock timestamps at configurable intervals.
 - **Local model choices.** Choose Whisper, Cohere Transcribe, or Moonshine models and download them from Settings.
 - **Optional text transformation.** Clean up, summarize, extract action items, or apply a custom prompt through local Ollama or remote OpenRouter models.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -371,6 +371,13 @@ A single VAD utterance can contain more than one speaker, so segmentation finds
 are, and the worker aligns transcript segments to those turns. Speaker indices
 stay stable across the session because turns reconcile by voice.
 
+By default, a sufficiently distinct long turn may create another session
+speaker. When `diarizationMaxSpeakers` is set and the registry reaches that
+count, subsequent turns attach to the nearest existing centroid instead. This
+prevents known two-person recordings from accumulating extra labels, at the
+explicit cost of merging a real additional speaker if the configured limit is
+too low.
+
 All speaker data lives in memory for the session and is discarded when it ends —
 no enrollment, no persisted voiceprints, no network. The bundled models are
 `pyannote/segmentation-3.0` (MIT) and `wespeaker_en_voxceleb_resnet34_LM`
@@ -449,6 +456,7 @@ A representative slice of user-facing settings (full list and defaults in
 | `accelerationPreference` | `auto` | GPU when available vs CPU-only |
 | `includeSystemAudio` | `false` | Capture system output instead of the mic |
 | `diarizationEnabled` | `false` | Label speakers (Speaker 1, 2, …) |
+| `diarizationMaxSpeakers` | `null` | Optional positive cap on session-stable speaker labels; `null` detects automatically |
 | `dictationAnchor` | `at_cursor` | Where transcript text lands (`at_cursor` / `end_of_note`) |
 | `transcriptFormatting` | `smart` | How utterance boundaries render |
 | `timestampsEnabled` | `false` | Render timestamps in the note |

--- a/native/src/app.rs
+++ b/native/src/app.rs
@@ -451,6 +451,7 @@ impl AppState {
             Command::StartSession {
                 acceleration_preference,
                 diarization_enabled,
+                diarization_max_speakers,
                 include_system_audio,
                 language,
                 mode,
@@ -477,6 +478,19 @@ impl AppState {
                         code: "session_already_exists".to_string(),
                         details: None,
                         message: "A dictation session with this id already exists.".to_string(),
+                        session_id: Some(session_id),
+                    });
+                    return (ControlFlow::Continue, events);
+                }
+
+                if diarization_max_speakers == Some(0) {
+                    events.push(Event::Error {
+                        code: "invalid_diarization_speaker_limit".to_string(),
+                        details: Some(
+                            "diarizationMaxSpeakers must be a positive integer".to_string(),
+                        ),
+                        message: "Maximum speakers must be at least 1 or set to Automatic."
+                            .to_string(),
                         session_id: Some(session_id),
                     });
                     return (ControlFlow::Continue, events);
@@ -538,6 +552,7 @@ impl AppState {
                                 family_id: resolved_model.family_id,
                                 gpu_config: GpuConfig { use_gpu },
                                 diarization_enabled,
+                                diarization_max_speakers,
                                 language,
                                 model_file_path: resolved_model.resolved_path.clone(),
                                 cancel_rx,
@@ -2249,6 +2264,27 @@ mod tests {
     }
 
     #[test]
+    fn start_session_rejects_zero_max_speakers() {
+        let model_file_path = create_model_file();
+        let mut command = start_session_command("session-1", &model_file_path);
+        let Command::StartSession {
+            diarization_max_speakers,
+            ..
+        } = &mut command
+        else {
+            panic!("expected start session command");
+        };
+        *diarization_max_speakers = Some(0);
+
+        let (_, events) = test_app().handle_command(command);
+
+        assert!(matches!(
+            events.first(),
+            Some(Event::Error { code, .. }) if code == "invalid_diarization_speaker_limit"
+        ));
+    }
+
+    #[test]
     fn probe_model_selection_reports_missing_managed_model() {
         let (_, events) = test_app().handle_command(Command::ProbeModelSelection {
             model_selection: SelectedModel::CatalogModel {
@@ -3393,6 +3429,7 @@ mod tests {
         Command::StartSession {
             acceleration_preference: AccelerationPreference::Auto,
             diarization_enabled: false,
+            diarization_max_speakers: None,
             include_system_audio,
             language: "en".to_string(),
             mode: ListeningMode::AlwaysOn,

--- a/native/src/diarize/mod.rs
+++ b/native/src/diarize/mod.rs
@@ -55,10 +55,14 @@ pub struct SessionDiarizer {
 
 impl SessionDiarizer {
     pub fn new() -> Result<Self, String> {
+        Self::with_max_speakers(None)
+    }
+
+    pub fn with_max_speakers(max_speakers: Option<usize>) -> Result<Self, String> {
         Ok(Self {
             segmenter: Segmenter::new()?,
             extractor: EmbeddingExtractor::new()?,
-            registry: SpeakerRegistry::new(),
+            registry: SpeakerRegistry::with_max_speakers(max_speakers),
         })
     }
 

--- a/native/src/diarize/registry.rs
+++ b/native/src/diarize/registry.rs
@@ -12,6 +12,8 @@
 //!   to the nearest speaker instead of over-splitting.
 //! - a short-utterance guard: very short utterances never spawn a new speaker,
 //!   because embeddings are unreliable on little audio.
+//! - an optional user limit: once the expected speaker count is reached, new
+//!   voices attach to the nearest existing cluster instead of creating labels.
 
 use super::{l2_norm, l2_normalize};
 
@@ -33,6 +35,7 @@ pub struct Assignment {
 
 #[derive(Default)]
 pub struct SpeakerRegistry {
+    max_speakers: Option<usize>,
     speakers: Vec<SpeakerCluster>,
 }
 
@@ -42,8 +45,17 @@ struct SpeakerCluster {
 }
 
 impl SpeakerRegistry {
+    #[cfg(test)]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn with_max_speakers(max_speakers: Option<usize>) -> Self {
+        debug_assert!(max_speakers.is_none_or(|limit| limit > 0));
+        Self {
+            max_speakers,
+            speakers: Vec::new(),
+        }
     }
 
     /// Assign `embedding` (need not be normalised) to a session-stable speaker.
@@ -60,6 +72,12 @@ impl SpeakerRegistry {
                     speaker_count: self.speakers.len(),
                 }
             }
+            Some((idx, sim)) if self.speaker_limit_reached() => Assignment {
+                speaker_index: idx as u32,
+                similarity: sim,
+                is_new_speaker: false,
+                speaker_count: self.speakers.len(),
+            },
             other => {
                 let similarity = other.map_or(0.0, |(_, sim)| sim);
                 let idx = self.add_speaker(embedding);
@@ -71,6 +89,11 @@ impl SpeakerRegistry {
                 }
             }
         }
+    }
+
+    fn speaker_limit_reached(&self) -> bool {
+        self.max_speakers
+            .is_some_and(|limit| self.speakers.len() >= limit)
     }
 
     fn best_match(&self, embedding: &[f32]) -> Option<(usize, f32)> {
@@ -197,5 +220,32 @@ mod tests {
         );
         assert!(!first_again.is_new_speaker);
         assert_eq!(first_again.speaker_count, 2);
+    }
+
+    #[test]
+    fn speaker_limit_assigns_new_voices_to_the_nearest_existing_cluster() {
+        let mut registry = SpeakerRegistry::with_max_speakers(Some(2));
+        registry.assign(&[1.0, 0.0, 0.0], LONG);
+        registry.assign(&[0.0, 1.0, 0.0], LONG);
+        let centroids_before = registry
+            .speakers
+            .iter()
+            .map(|speaker| speaker.centroid.clone())
+            .collect::<Vec<_>>();
+
+        let third_voice = registry.assign(&[0.1, 0.2, 1.0], LONG);
+
+        assert!(!third_voice.is_new_speaker);
+        assert!(third_voice.speaker_index < 2);
+        assert_eq!(third_voice.speaker_count, 2);
+        assert_eq!(
+            registry
+                .speakers
+                .iter()
+                .map(|speaker| speaker.centroid.clone())
+                .collect::<Vec<_>>(),
+            centroids_before,
+            "a forced assignment must not contaminate an existing voice centroid"
+        );
     }
 }

--- a/native/src/protocol.rs
+++ b/native/src/protocol.rs
@@ -273,6 +273,8 @@ pub enum Command {
         #[serde(default)]
         diarization_enabled: bool,
         #[serde(default)]
+        diarization_max_speakers: Option<u32>,
+        #[serde(default)]
         include_system_audio: bool,
         language: String,
         mode: ListeningMode,
@@ -664,6 +666,7 @@ mod tests {
             IncomingFrame::Command(Command::StartSession {
                 acceleration_preference: AccelerationPreference::Auto,
                 diarization_enabled: false,
+                diarization_max_speakers: None,
                 include_system_audio: true,
                 language: "en".to_string(),
                 mode: ListeningMode::AlwaysOn,
@@ -708,6 +711,43 @@ mod tests {
             parsed,
             IncomingFrame::Command(Command::StartSession { .. })
         ));
+    }
+
+    #[test]
+    fn start_session_speaker_limit_round_trips() {
+        let payload = serde_json::to_vec(&serde_json::json!({
+            "type": "start_session",
+            "sessionId": "session-speakers",
+            "mode": "always_on",
+            "modelSelection": {
+                "kind": "external_file",
+                "runtimeId": "whisper_cpp",
+                "familyId": "whisper",
+                "filePath": "/tmp/model.bin"
+            },
+            "language": "en",
+            "sessionStartUnixMs": 1_700_000_000_000_u64,
+            "diarizationEnabled": true,
+            "diarizationMaxSpeakers": 2
+        }))
+        .expect("payload should serialize");
+        let mut framed = Vec::new();
+        write_frame(&mut framed, JSON_FRAME_KIND, &payload).expect("frame should write");
+
+        let parsed = read_frame(&mut framed.as_slice())
+            .expect("frame should parse")
+            .expect("frame should exist");
+        let IncomingFrame::Command(Command::StartSession {
+            diarization_enabled,
+            diarization_max_speakers,
+            ..
+        }) = parsed
+        else {
+            panic!("expected start session command");
+        };
+
+        assert!(diarization_enabled);
+        assert_eq!(diarization_max_speakers, Some(2));
     }
 
     #[test]

--- a/native/src/worker.rs
+++ b/native/src/worker.rs
@@ -34,6 +34,7 @@ pub struct SessionMetadata {
     pub family_id: ModelFamilyId,
     pub gpu_config: GpuConfig,
     pub diarization_enabled: bool,
+    pub diarization_max_speakers: Option<u32>,
     pub language: String,
     pub model_file_path: PathBuf,
     pub cancel_rx: watch::Receiver<bool>,
@@ -281,7 +282,11 @@ fn worker_main(
                             &metadata.language,
                         );
                         let diarizer = if metadata.diarization_enabled && !streaming {
-                            match SessionDiarizer::new() {
+                            match SessionDiarizer::with_max_speakers(
+                                metadata
+                                    .diarization_max_speakers
+                                    .map(|value| value as usize),
+                            ) {
                                 Ok(diarizer) => Some(diarizer),
                                 Err(error) => {
                                     eprintln!(
@@ -1044,6 +1049,7 @@ mod tests {
             family_id: ModelFamilyId::Moonshine,
             gpu_config: GpuConfig::default(),
             diarization_enabled: false,
+            diarization_max_speakers: None,
             language: "en".to_string(),
             model_file_path: PathBuf::from("/tmp/frontend.ort"),
             cancel_rx,
@@ -1372,6 +1378,7 @@ mod tests {
             family_id: ModelFamilyId::Moonshine,
             gpu_config: GpuConfig::default(),
             diarization_enabled: false,
+            diarization_max_speakers: None,
             language: "en".to_string(),
             model_file_path: PathBuf::from("/tmp/frontend.ort"),
             cancel_rx,
@@ -1684,6 +1691,7 @@ mod tests {
                 family_id: ModelFamilyId::Moonshine,
                 gpu_config: GpuConfig::default(),
                 diarization_enabled: false,
+                diarization_max_speakers: None,
                 language: "en".to_string(),
                 model_file_path: PathBuf::from("/tmp/frontend.ort"),
                 cancel_rx,

--- a/native/tests/common/driver.rs
+++ b/native/tests/common/driver.rs
@@ -297,6 +297,7 @@ fn start_session_command(
     Command::StartSession {
         acceleration_preference: AccelerationPreference::CpuOnly,
         diarization_enabled,
+        diarization_max_speakers: None,
         include_system_audio: false,
         language: "en".to_string(),
         mode: ListeningMode::AlwaysOn,

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -70,6 +70,7 @@ type ControllerSession = Pick<
 interface ActiveSessionSnapshot {
   accelerationPreference: PluginSettings['accelerationPreference'];
   diarizationEnabled: PluginSettings['diarizationEnabled'];
+  diarizationMaxSpeakers: PluginSettings['diarizationMaxSpeakers'];
   includeSystemAudio: PluginSettings['includeSystemAudio'];
   dictationAnchor: PluginSettings['dictationAnchor'];
   listeningMode: PluginSettings['listeningMode'];
@@ -372,6 +373,7 @@ export class DictationSessionController {
       await this.dependencies.sidecarConnection.startSession({
         accelerationPreference: snapshot.accelerationPreference,
         diarizationEnabled: snapshot.diarizationEnabled,
+        diarizationMaxSpeakers: snapshot.diarizationMaxSpeakers,
         includeSystemAudio: snapshot.includeSystemAudio,
         language: 'en',
         mode: snapshot.listeningMode,
@@ -1544,6 +1546,7 @@ function createSessionSnapshot(
   return {
     accelerationPreference: settings.accelerationPreference,
     diarizationEnabled: settings.diarizationEnabled,
+    diarizationMaxSpeakers: settings.diarizationMaxSpeakers,
     includeSystemAudio: settings.includeSystemAudio,
     dictationAnchor: settings.dictationAnchor,
     listeningMode: settings.listeningMode,

--- a/src/settings/plugin-settings.ts
+++ b/src/settings/plugin-settings.ts
@@ -55,6 +55,9 @@ export const DEFAULT_SMART_PARAGRAPH_PAUSE_MS = 3_000;
 export const MIN_SMART_PARAGRAPH_PAUSE_MS = 500;
 export const MAX_SMART_PARAGRAPH_PAUSE_MS = 30_000;
 
+export const MIN_DIARIZATION_MAX_SPEAKERS = 1;
+export const MAX_DIARIZATION_MAX_SPEAKERS = 8;
+
 export const SPEAKING_STYLES = [
   'responsive',
   'balanced',
@@ -105,6 +108,7 @@ export interface PluginSettings {
   cudaLibraryPath: string;
   developerMode: boolean;
   diarizationEnabled: boolean;
+  diarizationMaxSpeakers: number | null;
   dictationAnchor: DictationAnchor;
   listeningMode: ListeningMode;
   llmFeaturesEnabled: boolean;
@@ -159,6 +163,7 @@ export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
   cudaLibraryPath: '',
   developerMode: false,
   diarizationEnabled: false,
+  diarizationMaxSpeakers: null,
   dictationAnchor: 'at_cursor',
   listeningMode: 'always_on',
   llmFeaturesEnabled: true,
@@ -226,6 +231,7 @@ export function resolvePluginSettings(data: unknown): PluginSettings {
     cudaLibraryPath: readString(raw.cudaLibraryPath, DEFAULT_PLUGIN_SETTINGS.cudaLibraryPath),
     developerMode: readBoolean(raw.developerMode, DEFAULT_PLUGIN_SETTINGS.developerMode),
     diarizationEnabled: readDiarizationEnabled(raw),
+    diarizationMaxSpeakers: readDiarizationMaxSpeakers(raw.diarizationMaxSpeakers),
     dictationAnchor: isDictationAnchor(raw.dictationAnchor)
       ? raw.dictationAnchor
       : DEFAULT_PLUGIN_SETTINGS.dictationAnchor,
@@ -485,6 +491,18 @@ function readSetupCompletedAt(value: unknown): string | null {
 
 function readPositiveInteger(value: unknown, fallback: number): number {
   return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function readDiarizationMaxSpeakers(value: unknown): number | null {
+  if (
+    typeof value !== 'number' ||
+    !Number.isInteger(value) ||
+    value < MIN_DIARIZATION_MAX_SPEAKERS ||
+    value > MAX_DIARIZATION_MAX_SPEAKERS
+  ) {
+    return null;
+  }
+  return value;
 }
 
 function readClampedInteger(value: unknown, fallback: number, min: number, max: number): number {

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -29,7 +29,9 @@ import {
   isTimestampClock,
   isTimestampDensity,
   isTranscriptFormattingMode,
+  MAX_DIARIZATION_MAX_SPEAKERS,
   MAX_TIMESTAMP_SPARSE_INTERVAL_MS,
+  MIN_DIARIZATION_MAX_SPEAKERS,
   MIN_TIMESTAMP_SPARSE_INTERVAL_MS,
   type PluginSettings,
   type TimestampClock,
@@ -228,10 +230,14 @@ export class LocalSttSettingTab extends PluginSettingTab {
 
     this.renderTranscriptFormattingSetting(outputCard);
 
+    let setSpeakerLimitEnabled = (_enabled: boolean): void => {};
     const diarizationSetting = addToggleSetting(outputCard, this.access, {
       name: 'Speaker labels (diarization)',
       desc: '',
       key: 'diarizationEnabled',
+      onChange: (enabled) => {
+        setSpeakerLimitEnabled(enabled);
+      },
     });
     const updateDiarizationDesc = (): void => {
       const caps = manager.getState().selectedModelCapabilities;
@@ -243,6 +249,39 @@ export class LocalSttSettingTab extends PluginSettingTab {
     };
     updateDiarizationDesc();
     this.disposeDiarizationDesc = manager.subscribe(updateDiarizationDesc);
+
+    const speakerLimitSetting = new Setting(outputCard)
+      .setName('Maximum speakers')
+      .setDesc(
+        'Use Automatic unless extra speaker labels appear. Setting the expected count prevents the session from creating labels beyond that limit.',
+      );
+    speakerLimitSetting.addDropdown((dropdown) => {
+      dropdown.addOption('auto', 'Automatic');
+      for (
+        let count = MIN_DIARIZATION_MAX_SPEAKERS;
+        count <= MAX_DIARIZATION_MAX_SPEAKERS;
+        count += 1
+      ) {
+        dropdown.addOption(String(count), String(count));
+      }
+      dropdown.setValue(settings.diarizationMaxSpeakers?.toString() ?? 'auto');
+      dropdown.setDisabled(!settings.diarizationEnabled);
+      setSpeakerLimitEnabled = (enabled) => {
+        dropdown.setDisabled(!enabled);
+      };
+      dropdown.onChange(async (value) => {
+        const parsed = value === 'auto' ? null : Number(value);
+        if (
+          parsed !== null &&
+          (!Number.isInteger(parsed) ||
+            parsed < MIN_DIARIZATION_MAX_SPEAKERS ||
+            parsed > MAX_DIARIZATION_MAX_SPEAKERS)
+        ) {
+          return;
+        }
+        await this.access.persistOne('diarizationMaxSpeakers', parsed);
+      });
+    });
 
     addToggleSetting(outputCard, this.access, {
       name: 'Keep recovery text in memory',

--- a/src/sidecar/protocol.ts
+++ b/src/sidecar/protocol.ts
@@ -111,6 +111,7 @@ export type ProbeSystemAudioCommand = EnvelopeBase<'probe_system_audio'>;
 export interface StartSessionCommand extends EnvelopeBase<'start_session'> {
   accelerationPreference: AccelerationPreference;
   diarizationEnabled: boolean;
+  diarizationMaxSpeakers: number | null;
   includeSystemAudio: boolean;
   language: 'en';
   mode: ListeningMode;

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -204,6 +204,25 @@ describe('DictationSessionController', () => {
     });
   });
 
+  it('passes the configured speaker limit to the sidecar session', async () => {
+    const sidecarConnection = new FakeSidecarConnection();
+    const controller = createController({
+      sidecarConnection,
+      getSettings: () =>
+        createSettings({
+          diarizationEnabled: true,
+          diarizationMaxSpeakers: 2,
+          selectedModel: createExternalModelSelection(),
+        }),
+    });
+
+    await controller.startDictation();
+
+    expect(sidecarConnection.startSession).toHaveBeenCalledWith(
+      expect.objectContaining({ diarizationEnabled: true, diarizationMaxSpeakers: 2 }),
+    );
+  });
+
   it('includes system audio without skipping microphone capture', async () => {
     const captureStream = new FakeCaptureStream();
     const sidecarConnection = new FakeSidecarConnection();

--- a/test/plugin-settings.test.ts
+++ b/test/plugin-settings.test.ts
@@ -49,8 +49,21 @@ describe('resolvePluginSettings', () => {
 
   it('defaults speaker diarization off and honors a persisted boolean', () => {
     expect(DEFAULT_PLUGIN_SETTINGS.diarizationEnabled).toBe(false);
+    expect(DEFAULT_PLUGIN_SETTINGS.diarizationMaxSpeakers).toBeNull();
     expect(resolvePluginSettings({ diarizationEnabled: true }).diarizationEnabled).toBe(true);
     expect(resolvePluginSettings({ diarizationEnabled: 'yes' }).diarizationEnabled).toBe(false);
+  });
+
+  it('accepts automatic or bounded maximum speaker counts', () => {
+    expect(
+      resolvePluginSettings({ diarizationMaxSpeakers: null }).diarizationMaxSpeakers,
+    ).toBeNull();
+    expect(resolvePluginSettings({ diarizationMaxSpeakers: 2 }).diarizationMaxSpeakers).toBe(2);
+    expect(resolvePluginSettings({ diarizationMaxSpeakers: 0 }).diarizationMaxSpeakers).toBeNull();
+    expect(resolvePluginSettings({ diarizationMaxSpeakers: 99 }).diarizationMaxSpeakers).toBeNull();
+    expect(
+      resolvePluginSettings({ diarizationMaxSpeakers: '2' }).diarizationMaxSpeakers,
+    ).toBeNull();
   });
 
   it('retains the last utterance by default and honors only a persisted boolean opt-out', () => {

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -231,6 +231,7 @@ describe('command serialization', () => {
       createStartSessionCommand({
         accelerationPreference: 'auto',
         diarizationEnabled: true,
+        diarizationMaxSpeakers: 2,
         includeSystemAudio: true,
         language: 'en',
         mode: 'always_on',
@@ -244,6 +245,7 @@ describe('command serialization', () => {
 
     expect(payload.accelerationPreference).toBe('auto');
     expect(payload.diarizationEnabled).toBe(true);
+    expect(payload.diarizationMaxSpeakers).toBe(2);
     expect(payload.includeSystemAudio).toBe(true);
     expect(payload).not.toHaveProperty('audioSource');
     expect(payload.sessionId).toBe('session-gpu');


### PR DESCRIPTION
## Summary

- Add an optional **Maximum speakers** setting (Automatic or 1–8) beside speaker labels.
- Carry the session snapshot through the TypeScript/native protocol into the diarization worker.
- Stop creating speaker clusters after the configured count and assign later turns to the nearest existing speaker.

## Root cause

The online speaker registry used similarity and short-utterance guards, but it had no ceiling. A noisy or shifted embedding could therefore create Speaker 3 or Speaker 4 in a known two-person recording. Users had no deterministic way to constrain that failure mode.

## Decisions and trade-offs

Automatic detection remains the default. A limit is an explicit recovery control for recordings where the participant count is known; it is not presented as a general quality fix.

When the limit is reached, a dissimilar turn is assigned to the nearest existing cluster without updating that cluster’s centroid. This prevents an unexpected third voice or noise embedding from contaminating the learned representation of a real participant. If the configured limit is too low, genuine additional speakers will be merged—this trade-off is stated in the architecture docs and UI copy.

The persisted setting accepts only 1–8 or `null`. The native boundary separately rejects zero so malformed external protocol clients fail closed.

## User impact

For a two-person interview that over-splits into extra labels, selecting 2 guarantees that the session cannot create Speaker 3+. The control is disabled when speaker labels are off and has no effect on streaming models, which continue to report the existing diarization capability warning.

Relates to #222.

## Interaction with active PRs

PRs #233, #236, and #239 also touch shared settings, controller, protocol, or documentation files. This PR does not implement personal corrections, selection re-dictation, or Markdown voice commands; its only runtime behavior is the diarization speaker ceiling carried in the immutable session snapshot. A normal rebase may be needed after those branches land, especially through the shared controller tests.

## Verification

- `npm run check:frontend` — typecheck, Biome, Obsidian ESLint, 62 files / 770 tests, and production build passed
- `npm run check:rust` — all-engine fmt/clippy plus 281 library tests and integration suites passed (model-dependent tests remained ignored as designed)
- Added focused coverage for settings validation, controller/protocol propagation, native malformed-input rejection, cluster limits, and centroid preservation

## Manual gap

Interactive Obsidian settings and a real two-speaker recording were not exercised in this non-interactive environment. Existing real-audio diarization integration tests passed; model-backed ignored tests still require local model paths.
