### PR TITLE
Clarify English-only support and multilingual roadmap

### DIFF
--- a/docs/specs/multilingual-support.md
+++ b/docs/specs/multilingual-support.md
@@ -1,0 +1,119 @@
+# First-class multilingual dictation
+
+## Status and scope
+
+Local Dictation is English-only today. This document defines the staged path to
+first-class multilingual support; it does not authorize a language selector or
+new catalog entries before the corresponding model and adapter paths are
+verified end to end.
+
+The current constraint exists at every layer:
+
+- Every managed model in `native/catalog.json` has `languageTags: ["en"]`.
+- `StartSessionCommand.language` is the literal type `'en'`, and the plugin sends
+  that value from `DictationSessionController`.
+- `App::resolve_runtime_model_path` rejects any language other than `en` before
+  resolving the selected model. Batch adapters repeat the check through
+  `validate_language`.
+- Whisper, Cohere Transcribe, and Moonshine all advertise
+  `LanguageSupport::EnglishOnly` and no language selection.
+- Cohere decoding currently inserts the fixed `<|en|>` token. The current
+  Moonshine streaming assets are English-only.
+
+An upstream family supporting several languages therefore does not mean the
+particular artifact, adapter, protocol, and product path support those languages.
+Family marketing copy must not be used as model eligibility.
+
+## Target invariants
+
+Multilingual support is first-class only when all of these are true:
+
+1. A selected language is persisted and restored, with an explicit policy for
+   automatic detection and regional BCP 47 tags.
+2. The model picker can determine whether each exact catalog model is eligible
+   for that language. A family-level capability alone is insufficient: Whisper
+   has both English-only and multilingual artifacts.
+3. Session startup carries the selected language to the resolved adapter, which
+   validates it against the resolved model rather than a global constant.
+4. Raw transcription, context prompting, post-processing, and LLM transforms
+   preserve the spoken language unless the user explicitly requests translation.
+5. Unsupported combinations fail before audio capture with a specific,
+   actionable message. They never silently fall back to English.
+
+## Staged delivery
+
+### 0. Truthful English-only UX
+
+- State the current English-only product constraint during setup and model
+  choice.
+- Display catalog language metadata on model rows.
+- Remove upstream language-count claims from product copy when the integration
+  does not expose those languages.
+
+### 1. Model-level language eligibility
+
+- Make exact-model language support authoritative. `languageTags` can remain the
+  catalog source for managed artifacts, but successful probes need an equivalent
+  capability for external files.
+- Separate family features (streaming, prompt support) from model-specific
+  language support. Do not mark the whole Whisper family multilingual because a
+  multilingual artifact exists.
+- Define normalized supported tags and, separately, whether an adapter supports
+  automatic detection. `all` is too weak when only a tested subset is eligible.
+- Add only pinned artifacts whose license, hashes, tokenizer/graph shape,
+  language behavior, and quality fixtures have been verified.
+
+### 2. Persisted selection and protocol
+
+- Add a persisted `dictationLanguage` setting with an explicit migration from
+  the current implicit English default.
+- Design the value as a normalized language tag plus an explicit `auto` state;
+  do not overload an empty string.
+- Widen the TypeScript start-session contract from `'en'` only after settings
+  validation and model eligibility are in place. Preserve the language as a
+  structured session value through the Rust protocol and worker metadata.
+- In setup and Manage Models, disable or explain ineligible models before the
+  user downloads them. Changing language must revalidate the current selection.
+
+### 3. Adapter enablement
+
+- **Whisper:** add verified multilingual artifacts, distinguish them from `.en`
+  variants, pass the selected language or automatic-detection mode to
+  whisper.cpp, and keep translation disabled by default.
+- **Cohere Transcribe:** replace the fixed English prompt token with a tested
+  language-token mapping. Enable only tags supported by the shipped tokenizer
+  and decoder implementation, not the upstream family claim alone.
+- **Moonshine:** keep the current streaming assets explicitly English-only until
+  separately licensed multilingual artifacts and their streaming graph contract
+  are integrated and quality-tested.
+- Move the global native English rejection to resolved-model validation. Adapter
+  capability failures must identify both language and model.
+
+### 4. Context and cleanup semantics
+
+- Audit initial prompts and note context with non-Latin text and mixed scripts.
+  Byte/character budgets and token estimates must not assume English density.
+- Make every built-in LLM transform explicitly preserve the transcript language
+  and forbid implicit translation. Verify local and remote providers with the
+  same contract.
+- Review English phrase lists and ASCII-oriented heuristics in the hallucination
+  filter before enabling each language. Language-specific rules should be gated,
+  not applied globally.
+- Confirm punctuation, capitalization, speaker labels, timestamps, and smart
+  paragraphs remain structurally correct for the supported scripts.
+
+### 5. Verification and release gate
+
+- Unit-test tag normalization, model eligibility, persisted-settings migration,
+  protocol round trips, and adapter rejection paths.
+- Add pinned audio/text fixtures per enabled language for both accuracy and
+  "does not translate" behavior. Include at least one non-Latin script before
+  claiming general multilingual support.
+- Add integration coverage for manual selection, automatic detection, wrong-model
+  rejection, context prompting, LLM cleanup, and English regression.
+- Document code-switching policy explicitly; do not imply it from monolingual
+  fixtures.
+
+The first multilingual release should enable a small, verified language/model
+matrix. Breadth follows evidence; it is not a prerequisite for a sound model-level
+architecture.

--- a/native/catalog.json
+++ b/native/catalog.json
@@ -23,7 +23,7 @@
       "familyId": "cohere_transcribe",
       "runtimeId": "onnx_runtime",
       "displayName": "Cohere Transcribe",
-      "summary": "Cohere Transcribe (2B parameters, 14 languages) running on ONNX Runtime."
+      "summary": "Cohere Transcribe (2B parameters) running on ONNX Runtime. Local Dictation currently enables English only."
     },
     {
       "familyId": "moonshine",

--- a/src/models/language-support.ts
+++ b/src/models/language-support.ts
@@ -1,0 +1,30 @@
+export const CURRENT_LANGUAGE_SUPPORT_NOTICE =
+  'Local Dictation currently supports English dictation only. Some upstream model families support additional languages, but this app does not enable them yet.';
+
+export function describeCatalogLanguageSupport(languageTags: readonly string[]): string {
+  const normalizedTags = [...new Set(languageTags.map(normalizeLanguageTag).filter(isPresent))];
+  const englishTags = normalizedTags.filter(isEnglishLanguageTag);
+
+  if (normalizedTags.length === 0) {
+    return 'Language support unverified';
+  }
+
+  if (englishTags.length === 0) {
+    return 'Not available for English';
+  }
+
+  return englishTags.length === normalizedTags.length ? 'English only' : 'Includes English';
+}
+
+function normalizeLanguageTag(value: string): string | null {
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function isEnglishLanguageTag(value: string): boolean {
+  return value === 'en' || value.startsWith('en-');
+}
+
+function isPresent<T>(value: T | null): value is T {
+  return value !== null;
+}

--- a/src/models/manage-models-modal.ts
+++ b/src/models/manage-models-modal.ts
@@ -4,6 +4,10 @@ import { Modal, Setting, setIcon } from 'obsidian';
 import { formatBytes } from '../shared/format-utils';
 import type { UserFeedback } from '../shared/user-feedback';
 import { resolveEngineCapabilities } from './capability-view';
+import {
+  CURRENT_LANGUAGE_SUPPORT_NOTICE,
+  describeCatalogLanguageSupport,
+} from './language-support';
 import { isCancellingPhase, type ModelInstallManager } from './model-install-manager';
 import {
   createInstallProgressElement,
@@ -215,6 +219,11 @@ export class ManageModelsModal extends Modal {
       });
       return;
     }
+
+    this.listContainer.createEl('p', {
+      cls: 'local-stt-family-summary',
+      text: CURRENT_LANGUAGE_SUPPORT_NOTICE,
+    });
 
     const activeFamily = state.catalog.families.find(
       (f) => f.runtimeId === this.activeTab?.runtimeId && f.familyId === this.activeTab?.familyId,
@@ -511,6 +520,11 @@ export class ManageModelsModal extends Modal {
   private buildTagsFragment(model: CatalogModelRecord): DocumentFragment {
     const frag = createFragment();
     const tagsContainer = frag.createSpan({ cls: 'local-stt-tags' });
+
+    tagsContainer.createSpan({
+      cls: 'local-stt-tag',
+      text: describeCatalogLanguageSupport(model.languageTags),
+    });
 
     for (const tag of model.uxTags) {
       tagsContainer.createSpan({

--- a/src/setup/setup-wizard-modal.ts
+++ b/src/setup/setup-wizard-modal.ts
@@ -1,5 +1,6 @@
 import type { App } from 'obsidian';
 import { Modal, Platform, setIcon } from 'obsidian';
+import { CURRENT_LANGUAGE_SUPPORT_NOTICE } from '../models/language-support';
 import { ManageModelsModal } from '../models/manage-models-modal';
 import type { ModelInstallManager } from '../models/model-install-manager';
 import type { PluginLogger } from '../shared/plugin-logger';
@@ -207,6 +208,10 @@ export class SetupWizardModal extends Modal {
     body.createEl('h2', {
       cls: 'local-stt-wizard-step__title',
       text: this.modelReady ? 'Model selected' : 'Pick a transcription model',
+    });
+    body.createEl('p', {
+      cls: 'local-stt-wizard-step__muted',
+      text: CURRENT_LANGUAGE_SUPPORT_NOTICE,
     });
 
     if (this.modelReady) {

--- a/test/language-support.test.ts
+++ b/test/language-support.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { describeCatalogLanguageSupport } from '../src/models/language-support';
+
+describe('describeCatalogLanguageSupport', () => {
+  it('recognizes normalized English-only catalog tags', () => {
+    expect(describeCatalogLanguageSupport([' EN ', 'en-US', 'en'])).toBe('English only');
+  });
+
+  it('does not present a multilingual model as app-level multilingual support', () => {
+    expect(describeCatalogLanguageSupport(['en', 'fr', 'de'])).toBe('Includes English');
+  });
+
+  it('flags a model that cannot serve the current English-only pipeline', () => {
+    expect(describeCatalogLanguageSupport(['fr', 'de'])).toBe('Not available for English');
+  });
+
+  it('treats missing language metadata conservatively', () => {
+    expect(describeCatalogLanguageSupport(['', '  '])).toBe('Language support unverified');
+  });
+});


### PR DESCRIPTION
## Summary

- Makes the current English-only product boundary explicit during setup and in Manage Models, where users form expectations and choose downloads.
- Shows each managed model's enabled catalog language as a row badge and removes the misleading `14 languages` claim from the Cohere family summary.
- Adds a staged architecture spec for real multilingual support across exact-model eligibility, persisted language selection, protocol/adapter validation, cleanup behavior, and release tests.

Relates to #243. This is the truthful-readiness slice; it intentionally does not close the issue or add a selector before the runtime can honor one.

## Key changes

- **Setup:** the model step now says that Local Dictation accepts English dictation only, including when an upstream family supports more languages.
- **Model choice:** Manage Models repeats that product constraint and derives a conservative language badge from each catalog entry's `languageTags`.
- **Catalog copy:** Cohere remains described as the shipped 2B model, but the family summary no longer advertises upstream language breadth that the fixed-English adapter path cannot expose.
- **Architecture:** `docs/specs/multilingual-support.md` defines the required sequence and acceptance invariants without adding unverified models.
- **Tests:** language-tag presentation normalizes case/spacing, distinguishes English-only from multilingual metadata, and handles missing or incompatible tags conservatively.

## Evidence and decisions

The current system is English-only at several independent boundaries:

- `StartSessionCommand.language` is the literal TypeScript type `'en'`, and `DictationSessionController` sends that value.
- native session startup rejects any language other than `en` before model resolution; batch adapters repeat the shared validation.
- Whisper, Cohere Transcribe, and Moonshine all report `LanguageSupport::EnglishOnly` with language selection disabled.
- Cohere decoding uses a fixed `<|en|>` prompt token, Moonshine's current streaming assets are English-only, and every managed catalog entry is tagged `en`.

Because language eligibility differs by exact artifact (not just family), this PR does not infer support from family marketing, change capability flags, widen the protocol, or add a settings value that would still fail at runtime. The spec requires model-level eligibility and verified artifacts before those changes.

## Interaction with parallel PRs

PR #253 also touches `native/catalog.json` and `src/models/manage-models-modal.ts` for external-model guidance. Its catalog edits are on the Whisper/Moonshine summaries rather than the Cohere line changed here, and its model-picker work is functionally independent. A small import-context conflict may still need resolution depending on merge order.

No settings-tab, protocol, adapter, transcription, README, or `marketing/` files are changed.

## Follow-up path

1. Make supported languages authoritative per exact catalog/probed model, including external-file results.
2. Persist a validated BCP 47 language or explicit auto-detect state and revalidate the selected model when it changes.
3. Carry that value through the session protocol and replace global English rejection with resolved-model validation.
4. Enable verified adapter paths incrementally: multilingual Whisper artifacts, Cohere language-token mapping, and separate Moonshine artifacts only when licensed and tested.
5. Audit prompt/context budgets, hallucination rules, LLM transforms, punctuation, and non-Latin scripts; add per-language accuracy and no-translation fixtures.

## Test plan

- [x] `npm run check` (release metadata, TypeScript typecheck, Biome, Obsidian ESLint, 772 Vitest tests, frontend build, sidecar build/output verification, Rust fmt/clippy/tests)
- [x] `npm test -- --run test/language-support.test.ts`
- [x] `cargo test --manifest-path native/Cargo.toml catalog::tests --lib`
- [ ] Manual Obsidian interaction (not available in this environment; production bundle compilation verifies both UI call sites)

Known pre-existing diagnostics: Biome reports the checked-in schema URL is for 2.5.0 while the lockfile uses 2.5.2, and Obsidian ESLint warns that the existing settings tab has not adopted the future declarative search API. Both checks complete successfully and neither diagnostic is introduced here.
