### PR TITLE
Add local WAV and MP3 transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ All transcription models in the current catalog run locally and support English.
 
 - **Live text.** Moonshine streaming models show provisional words and revise them in place until each utterance finalizes.
 - **Meeting capture.** Include system audio from meetings, calls, or videos alongside your microphone on Windows, Linux, and macOS 14.2 or later.
-- **Audio file transcription.** Transcribe a WAV or MP3 file up to 256 MB and 30 minutes from the ribbon or command palette.
+- **Audio file transcription.** Use a Whisper or Cohere Transcribe batch model to transcribe a WAV or MP3 file up to 256 MB and 30 minutes from the ribbon or command palette.
 - **Speaker labels.** Optional on-device diarization assigns session-stable speaker labels. Speaker embeddings stay in memory and are discarded after the session.
 - **Timestamps.** Add elapsed or wall-clock timestamps at configurable intervals.
 - **Local model choices.** Choose Whisper, Cohere Transcribe, or Moonshine models and download them from Settings.
@@ -53,7 +53,7 @@ All transcription models in the current catalog run locally and support English.
 2. Follow the setup wizard to download the native speech-to-text engine and a starter model.
 3. On the final step, select **Try dictation now** to begin in the open Markdown note. Or select **Done** and start later from the ribbon microphone or **Local Dictation: Toggle dictation** hotkey. Text lands at your cursor.
 
-To transcribe an existing recording into the open note, select the ribbon audio-file icon or run **Local Dictation: Transcribe audio file**. Choose a WAV or MP3 file up to 256 MB and 30 minutes. Use the active ribbon control to stop and keep the audio processed so far, or run **Local Dictation: Cancel dictation** to discard the in-progress session.
+To transcribe an existing recording into the open note, select a Whisper or Cohere Transcribe batch model, then select the ribbon audio-file icon or run **Local Dictation: Transcribe audio file**. Choose a WAV or MP3 file up to 256 MB and 30 minutes. Use the active ribbon control to stop and keep the audio processed so far, or run **Local Dictation: Cancel dictation** to discard the in-progress session.
 
 The engine and models need a one-time download. Transcription then works without an ongoing network connection.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ _The first-run wizard installs the native engine and helps you choose between li
 | **Live dictation** | Provisional words appear and revise in place while you speak. | Moonshine streaming models |
 | **Notes and drafts** | Final text lands at your cursor after each pause. | Whisper or Cohere Transcribe batch models |
 | **Meetings and calls** | Add computer audio to microphone capture, then optionally label speakers and add timestamps. | Whisper or Cohere Transcribe batch models |
+| **Audio files** | Choose a WAV or MP3 file and insert its transcript into the open note. | Whisper or Cohere Transcribe batch models |
 
 All transcription models in the current catalog run locally and support English. Moonshine is optimized for live dictation; speaker labels currently require a batch model.
 
@@ -38,6 +39,7 @@ All transcription models in the current catalog run locally and support English.
 
 - **Live text.** Moonshine streaming models show provisional words and revise them in place until each utterance finalizes.
 - **Meeting capture.** Include system audio from meetings, calls, or videos alongside your microphone on Windows, Linux, and macOS 14.2 or later.
+- **Audio file transcription.** Transcribe a WAV or MP3 file up to 256 MB and 30 minutes from the ribbon or command palette.
 - **Speaker labels.** Optional on-device diarization assigns session-stable speaker labels. Speaker embeddings stay in memory and are discarded after the session.
 - **Timestamps.** Add elapsed or wall-clock timestamps at configurable intervals.
 - **Local model choices.** Choose Whisper, Cohere Transcribe, or Moonshine models and download them from Settings.
@@ -50,6 +52,8 @@ All transcription models in the current catalog run locally and support English.
 1. [Install **Local Dictation** from Community Plugins](https://obsidian.md/plugins?id=local-dictation).
 2. Follow the setup wizard to download the native speech-to-text engine and a starter model.
 3. On the final step, select **Try dictation now** to begin in the open Markdown note. Or select **Done** and start later from the ribbon microphone or **Local Dictation: Toggle dictation** hotkey. Text lands at your cursor.
+
+To transcribe an existing recording into the open note, select the ribbon audio-file icon or run **Local Dictation: Transcribe audio file**. Choose a WAV or MP3 file up to 256 MB and 30 minutes. Use the active ribbon control to stop and keep the audio processed so far, or run **Local Dictation: Cancel dictation** to discard the in-progress session.
 
 The engine and models need a one-time download. Transcription then works without an ongoing network connection.
 
@@ -72,6 +76,7 @@ For CUDA requirements and Flatpak-specific setup, see the [CUDA setup guide](doc
 ## Privacy
 
 - **Transcription stays local.** Audio is processed by the native sidecar on your computer and is not uploaded for transcription.
+- **Selected files stay local.** WAV/MP3 files are decoded in Obsidian memory, sent only to the local sidecar as PCM, and never copied into your vault by Local Dictation.
 - **Downloads are explicit.** The sidecar comes from GitHub Releases and is installed with the plugin. Model files come from the source URLs shown in the catalog and use a shared local data directory outside your vault by default.
 - **Remote cleanup uses text, not audio.** If you configure and select OpenRouter, it receives the transcript plus any note context you choose to include. Ollama requests stay on your computer through its loopback interface.
 - **Remote processing is optional.** You can disable OpenRouter routing or all LLM features from Settings. If you use OpenRouter, configure its provider and zero-data-retention controls to match your requirements.

--- a/src/audio/audio-file-model-support.ts
+++ b/src/audio/audio-file-model-support.ts
@@ -1,0 +1,46 @@
+import { selectedModelEquals } from '../models/model-management-types';
+import type { PluginSettings } from '../settings/plugin-settings';
+
+type AudioFileModelSettings = Pick<
+  PluginSettings,
+  'selectedModel' | 'selectedModelCapabilitiesSnapshot'
+>;
+
+export type AudioFileModelSupport =
+  | { kind: 'capabilities_unavailable' }
+  | { kind: 'model_required' }
+  | { kind: 'streaming_unsupported' }
+  | { kind: 'supported' };
+
+export function resolveAudioFileModelSupport(
+  settings: AudioFileModelSettings,
+): AudioFileModelSupport {
+  if (settings.selectedModel === null) {
+    return { kind: 'model_required' };
+  }
+
+  const snapshot = settings.selectedModelCapabilitiesSnapshot;
+  if (snapshot === null || !selectedModelEquals(snapshot.selection, settings.selectedModel)) {
+    return { kind: 'capabilities_unavailable' };
+  }
+
+  return snapshot.capabilities.family.supportsStreaming
+    ? { kind: 'streaming_unsupported' }
+    : { kind: 'supported' };
+}
+
+export function describeAudioFileModelRequirement(
+  support: Exclude<AudioFileModelSupport, { kind: 'model_required' | 'supported' }>,
+): { actionLabel: string; message: string } {
+  if (support.kind === 'streaming_unsupported') {
+    return {
+      actionLabel: 'Choose a batch model',
+      message:
+        'Audio file transcription currently requires a batch model. Choose a Whisper or Cohere Transcribe model, then try again.',
+    };
+  }
+  return {
+    actionLabel: 'Manage models',
+    message: 'Verify the selected model in Manage models before transcribing an audio file.',
+  };
+}

--- a/src/audio/audio-file-picker.ts
+++ b/src/audio/audio-file-picker.ts
@@ -1,0 +1,27 @@
+import { AUDIO_FILE_ACCEPT, type AudioFileLike } from './audio-file-source';
+
+export function pickAudioFile(): Promise<AudioFileLike | null> {
+  const input = createEl('input');
+  input.type = 'file';
+  input.accept = AUDIO_FILE_ACCEPT;
+  input.multiple = false;
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (file: File | null): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      input.removeEventListener('cancel', onCancel);
+      input.removeEventListener('change', onChange);
+      resolve(file);
+    };
+    const onCancel = (): void => finish(null);
+    const onChange = (): void => finish(input.files?.item(0) ?? null);
+
+    input.addEventListener('cancel', onCancel);
+    input.addEventListener('change', onChange);
+    input.click();
+  });
+}

--- a/src/audio/audio-file-source.ts
+++ b/src/audio/audio-file-source.ts
@@ -6,12 +6,13 @@ export const MAX_AUDIO_FILE_DURATION_SECONDS = 30 * 60;
 export const MAX_AUDIO_FILE_BYTES = 256 * 1024 * 1024;
 
 const SOURCE_CHUNK_SAMPLES = 16_384;
-const YIELD_EVERY_CHUNKS = 8;
+const METADATA_PROBE_TIMEOUT_MS = 10_000;
+// Yield after at most ~1 second of 16 kHz source audio (and more often for the
+// common 44.1/48 kHz case) so sidecar queue events can reach the flow gate.
+const YIELD_EVERY_CHUNKS = 1;
 
-export interface AudioFileLike {
-  arrayBuffer(): Promise<ArrayBuffer>;
-  name: string;
-  size: number;
+export interface AudioFileLike extends Blob {
+  readonly name: string;
 }
 
 interface DecodedAudio {
@@ -24,7 +25,14 @@ interface DecodedAudio {
 
 interface AudioFileFrameSourceDependencies {
   decodeAudio: (encodedAudio: ArrayBuffer) => Promise<DecodedAudio>;
+  probeDuration: (file: AudioFileLike, abortSignal: AbortSignal) => Promise<number>;
   yieldToEventLoop: () => Promise<void>;
+}
+
+interface AudioMetadataProbeDependencies {
+  createAudioElement: () => HTMLAudioElement;
+  createObjectUrl: (file: Blob) => string;
+  revokeObjectUrl: (url: string) => void;
 }
 
 export class AudioFileFrameSource implements AudioFrameSource {
@@ -35,6 +43,7 @@ export class AudioFileFrameSource implements AudioFrameSource {
     file: AudioFileLike,
     dependencies: AudioFileFrameSourceDependencies = {
       decodeAudio: decodeWithWebAudio,
+      probeDuration: probeAudioDuration,
       yieldToEventLoop,
     },
   ) {
@@ -50,6 +59,9 @@ export class AudioFileFrameSource implements AudioFrameSource {
   }): Promise<void> {
     throwIfAborted(options.abortSignal);
     options.onProgress({ fraction: 0, phase: 'decoding' });
+
+    validateAudioDuration(await this.dependencies.probeDuration(this.file, options.abortSignal));
+    throwIfAborted(options.abortSignal);
 
     const decoded = await this.dependencies.decodeAudio(await this.file.arrayBuffer());
     validateDecodedAudio(decoded);
@@ -111,8 +123,77 @@ function validateDecodedAudio(decoded: DecodedAudio): void {
   ) {
     throw new Error('The selected audio file did not contain decodable audio.');
   }
-  if (decoded.duration > MAX_AUDIO_FILE_DURATION_SECONDS) {
+  validateAudioDuration(decoded.duration);
+}
+
+function validateAudioDuration(duration: number): void {
+  if (!Number.isFinite(duration) || duration <= 0) {
+    throw new Error('The selected audio file did not contain decodable audio.');
+  }
+  if (duration > MAX_AUDIO_FILE_DURATION_SECONDS) {
     throw new Error('Choose an audio file that is 30 minutes or shorter.');
+  }
+}
+
+export async function probeAudioDuration(
+  file: AudioFileLike,
+  abortSignal: AbortSignal,
+  dependencies: AudioMetadataProbeDependencies = {
+    createAudioElement: () => createEl('audio'),
+    createObjectUrl: (blob) => URL.createObjectURL(blob),
+    revokeObjectUrl: (url) => URL.revokeObjectURL(url),
+  },
+): Promise<number> {
+  throwIfAborted(abortSignal);
+  const audio = dependencies.createAudioElement();
+  const objectUrl = dependencies.createObjectUrl(file);
+  audio.preload = 'metadata';
+
+  try {
+    return await new Promise<number>((resolve, reject) => {
+      let timeoutId: number | null = null;
+      const cleanup = (): void => {
+        if (timeoutId !== null) {
+          window.clearTimeout(timeoutId);
+        }
+        audio.removeEventListener('error', onError);
+        audio.removeEventListener('loadedmetadata', onLoadedMetadata);
+        abortSignal.removeEventListener('abort', onAbort);
+      };
+      const onAbort = (): void => {
+        cleanup();
+        const error = new Error('Audio file transcription was cancelled.');
+        error.name = 'AbortError';
+        reject(error);
+      };
+      const onError = (): void => {
+        cleanup();
+        reject(new Error('Obsidian could not read metadata from this WAV or MP3 file.'));
+      };
+      const onLoadedMetadata = (): void => {
+        cleanup();
+        resolve(audio.duration);
+      };
+      const onTimeout = (): void => {
+        cleanup();
+        reject(new Error('Timed out while reading metadata from the selected audio file.'));
+      };
+
+      audio.addEventListener('error', onError, { once: true });
+      audio.addEventListener('loadedmetadata', onLoadedMetadata, { once: true });
+      abortSignal.addEventListener('abort', onAbort, { once: true });
+      timeoutId = window.setTimeout(onTimeout, METADATA_PROBE_TIMEOUT_MS);
+      audio.src = objectUrl;
+      audio.load();
+    });
+  } finally {
+    try {
+      audio.pause();
+      audio.removeAttribute('src');
+      audio.load();
+    } finally {
+      dependencies.revokeObjectUrl(objectUrl);
+    }
   }
 }
 

--- a/src/audio/audio-file-source.ts
+++ b/src/audio/audio-file-source.ts
@@ -1,0 +1,154 @@
+import type { AudioFrameSource, AudioFrameSourceProgress } from './audio-frame-source';
+import { mixChannelsToMono, PcmFrameProcessor } from './pcm-frame-processor';
+
+export const AUDIO_FILE_ACCEPT = '.mp3,.wav,audio/mpeg,audio/wav';
+export const MAX_AUDIO_FILE_DURATION_SECONDS = 30 * 60;
+export const MAX_AUDIO_FILE_BYTES = 256 * 1024 * 1024;
+
+const SOURCE_CHUNK_SAMPLES = 16_384;
+const YIELD_EVERY_CHUNKS = 8;
+
+export interface AudioFileLike {
+  arrayBuffer(): Promise<ArrayBuffer>;
+  name: string;
+  size: number;
+}
+
+interface DecodedAudio {
+  duration: number;
+  getChannelData(channel: number): Float32Array;
+  length: number;
+  numberOfChannels: number;
+  sampleRate: number;
+}
+
+interface AudioFileFrameSourceDependencies {
+  decodeAudio: (encodedAudio: ArrayBuffer) => Promise<DecodedAudio>;
+  yieldToEventLoop: () => Promise<void>;
+}
+
+export class AudioFileFrameSource implements AudioFrameSource {
+  private readonly dependencies: AudioFileFrameSourceDependencies;
+  private readonly file: AudioFileLike;
+
+  constructor(
+    file: AudioFileLike,
+    dependencies: AudioFileFrameSourceDependencies = {
+      decodeAudio: decodeWithWebAudio,
+      yieldToEventLoop,
+    },
+  ) {
+    validateAudioFile(file);
+    this.file = file;
+    this.dependencies = dependencies;
+  }
+
+  async stream(options: {
+    abortSignal: AbortSignal;
+    onFrame: (frameBytes: Uint8Array) => Promise<void>;
+    onProgress: (progress: AudioFrameSourceProgress) => void;
+  }): Promise<void> {
+    throwIfAborted(options.abortSignal);
+    options.onProgress({ fraction: 0, phase: 'decoding' });
+
+    const decoded = await this.dependencies.decodeAudio(await this.file.arrayBuffer());
+    validateDecodedAudio(decoded);
+    throwIfAborted(options.abortSignal);
+    options.onProgress({ fraction: 0, phase: 'streaming' });
+
+    const processor = new PcmFrameProcessor({ sourceSampleRate: decoded.sampleRate });
+
+    for (let offset = 0, chunkIndex = 0; offset < decoded.length; chunkIndex += 1) {
+      throwIfAborted(options.abortSignal);
+      const end = Math.min(offset + SOURCE_CHUNK_SAMPLES, decoded.length);
+      const channels = Array.from({ length: decoded.numberOfChannels }, (_, channel) =>
+        decoded.getChannelData(channel).subarray(offset, end),
+      );
+
+      for (const frame of processor.push(mixChannelsToMono(channels))) {
+        throwIfAborted(options.abortSignal);
+        await options.onFrame(encodePcm16Le(frame));
+      }
+
+      offset = end;
+      options.onProgress({ fraction: offset / decoded.length, phase: 'streaming' });
+      if ((chunkIndex + 1) % YIELD_EVERY_CHUNKS === 0) {
+        await this.dependencies.yieldToEventLoop();
+      }
+    }
+
+    const finalFrame = processor.finish();
+    if (finalFrame !== null) {
+      throwIfAborted(options.abortSignal);
+      await options.onFrame(encodePcm16Le(finalFrame));
+    }
+  }
+}
+
+export function validateAudioFile(file: Pick<AudioFileLike, 'name' | 'size'>): void {
+  const extension = file.name.slice(file.name.lastIndexOf('.')).toLowerCase();
+  if (extension !== '.mp3' && extension !== '.wav') {
+    throw new Error('Choose a WAV or MP3 audio file.');
+  }
+  if (!Number.isFinite(file.size) || file.size <= 0) {
+    throw new Error('The selected audio file is empty.');
+  }
+  if (file.size > MAX_AUDIO_FILE_BYTES) {
+    throw new Error('The selected audio file is larger than 256 MB.');
+  }
+}
+
+function validateDecodedAudio(decoded: DecodedAudio): void {
+  if (
+    !Number.isFinite(decoded.duration) ||
+    decoded.duration <= 0 ||
+    !Number.isInteger(decoded.length) ||
+    decoded.length <= 0 ||
+    !Number.isInteger(decoded.numberOfChannels) ||
+    decoded.numberOfChannels <= 0 ||
+    !Number.isFinite(decoded.sampleRate) ||
+    decoded.sampleRate <= 0
+  ) {
+    throw new Error('The selected audio file did not contain decodable audio.');
+  }
+  if (decoded.duration > MAX_AUDIO_FILE_DURATION_SECONDS) {
+    throw new Error('Choose an audio file that is 30 minutes or shorter.');
+  }
+}
+
+function encodePcm16Le(samples: Int16Array): Uint8Array {
+  const bytes = new Uint8Array(samples.length * Int16Array.BYTES_PER_ELEMENT);
+  const view = new DataView(bytes.buffer);
+  for (let index = 0; index < samples.length; index += 1) {
+    view.setInt16(index * Int16Array.BYTES_PER_ELEMENT, samples[index] ?? 0, true);
+  }
+  return bytes;
+}
+
+async function decodeWithWebAudio(encodedAudio: ArrayBuffer): Promise<DecodedAudio> {
+  if (window.AudioContext === undefined) {
+    throw new Error('Audio file decoding is not available in this Obsidian runtime.');
+  }
+
+  const context = new window.AudioContext();
+  try {
+    return await context.decodeAudioData(encodedAudio);
+  } catch (error) {
+    throw new Error('Obsidian could not decode this WAV or MP3 file.', { cause: error });
+  } finally {
+    await context.close().catch(() => {});
+  }
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (!signal.aborted) {
+    return;
+  }
+  const error = new Error('Audio file transcription was cancelled.');
+  error.name = 'AbortError';
+  throw error;
+}
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, 0));
+}

--- a/src/audio/audio-frame-flow-control.ts
+++ b/src/audio/audio-frame-flow-control.ts
@@ -1,0 +1,57 @@
+import type { QueueBackpressureTier } from '../sidecar/protocol';
+
+interface FlowWaiter {
+  abortSignal: AbortSignal;
+  onAbort: () => void;
+  resolve: () => void;
+}
+
+export class AudioFrameFlowControl {
+  private readonly waiters = new Set<FlowWaiter>();
+  private tier: QueueBackpressureTier = 'normal';
+
+  setTier(tier: QueueBackpressureTier): void {
+    this.tier = tier;
+    if (tier !== 'normal') {
+      return;
+    }
+
+    for (const waiter of [...this.waiters]) {
+      this.release(waiter);
+      waiter.resolve();
+    }
+  }
+
+  waitUntilReady(abortSignal: AbortSignal): Promise<void> {
+    if (abortSignal.aborted) {
+      return Promise.reject(createAbortError());
+    }
+    if (this.tier === 'normal') {
+      return Promise.resolve();
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      const waiter: FlowWaiter = {
+        abortSignal,
+        onAbort: () => {
+          this.release(waiter);
+          reject(createAbortError());
+        },
+        resolve,
+      };
+      this.waiters.add(waiter);
+      abortSignal.addEventListener('abort', waiter.onAbort, { once: true });
+    });
+  }
+
+  private release(waiter: FlowWaiter): void {
+    waiter.abortSignal.removeEventListener('abort', waiter.onAbort);
+    this.waiters.delete(waiter);
+  }
+}
+
+function createAbortError(): Error {
+  const error = new Error('Audio frame flow was cancelled.');
+  error.name = 'AbortError';
+  return error;
+}

--- a/src/audio/audio-frame-source.ts
+++ b/src/audio/audio-frame-source.ts
@@ -1,0 +1,12 @@
+export interface AudioFrameSourceProgress {
+  fraction: number;
+  phase: 'decoding' | 'streaming';
+}
+
+export interface AudioFrameSource {
+  stream(options: {
+    abortSignal: AbortSignal;
+    onFrame: (frameBytes: Uint8Array) => Promise<void>;
+    onProgress: (progress: AudioFrameSourceProgress) => void;
+  }): Promise<void>;
+}

--- a/src/audio/pcm-frame-processor.ts
+++ b/src/audio/pcm-frame-processor.ts
@@ -77,6 +77,18 @@ export class PcmFrameProcessor {
     return completedFrames;
   }
 
+  finish(): Int16Array | null {
+    if (this.frameOffset === 0) {
+      this.reset();
+      return null;
+    }
+
+    this.frameBuffer.fill(0, this.frameOffset);
+    const finalFrame = this.frameBuffer.slice();
+    this.reset();
+    return finalFrame;
+  }
+
   reset(): void {
     this.frameBuffer.fill(0);
     this.frameOffset = 0;

--- a/src/commands/register-commands.ts
+++ b/src/commands/register-commands.ts
@@ -9,6 +9,7 @@ const CLEAR_LAST_UTTERANCE_COMMAND_ID = 'clear-last-utterance';
 const RESTORE_RAW_TRANSCRIPT_COMMAND_ID = 'restore-raw-transcript';
 const COPY_RAW_TRANSCRIPT_COMMAND_ID = 'copy-raw-transcript';
 const CLEAR_RAW_RECOVERY_COMMAND_ID = 'clear-raw-transcript-recovery';
+const TRANSCRIBE_AUDIO_FILE_COMMAND_ID = 'transcribe-audio-file';
 
 interface CommandDependencies {
   cancelDictation: () => Promise<void>;
@@ -25,6 +26,7 @@ interface CommandDependencies {
   startDictation: () => Promise<void>;
   stopDictation: () => Promise<void>;
   toggleDictation: () => Promise<void>;
+  transcribeAudioFile: () => Promise<void>;
 }
 
 export function registerCommands(dependencies: CommandDependencies): void {
@@ -57,6 +59,14 @@ export function registerCommands(dependencies: CommandDependencies): void {
     name: 'Cancel dictation',
     callback: async () => {
       await dependencies.cancelDictation();
+    },
+  });
+
+  dependencies.plugin.addCommand({
+    id: TRANSCRIBE_AUDIO_FILE_COMMAND_ID,
+    name: 'Transcribe audio file',
+    callback: async () => {
+      await dependencies.transcribeAudioFile();
     },
   });
 

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { Platform } from 'obsidian';
 
 import type { AudioCaptureStream } from '../audio/audio-capture-stream';
+import { AudioFrameFlowControl } from '../audio/audio-frame-flow-control';
 import type { AudioFrameSource, AudioFrameSourceProgress } from '../audio/audio-frame-source';
 import { formatMicrophoneCaptureErrorMessage } from '../audio/microphone-permission-message';
 import type { SidecarAudioLevelMeter } from '../audio/sidecar-audio-level-meter';
@@ -104,6 +105,7 @@ type TerminalArbitrationState = 'open' | 'feedback-claimed' | 'cancelled';
 interface ManagedSession {
   anchorTimerId: number | null;
   audioSourceAbortController: AbortController | null;
+  audioFrameFlowControl: AudioFrameFlowControl;
   // Final revisions enter this FIFO so concurrent per-utterance cleanups land
   // in final-event order. Partials bypass it and project immediately.
   cleanupChain: Promise<void>;
@@ -347,6 +349,7 @@ export class DictationSessionController {
       await source.stream({
         abortSignal: abortController.signal,
         onFrame: async (frameBytes) => {
+          await entry.audioFrameFlowControl.waitUntilReady(abortController.signal);
           if (
             this.activeSessionId !== sessionId ||
             entry.phase !== 'active' ||
@@ -468,6 +471,7 @@ export class DictationSessionController {
 
     const entry: ManagedSession = {
       anchorTimerId: null,
+      audioFrameFlowControl: new AudioFrameFlowControl(),
       audioSourceAbortController: null,
       cleanupChain: Promise.resolve(),
       cleanupAbortControllers: new Set(),
@@ -834,6 +838,15 @@ export class DictationSessionController {
     const entry = this.sessions.get(event.sessionId);
     if (entry === undefined) {
       return;
+    }
+
+    entry.audioFrameFlowControl.setTier(event.tier);
+    if (entry.source === 'audio_file' && event.tier !== 'normal') {
+      this.dependencies.feedback.show({
+        intent: 'information',
+        key: 'audio-file-progress',
+        message: 'Waiting for the local engine to catch up…',
+      });
     }
 
     if (event.sessionId === this.activeSessionId) {

--- a/src/dictation/dictation-session-controller.ts
+++ b/src/dictation/dictation-session-controller.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { Platform } from 'obsidian';
 
 import type { AudioCaptureStream } from '../audio/audio-capture-stream';
+import type { AudioFrameSource, AudioFrameSourceProgress } from '../audio/audio-frame-source';
 import { formatMicrophoneCaptureErrorMessage } from '../audio/microphone-permission-message';
 import type { SidecarAudioLevelMeter } from '../audio/sidecar-audio-level-meter';
 import {
@@ -50,6 +51,7 @@ export type DictationControllerState =
   | 'starting'
   | 'listening'
   | 'speech_detected'
+  | 'processing_file'
   | 'error';
 
 type ControllerSession = Pick<
@@ -101,6 +103,7 @@ type TerminalArbitrationState = 'open' | 'feedback-claimed' | 'cancelled';
 
 interface ManagedSession {
   anchorTimerId: number | null;
+  audioSourceAbortController: AbortController | null;
   // Final revisions enter this FIFO so concurrent per-utterance cleanups land
   // in final-event order. Partials bypass it and project immediately.
   cleanupChain: Promise<void>;
@@ -110,6 +113,7 @@ interface ManagedSession {
   phase: SessionPhase;
   session: ControllerSession;
   snapshot: ActiveSessionSnapshot;
+  source: 'audio_file' | 'microphone';
   terminalArbitration: TerminalArbitrationState;
 }
 
@@ -149,6 +153,7 @@ interface DictationSessionControllerDependencies {
     | 'ensureStarted'
     | 'requestStopSession'
     | 'sendAudioFrame'
+    | 'sendAudioFrameWithBackpressure'
     | 'sendContextResponse'
     | 'startSession'
     | 'subscribe'
@@ -166,6 +171,10 @@ const FEEDBACK_FAILURES = {
   recordTranscript: {
     key: 'transcript-record-failed',
     message: 'Could not record the transcript.',
+  },
+  startAudioFile: {
+    key: 'audio-file-transcription-failed',
+    message: 'Could not transcribe the audio file.',
   },
   microphoneDisconnected: {
     key: 'microphone-capture-ended',
@@ -280,119 +289,14 @@ export class DictationSessionController {
   }
 
   async startDictation(): Promise<void> {
-    if (this.activeSessionId !== null || this.sessions.size >= MAX_CONTROLLER_SESSIONS) {
+    const started = await this.startManagedSession('microphone');
+    if (started === null) {
       return;
     }
-
-    this.applyUiState('starting');
-
-    const settings = this.dependencies.getSettings();
-    if (settings.selectedModel === null) {
-      this.dependencies.logger?.debug('session', 'no model selected; prompting model picker');
-      this.applyUiState('idle');
-      this.dependencies.onModelMissing?.();
-      return;
-    }
+    const { sessionId } = started;
 
     try {
-      await this.assertMicrophoneInputAvailable();
-    } catch (error) {
-      this.handleError(FEEDBACK_FAILURES.startDictation, error);
-      return;
-    }
-
-    try {
-      await this.dependencies.sidecarConnection.ensureStarted();
-    } catch (error) {
-      if (error instanceof SidecarNotInstalledError) {
-        this.dependencies.logger?.debug('sidecar', 'sidecar not installed; prompting install');
-        this.applyUiState('idle');
-        this.dependencies.onSidecarMissing?.();
-        return;
-      }
-      this.handleError(FEEDBACK_FAILURES.startDictation, error);
-      return;
-    }
-
-    const sessionId = createSessionId();
-    const snapshot = createSessionSnapshot(
-      settings,
-      settings.selectedModel,
-      this.dependencies.createLlmRouter(settings),
-    );
-    let session: ControllerSession;
-
-    try {
-      session = this.dependencies.createSession({
-        callbacks: {
-          onLockedNoteClosed: () => {
-            this.cancelOnLockedNoteEvent(sessionId, 'closed');
-          },
-          onLockedNoteDeleted: () => {
-            this.cancelOnLockedNoteEvent(sessionId, 'deleted');
-          },
-          onSurfaceDesynchronized: (failure) => {
-            this.cancelOnFatalTranscriptFailure(
-              sessionId,
-              FEEDBACK_FAILURES.surfaceDesynchronized,
-              failure,
-            );
-          },
-        },
-        placement: { anchor: snapshot.dictationAnchor },
-        rendererOptions: {
-          smartParagraphPauses: snapshot.smartParagraphPauses,
-          timestamps: snapshot.timestamps,
-          transcriptFormatting: snapshot.transcriptFormatting,
-        },
-        sessionId,
-      });
-    } catch (error) {
-      this.handleError(FEEDBACK_FAILURES.startDictation, error);
-      return;
-    }
-
-    const entry: ManagedSession = {
-      anchorTimerId: null,
-      cleanupChain: Promise.resolve(),
-      cleanupAbortControllers: new Set(),
-      llmFailureLogged: false,
-      pendingTranscriptWork: new Set(),
-      phase: 'starting',
-      session,
-      snapshot,
-      terminalArbitration: 'open',
-    };
-    this.sessions.set(sessionId, entry);
-    this.activeSessionId = sessionId;
-    this.dependencies.audioLevelMeter.bindSession(sessionId);
-    this.dependencies.logger?.debug('session', `starting dictation session ${sessionId}`);
-
-    try {
-      await this.dependencies.sidecarConnection.startSession({
-        accelerationPreference: snapshot.accelerationPreference,
-        diarizationEnabled: snapshot.diarizationEnabled,
-        includeSystemAudio: snapshot.includeSystemAudio,
-        language: 'en',
-        mode: snapshot.listeningMode,
-        modelSelection: snapshot.modelSelection,
-        sessionStartUnixMs: snapshot.sessionStartUnixMs,
-        sessionId,
-        speakingStyle: snapshot.speakingStyle,
-        ...(snapshot.modelStorePathOverride.length > 0
-          ? { modelStorePathOverride: snapshot.modelStorePathOverride }
-          : {}),
-      });
-
-      if (entry.phase !== 'starting' || this.activeSessionId !== sessionId) {
-        return;
-      }
-      entry.phase = 'active';
-
-      // Read the saved deviceId at session-start time so a settings change
-      // applies on the next dictation rather than mid-session.
       const audioInputDeviceId = this.dependencies.getSettings().audioInputDevice?.deviceId ?? null;
-
       await this.dependencies.captureStream.start(
         { sessionId, audioInputDeviceId },
         (frameSessionId, frameBytes) => {
@@ -428,6 +332,189 @@ export class DictationSessionController {
     }
   }
 
+  async transcribeAudioSource(source: AudioFrameSource): Promise<void> {
+    const started = await this.startManagedSession('audio_file');
+    if (started === null) {
+      return;
+    }
+    const { entry, sessionId } = started;
+    const abortController = new AbortController();
+    entry.audioSourceAbortController = abortController;
+    let lastProgressBucket = -1;
+    this.applyUiState('processing_file');
+
+    try {
+      await source.stream({
+        abortSignal: abortController.signal,
+        onFrame: async (frameBytes) => {
+          if (
+            this.activeSessionId !== sessionId ||
+            entry.phase !== 'active' ||
+            abortController.signal.aborted
+          ) {
+            return;
+          }
+          await this.dependencies.sidecarConnection.sendAudioFrameWithBackpressure(
+            sessionId,
+            frameBytes,
+          );
+        },
+        onProgress: (progress) => {
+          if (
+            this.activeSessionId === sessionId &&
+            entry.phase === 'active' &&
+            !abortController.signal.aborted
+          ) {
+            lastProgressBucket = this.reportAudioFileProgress(progress, lastProgressBucket);
+          }
+        },
+      });
+
+      if (this.activeSessionId !== sessionId || entry.phase !== 'active') {
+        return;
+      }
+      this.dependencies.feedback.show({
+        intent: 'information',
+        key: 'audio-file-progress',
+        message: 'Audio sent to the local engine. Finishing transcription…',
+      });
+      await this.stopDictation();
+    } catch (error) {
+      if (isAbortError(error) && abortController.signal.aborted) {
+        return;
+      }
+      this.handleError(
+        {
+          ...FEEDBACK_FAILURES.startAudioFile,
+          message: `${FEEDBACK_FAILURES.startAudioFile.message} ${formatErrorMessage(error)}`,
+        },
+        error,
+        entry,
+      );
+      await this.cancelSession(sessionId);
+    }
+  }
+
+  private async startManagedSession(
+    source: ManagedSession['source'],
+  ): Promise<{ entry: ManagedSession; sessionId: string } | null> {
+    if (this.activeSessionId !== null || this.sessions.size >= MAX_CONTROLLER_SESSIONS) {
+      return null;
+    }
+
+    const failure =
+      source === 'audio_file' ? FEEDBACK_FAILURES.startAudioFile : FEEDBACK_FAILURES.startDictation;
+    this.applyUiState('starting');
+    const settings = this.dependencies.getSettings();
+    if (settings.selectedModel === null) {
+      this.dependencies.logger?.debug('session', 'no model selected; prompting model picker');
+      this.applyUiState('idle');
+      this.dependencies.onModelMissing?.();
+      return null;
+    }
+
+    try {
+      if (source === 'microphone') {
+        await this.assertMicrophoneInputAvailable();
+      }
+      await this.dependencies.sidecarConnection.ensureStarted();
+    } catch (error) {
+      if (error instanceof SidecarNotInstalledError) {
+        this.dependencies.logger?.debug('sidecar', 'sidecar not installed; prompting install');
+        this.applyUiState('idle');
+        this.dependencies.onSidecarMissing?.();
+        return null;
+      }
+      this.handleError(failure, error);
+      return null;
+    }
+
+    const sessionId = createSessionId();
+    const snapshot = createSessionSnapshot(
+      settings,
+      settings.selectedModel,
+      this.dependencies.createLlmRouter(settings),
+    );
+    let session: ControllerSession;
+    try {
+      session = this.dependencies.createSession({
+        callbacks: {
+          onLockedNoteClosed: () => {
+            this.cancelOnLockedNoteEvent(sessionId, 'closed');
+          },
+          onLockedNoteDeleted: () => {
+            this.cancelOnLockedNoteEvent(sessionId, 'deleted');
+          },
+          onSurfaceDesynchronized: (surfaceFailure) => {
+            this.cancelOnFatalTranscriptFailure(
+              sessionId,
+              FEEDBACK_FAILURES.surfaceDesynchronized,
+              surfaceFailure,
+            );
+          },
+        },
+        placement: { anchor: snapshot.dictationAnchor },
+        rendererOptions: {
+          smartParagraphPauses: snapshot.smartParagraphPauses,
+          timestamps: snapshot.timestamps,
+          transcriptFormatting: snapshot.transcriptFormatting,
+        },
+        sessionId,
+      });
+    } catch (error) {
+      this.handleError(failure, error);
+      return null;
+    }
+
+    const entry: ManagedSession = {
+      anchorTimerId: null,
+      audioSourceAbortController: null,
+      cleanupChain: Promise.resolve(),
+      cleanupAbortControllers: new Set(),
+      llmFailureLogged: false,
+      pendingTranscriptWork: new Set(),
+      phase: 'starting',
+      session,
+      snapshot,
+      source,
+      terminalArbitration: 'open',
+    };
+    this.sessions.set(sessionId, entry);
+    this.activeSessionId = sessionId;
+    if (source === 'microphone') {
+      this.dependencies.audioLevelMeter.bindSession(sessionId);
+    }
+    this.dependencies.logger?.debug(
+      'session',
+      `starting ${source === 'microphone' ? 'dictation' : 'audio file'} session ${sessionId}`,
+    );
+
+    try {
+      await this.dependencies.sidecarConnection.startSession({
+        accelerationPreference: snapshot.accelerationPreference,
+        diarizationEnabled: snapshot.diarizationEnabled,
+        includeSystemAudio: source === 'microphone' && snapshot.includeSystemAudio,
+        language: 'en',
+        mode: source === 'audio_file' ? 'always_on' : snapshot.listeningMode,
+        modelSelection: snapshot.modelSelection,
+        sessionStartUnixMs: snapshot.sessionStartUnixMs,
+        sessionId,
+        speakingStyle: snapshot.speakingStyle,
+        ...(snapshot.modelStorePathOverride.length > 0
+          ? { modelStorePathOverride: snapshot.modelStorePathOverride }
+          : {}),
+      });
+      if (entry.phase !== 'starting' || this.activeSessionId !== sessionId) {
+        return null;
+      }
+      entry.phase = 'active';
+      return { entry, sessionId };
+    } catch (error) {
+      await this.cleanupFailedStart(sessionId, error, failure);
+      return null;
+    }
+  }
+
   async stopDictation(): Promise<void> {
     const sessionId = this.activeSessionId;
 
@@ -442,6 +529,7 @@ export class DictationSessionController {
 
     const entry = this.sessions.get(sessionId);
     if (entry !== undefined) {
+      entry.audioSourceAbortController?.abort();
       entry.phase = 'stopping';
       // Keep the cursor where text will land while queued transcripts drain.
       // It is cleared when the session is finally disposed (after the drain),
@@ -480,7 +568,11 @@ export class DictationSessionController {
     await this.stopDictation();
   }
 
-  private async cleanupFailedStart(sessionId: string, error: unknown): Promise<void> {
+  private async cleanupFailedStart(
+    sessionId: string,
+    error: unknown,
+    failure: FeedbackFailure = FEEDBACK_FAILURES.startDictation,
+  ): Promise<void> {
     const entry = this.sessions.get(sessionId);
     if (entry === undefined) {
       if (this.activeSessionId === sessionId) {
@@ -496,7 +588,7 @@ export class DictationSessionController {
       return;
     }
 
-    this.handleError(FEEDBACK_FAILURES.startDictation, error, entry);
+    this.handleError(failure, error, entry);
     if (entry.phase === 'starting') {
       this.disposeLocalSession(sessionId);
     } else {
@@ -534,6 +626,7 @@ export class DictationSessionController {
     // duplicate cancellation commands to the sidecar.
     entry.terminalArbitration = 'cancelled';
     entry.phase = 'cancelling';
+    entry.audioSourceAbortController?.abort();
     this.abortProviderCleanups(entry);
     const cancellation = Promise.resolve().then(() => this.completeSessionCancellation(sessionId));
     this.cancellationPromises.set(sessionId, cancellation);
@@ -609,6 +702,7 @@ export class DictationSessionController {
     }
 
     this.clearAnchorTimer(entry);
+    entry.audioSourceAbortController?.abort();
     this.abortProviderCleanups(entry);
     entry.session.clearSessionProcessingMark();
     entry.session.dispose();
@@ -713,6 +807,15 @@ export class DictationSessionController {
     }
 
     this.applySessionStateToAnchor(entry, event.state);
+
+    if (
+      entry.source === 'audio_file' &&
+      event.sessionId === this.activeSessionId &&
+      entry.phase === 'active'
+    ) {
+      this.applyUiState('processing_file');
+      return;
+    }
 
     const audioActive = this.dependencies.captureStream.isCapturing();
     if (event.sessionId !== this.activeSessionId || entry.phase !== 'active' || !audioActive) {
@@ -1085,7 +1188,7 @@ export class DictationSessionController {
       return;
     }
     const entry = this.sessions.get(event.sessionId);
-    if (entry === undefined || entry.phase !== 'active') {
+    if (entry === undefined || entry.phase !== 'active' || entry.source !== 'microphone') {
       return;
     }
     this.dependencies.audioLevelMeter.update(event);
@@ -1485,6 +1588,34 @@ export class DictationSessionController {
       this.applyUiState('error');
     }
   }
+
+  private reportAudioFileProgress(
+    progress: AudioFrameSourceProgress,
+    previousBucket: number,
+  ): number {
+    if (progress.phase === 'decoding') {
+      this.dependencies.feedback.show({
+        intent: 'information',
+        key: 'audio-file-progress',
+        message: 'Decoding WAV/MP3 audio locally…',
+      });
+      return -1;
+    }
+
+    const normalizedFraction = Number.isFinite(progress.fraction)
+      ? Math.max(0, Math.min(1, progress.fraction))
+      : 0;
+    const bucket = Math.floor(normalizedFraction * 10) * 10;
+    if (bucket === previousBucket) {
+      return previousBucket;
+    }
+    this.dependencies.feedback.show({
+      intent: 'information',
+      key: 'audio-file-progress',
+      message: `Sending decoded audio to the local engine… ${bucket}%`,
+    });
+    return bucket;
+  }
 }
 
 function createSessionId(): string {
@@ -1493,6 +1624,10 @@ function createSessionId(): string {
 
 function isCapacityExceededStartError(error: unknown): boolean {
   return error instanceof SidecarError && error.code === 'session_capacity_exceeded';
+}
+
+function isAbortError(error: unknown): boolean {
+  return (error as { name?: unknown } | null)?.name === 'AbortError';
 }
 
 async function countBrowserAudioInputDevices(): Promise<number | null> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,10 @@ import { IS_PRODUCTION_BUILD } from 'virtual:build-mode';
 import { FileSystemAdapter, Platform, Plugin } from 'obsidian';
 
 import { AudioCaptureStream } from './audio/audio-capture-stream';
+import {
+  describeAudioFileModelRequirement,
+  resolveAudioFileModelSupport,
+} from './audio/audio-file-model-support';
 import { pickAudioFile } from './audio/audio-file-picker';
 import { AudioFileFrameSource } from './audio/audio-file-source';
 import { SidecarAudioLevelMeter } from './audio/sidecar-audio-level-meter';
@@ -428,6 +432,27 @@ export default class LocalSttPlugin extends Plugin {
         intent: 'warning',
         key: 'audio-file-busy',
         message: 'Stop or cancel the current transcription before choosing an audio file.',
+      });
+      return;
+    }
+
+    const modelSupport = resolveAudioFileModelSupport(this.settings);
+    if (modelSupport.kind === 'model_required') {
+      await this.openModelPicker();
+      return;
+    }
+    if (modelSupport.kind !== 'supported') {
+      const requirement = describeAudioFileModelRequirement(modelSupport);
+      this.feedback.show({
+        action: {
+          label: requirement.actionLabel,
+          run: () => {
+            void this.openModelPicker();
+          },
+        },
+        intent: 'action-required',
+        key: 'audio-file-model-required',
+        message: requirement.message,
       });
       return;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,8 @@ import { IS_PRODUCTION_BUILD } from 'virtual:build-mode';
 import { FileSystemAdapter, Platform, Plugin } from 'obsidian';
 
 import { AudioCaptureStream } from './audio/audio-capture-stream';
+import { pickAudioFile } from './audio/audio-file-picker';
+import { AudioFileFrameSource } from './audio/audio-file-source';
 import { SidecarAudioLevelMeter } from './audio/sidecar-audio-level-meter';
 import { registerCommands } from './commands/register-commands';
 import { DictationSessionController } from './dictation/dictation-session-controller';
@@ -34,6 +36,7 @@ import {
   type SidecarInstallActionDeps,
 } from './settings/sidecar-settings-section';
 import { SetupWizardModal } from './setup/setup-wizard-modal';
+import { formatErrorMessage } from './shared/format-utils';
 import { createObsidianFeedbackPresenter } from './shared/obsidian-feedback-presenter';
 import { createPluginLogger, type PluginLogger } from './shared/plugin-logger';
 import { createUserFeedback, type UserFeedback } from './shared/user-feedback';
@@ -172,6 +175,9 @@ export default class LocalSttPlugin extends Plugin {
     const ribbonElement = this.addRibbonIcon('mic', 'Local Dictation — start dictation', () => {
       void this.requireDictationController().toggleDictation();
     });
+    this.addRibbonIcon('file-audio', 'Local Dictation — transcribe audio file', () => {
+      void this.transcribeAudioFile();
+    });
     this.ribbonController = new DictationRibbonController(ribbonElement);
     this.ribbonController.setVisualizer(this.audioLevelMeter);
     this.dictationController = new DictationSessionController({
@@ -281,6 +287,7 @@ export default class LocalSttPlugin extends Plugin {
       startDictation: async () => this.requireDictationController().startDictation(),
       stopDictation: async () => this.requireDictationController().stopDictation(),
       toggleDictation: async () => this.requireDictationController().toggleDictation(),
+      transcribeAudioFile: async () => this.transcribeAudioFile(),
     });
 
     this.app.workspace.onLayoutReady(() => {
@@ -412,6 +419,45 @@ export default class LocalSttPlugin extends Plugin {
         void this.openSetupWizard();
       },
     }).open();
+  }
+
+  private async transcribeAudioFile(): Promise<void> {
+    const controller = this.requireDictationController();
+    if (controller.isBusy()) {
+      this.feedback.show({
+        intent: 'warning',
+        key: 'audio-file-busy',
+        message: 'Stop or cancel the current transcription before choosing an audio file.',
+      });
+      return;
+    }
+
+    const file = await pickAudioFile();
+    if (file === null) {
+      return;
+    }
+    if (controller.isBusy()) {
+      this.feedback.show({
+        intent: 'warning',
+        key: 'audio-file-busy',
+        message: 'Another transcription started while the file picker was open.',
+      });
+      return;
+    }
+
+    let source: AudioFileFrameSource;
+    try {
+      source = new AudioFileFrameSource(file);
+    } catch (error) {
+      this.feedback.show({
+        cause: error,
+        intent: 'error',
+        key: 'audio-file-invalid',
+        message: formatErrorMessage(error),
+      });
+      return;
+    }
+    await controller.transcribeAudioSource(source);
   }
 
   private async isSidecarInstalled(): Promise<boolean> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -436,24 +436,7 @@ export default class LocalSttPlugin extends Plugin {
       return;
     }
 
-    const modelSupport = resolveAudioFileModelSupport(this.settings);
-    if (modelSupport.kind === 'model_required') {
-      await this.openModelPicker();
-      return;
-    }
-    if (modelSupport.kind !== 'supported') {
-      const requirement = describeAudioFileModelRequirement(modelSupport);
-      this.feedback.show({
-        action: {
-          label: requirement.actionLabel,
-          run: () => {
-            void this.openModelPicker();
-          },
-        },
-        intent: 'action-required',
-        key: 'audio-file-model-required',
-        message: requirement.message,
-      });
+    if (!(await this.ensureAudioFileModelSupported())) {
       return;
     }
 
@@ -467,6 +450,9 @@ export default class LocalSttPlugin extends Plugin {
         key: 'audio-file-busy',
         message: 'Another transcription started while the file picker was open.',
       });
+      return;
+    }
+    if (!(await this.ensureAudioFileModelSupported())) {
       return;
     }
 
@@ -483,6 +469,31 @@ export default class LocalSttPlugin extends Plugin {
       return;
     }
     await controller.transcribeAudioSource(source);
+  }
+
+  private async ensureAudioFileModelSupported(): Promise<boolean> {
+    const modelSupport = resolveAudioFileModelSupport(this.settings);
+    if (modelSupport.kind === 'supported') {
+      return true;
+    }
+    if (modelSupport.kind === 'model_required') {
+      await this.openModelPicker();
+      return false;
+    }
+
+    const requirement = describeAudioFileModelRequirement(modelSupport);
+    this.feedback.show({
+      action: {
+        label: requirement.actionLabel,
+        run: () => {
+          void this.openModelPicker();
+        },
+      },
+      intent: 'action-required',
+      key: 'audio-file-model-required',
+      message: requirement.message,
+    });
+    return false;
   }
 
   private async isSidecarInstalled(): Promise<boolean> {

--- a/src/sidecar/sidecar-connection.ts
+++ b/src/sidecar/sidecar-connection.ts
@@ -71,6 +71,7 @@ interface SidecarProcessLike {
   start(): Promise<void>;
   stop(): Promise<void>;
   write(frameBytes: Uint8Array): void;
+  writeWithBackpressure(frameBytes: Uint8Array): Promise<void>;
 }
 
 interface SidecarConnectionOptions {
@@ -314,6 +315,10 @@ export class SidecarConnection {
 
   sendAudioFrame(sessionId: string, frameBytes: Uint8Array): void {
     this.process.write(encodeAudioFrame(sessionId, frameBytes));
+  }
+
+  async sendAudioFrameWithBackpressure(sessionId: string, frameBytes: Uint8Array): Promise<void> {
+    await this.process.writeWithBackpressure(encodeAudioFrame(sessionId, frameBytes));
   }
 
   sendContextResponse(correlationId: string, context: ContextWindow | null): void {

--- a/src/sidecar/sidecar-process.ts
+++ b/src/sidecar/sidecar-process.ts
@@ -121,13 +121,46 @@ export class SidecarProcess {
   }
 
   write(frameBytes: Uint8Array): void {
-    const child = this.child;
+    this.requireWritableChild().stdin.write(frameBytes);
+  }
 
+  async writeWithBackpressure(frameBytes: Uint8Array): Promise<void> {
+    const child = this.requireWritableChild();
+    if (child.stdin.write(frameBytes)) {
+      return;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const cleanup = (): void => {
+        child.stdin.off('drain', onDrain);
+        child.stdin.off('error', onError);
+        child.off('exit', onExit);
+      };
+      const onDrain = (): void => {
+        cleanup();
+        resolve();
+      };
+      const onError = (error: Error): void => {
+        cleanup();
+        reject(error);
+      };
+      const onExit = (): void => {
+        cleanup();
+        reject(new Error('Sidecar process exited before its audio buffer drained.'));
+      };
+
+      child.stdin.once('drain', onDrain);
+      child.stdin.once('error', onError);
+      child.once('exit', onExit);
+    });
+  }
+
+  private requireWritableChild(): ChildProcessWithoutNullStreams {
+    const child = this.child;
     if (child === null || this.stdinDead || !child.stdin.writable) {
       throw new Error('Sidecar process is not running.');
     }
-
-    child.stdin.write(frameBytes);
+    return child;
   }
 
   private disposeReaders(): void {

--- a/src/ui/dictation-ribbon.ts
+++ b/src/ui/dictation-ribbon.ts
@@ -232,6 +232,8 @@ function iconForState(state: DictationControllerState): RibbonIcon {
     case 'listening':
     case 'speech_detected':
       return 'audio-lines';
+    case 'processing_file':
+      return 'loader';
     case 'error':
       return 'mic-off';
     default:
@@ -249,6 +251,8 @@ function buildRibbonLabel(state: DictationControllerState): string {
       return 'Local Dictation — listening';
     case 'speech_detected':
       return 'Local Dictation — hearing speech';
+    case 'processing_file':
+      return 'Local Dictation — transcribing audio file';
     case 'error':
       return 'Local Dictation — error';
     default:

--- a/styles.css
+++ b/styles.css
@@ -388,6 +388,16 @@
   animation-delay: 1.05s;
 }
 
+.side-dock-ribbon-action[data-local-stt-state="processing_file"] > svg {
+  animation: local-stt-processing-spin 1.2s linear infinite;
+}
+
+@keyframes local-stt-processing-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .side-dock-ribbon-action[data-local-stt-state="listening"] > svg {
   opacity: 0.45;
 }

--- a/test/audio-file-model-support.test.ts
+++ b/test/audio-file-model-support.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  describeAudioFileModelRequirement,
+  resolveAudioFileModelSupport,
+} from '../src/audio/audio-file-model-support';
+import type { EngineCapabilitiesRecord, SelectedModel } from '../src/models/model-management-types';
+
+const WHISPER_SELECTION: SelectedModel = {
+  familyId: 'whisper',
+  filePath: '/models/whisper.bin',
+  kind: 'external_file',
+  runtimeId: 'whisper_cpp',
+};
+
+function capabilities(supportsStreaming: boolean): EngineCapabilitiesRecord {
+  return {
+    family: {
+      maxAudioDurationSecs: null,
+      producesPunctuation: true,
+      supportedLanguages: { kind: 'english_only' },
+      supportsInitialPrompt: true,
+      supportsLanguageSelection: false,
+      supportsSegmentTimestamps: true,
+      supportsStreaming,
+      supportsWordTimestamps: true,
+    },
+    familyId: supportsStreaming ? 'moonshine' : 'whisper',
+    runtime: {
+      acceleratorDetails: {},
+      availableAccelerators: ['cpu'],
+      supportedModelFormats: [supportsStreaming ? 'onnx' : 'ggml'],
+    },
+    runtimeId: supportsStreaming ? 'onnx_runtime' : 'whisper_cpp',
+  };
+}
+
+describe('audio file model support', () => {
+  it('requires a model before the file picker can open', () => {
+    expect(
+      resolveAudioFileModelSupport({
+        selectedModel: null,
+        selectedModelCapabilitiesSnapshot: null,
+      }),
+    ).toEqual({ kind: 'model_required' });
+  });
+
+  it('accepts a matching batch-model capability snapshot', () => {
+    expect(
+      resolveAudioFileModelSupport({
+        selectedModel: WHISPER_SELECTION,
+        selectedModelCapabilitiesSnapshot: {
+          capabilities: capabilities(false),
+          selection: WHISPER_SELECTION,
+        },
+      }),
+    ).toEqual({ kind: 'supported' });
+  });
+
+  it('rejects a stale snapshot even when its capabilities would be supported', () => {
+    const support = resolveAudioFileModelSupport({
+      selectedModel: WHISPER_SELECTION,
+      selectedModelCapabilitiesSnapshot: {
+        capabilities: capabilities(false),
+        selection: { ...WHISPER_SELECTION, filePath: '/models/old.bin' },
+      },
+    });
+
+    expect(support).toEqual({ kind: 'capabilities_unavailable' });
+    if (support.kind === 'capabilities_unavailable') {
+      expect(describeAudioFileModelRequirement(support).actionLabel).toBe('Manage models');
+    }
+  });
+
+  it('rejects streaming models with actionable batch-model guidance', () => {
+    const moonshine: SelectedModel = {
+      familyId: 'moonshine',
+      filePath: '/models/moonshine.onnx',
+      kind: 'external_file',
+      runtimeId: 'onnx_runtime',
+    };
+    const support = resolveAudioFileModelSupport({
+      selectedModel: moonshine,
+      selectedModelCapabilitiesSnapshot: {
+        capabilities: capabilities(true),
+        selection: moonshine,
+      },
+    });
+
+    expect(support).toEqual({ kind: 'streaming_unsupported' });
+    if (support.kind === 'streaming_unsupported') {
+      const requirement = describeAudioFileModelRequirement(support);
+      expect(requirement.actionLabel).toBe('Choose a batch model');
+      expect(requirement.message).toMatch(/Whisper or Cohere Transcribe/u);
+    }
+  });
+});

--- a/test/audio-file-source.test.ts
+++ b/test/audio-file-source.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  AudioFileFrameSource,
+  MAX_AUDIO_FILE_BYTES,
+  MAX_AUDIO_FILE_DURATION_SECONDS,
+  validateAudioFile,
+} from '../src/audio/audio-file-source';
+import { PCM_BYTES_PER_FRAME } from '../src/shared/pcm-format';
+
+function createDecodedAudio(
+  options: { channels?: Float32Array[]; duration?: number; sampleRate?: number } = {},
+) {
+  const channels = options.channels ?? [new Float32Array(320).fill(0.5)];
+  const sampleRate = options.sampleRate ?? 16_000;
+  return {
+    duration: options.duration ?? (channels[0]?.length ?? 0) / sampleRate,
+    getChannelData: (channel: number) => channels[channel] ?? new Float32Array(),
+    length: channels[0]?.length ?? 0,
+    numberOfChannels: channels.length,
+    sampleRate,
+  };
+}
+
+function createFile(overrides: { name?: string; size?: number } = {}) {
+  return {
+    arrayBuffer: vi.fn(async () => new ArrayBuffer(8)),
+    name: overrides.name ?? 'recording.wav',
+    size: overrides.size ?? 8,
+  };
+}
+
+describe('AudioFileFrameSource', () => {
+  it('mixes channels, emits fixed little-endian PCM frames, and reports progress', async () => {
+    const left = new Float32Array(320).fill(1);
+    const right = new Float32Array(320).fill(0);
+    const onFrame = vi.fn(async (_frame: Uint8Array) => {});
+    const onProgress = vi.fn();
+    const source = new AudioFileFrameSource(createFile(), {
+      decodeAudio: vi.fn(async () => createDecodedAudio({ channels: [left, right] })),
+      yieldToEventLoop: vi.fn(async () => {}),
+    });
+
+    await source.stream({
+      abortSignal: new AbortController().signal,
+      onFrame,
+      onProgress,
+    });
+
+    expect(onFrame).toHaveBeenCalledOnce();
+    const frame = onFrame.mock.calls[0]?.[0];
+    expect(frame).toHaveLength(PCM_BYTES_PER_FRAME);
+    expect(new DataView(frame?.buffer ?? new ArrayBuffer(0)).getInt16(0, true)).toBe(16_384);
+    expect(onProgress).toHaveBeenNthCalledWith(1, { fraction: 0, phase: 'decoding' });
+    expect(onProgress).toHaveBeenLastCalledWith({ fraction: 1, phase: 'streaming' });
+  });
+
+  it('pads short decoded audio to one complete sidecar frame', async () => {
+    const onFrame = vi.fn(async (_frame: Uint8Array) => {});
+    const source = new AudioFileFrameSource(createFile(), {
+      decodeAudio: vi.fn(async () =>
+        createDecodedAudio({ channels: [new Float32Array(100).fill(-1)] }),
+      ),
+      yieldToEventLoop: vi.fn(async () => {}),
+    });
+
+    await source.stream({
+      abortSignal: new AbortController().signal,
+      onFrame,
+      onProgress: vi.fn(),
+    });
+
+    const frame = onFrame.mock.calls[0]?.[0];
+    const view = new DataView(frame?.buffer ?? new ArrayBuffer(0));
+    expect(frame).toHaveLength(PCM_BYTES_PER_FRAME);
+    expect(view.getInt16(0, true)).toBe(-32_768);
+    expect(view.getInt16(200, true)).toBe(0);
+  });
+
+  it('stops before sending another frame after cancellation', async () => {
+    const abortController = new AbortController();
+    const onFrame = vi.fn(async () => {
+      abortController.abort();
+    });
+    const source = new AudioFileFrameSource(createFile(), {
+      decodeAudio: vi.fn(async () =>
+        createDecodedAudio({ channels: [new Float32Array(640).fill(0.25)] }),
+      ),
+      yieldToEventLoop: vi.fn(async () => {}),
+    });
+
+    await expect(
+      source.stream({
+        abortSignal: abortController.signal,
+        onFrame,
+        onProgress: vi.fn(),
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(onFrame).toHaveBeenCalledOnce();
+  });
+
+  it('rejects unsupported, empty, oversized, and overlong inputs', async () => {
+    expect(() => validateAudioFile(createFile({ name: 'clip.m4a' }))).toThrow(/WAV or MP3/u);
+    expect(() => validateAudioFile(createFile({ size: 0 }))).toThrow(/empty/u);
+    expect(() => validateAudioFile(createFile({ size: MAX_AUDIO_FILE_BYTES + 1 }))).toThrow(
+      /larger than 256 MB/u,
+    );
+
+    const source = new AudioFileFrameSource(createFile(), {
+      decodeAudio: vi.fn(async () =>
+        createDecodedAudio({ duration: MAX_AUDIO_FILE_DURATION_SECONDS + 1 }),
+      ),
+      yieldToEventLoop: vi.fn(async () => {}),
+    });
+    await expect(
+      source.stream({
+        abortSignal: new AbortController().signal,
+        onFrame: vi.fn(async () => {}),
+        onProgress: vi.fn(),
+      }),
+    ).rejects.toThrow(/30 minutes or shorter/u);
+  });
+});

--- a/test/audio-file-source.test.ts
+++ b/test/audio-file-source.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   AudioFileFrameSource,
+  type AudioFileLike,
   MAX_AUDIO_FILE_BYTES,
   MAX_AUDIO_FILE_DURATION_SECONDS,
+  probeAudioDuration,
   validateAudioFile,
 } from '../src/audio/audio-file-source';
 import { PCM_BYTES_PER_FRAME } from '../src/shared/pcm-format';
@@ -22,12 +24,10 @@ function createDecodedAudio(
   };
 }
 
-function createFile(overrides: { name?: string; size?: number } = {}) {
-  return {
-    arrayBuffer: vi.fn(async () => new ArrayBuffer(8)),
+function createFile(overrides: { name?: string; size?: number } = {}): AudioFileLike {
+  return Object.assign(new Blob([new Uint8Array(overrides.size ?? 8)]), {
     name: overrides.name ?? 'recording.wav',
-    size: overrides.size ?? 8,
-  };
+  });
 }
 
 describe('AudioFileFrameSource', () => {
@@ -38,6 +38,7 @@ describe('AudioFileFrameSource', () => {
     const onProgress = vi.fn();
     const source = new AudioFileFrameSource(createFile(), {
       decodeAudio: vi.fn(async () => createDecodedAudio({ channels: [left, right] })),
+      probeDuration: vi.fn(async () => 1),
       yieldToEventLoop: vi.fn(async () => {}),
     });
 
@@ -61,6 +62,7 @@ describe('AudioFileFrameSource', () => {
       decodeAudio: vi.fn(async () =>
         createDecodedAudio({ channels: [new Float32Array(100).fill(-1)] }),
       ),
+      probeDuration: vi.fn(async () => 1),
       yieldToEventLoop: vi.fn(async () => {}),
     });
 
@@ -86,6 +88,7 @@ describe('AudioFileFrameSource', () => {
       decodeAudio: vi.fn(async () =>
         createDecodedAudio({ channels: [new Float32Array(640).fill(0.25)] }),
       ),
+      probeDuration: vi.fn(async () => 1),
       yieldToEventLoop: vi.fn(async () => {}),
     });
 
@@ -100,16 +103,18 @@ describe('AudioFileFrameSource', () => {
   });
 
   it('rejects unsupported, empty, oversized, and overlong inputs', async () => {
-    expect(() => validateAudioFile(createFile({ name: 'clip.m4a' }))).toThrow(/WAV or MP3/u);
-    expect(() => validateAudioFile(createFile({ size: 0 }))).toThrow(/empty/u);
-    expect(() => validateAudioFile(createFile({ size: MAX_AUDIO_FILE_BYTES + 1 }))).toThrow(
+    expect(() => validateAudioFile({ name: 'clip.m4a', size: 8 })).toThrow(/WAV or MP3/u);
+    expect(() => validateAudioFile({ name: 'clip.wav', size: 0 })).toThrow(/empty/u);
+    expect(() => validateAudioFile({ name: 'clip.mp3', size: MAX_AUDIO_FILE_BYTES + 1 })).toThrow(
       /larger than 256 MB/u,
     );
 
-    const source = new AudioFileFrameSource(createFile(), {
-      decodeAudio: vi.fn(async () =>
-        createDecodedAudio({ duration: MAX_AUDIO_FILE_DURATION_SECONDS + 1 }),
-      ),
+    const file = createFile();
+    const arrayBuffer = vi.spyOn(file, 'arrayBuffer');
+    const decodeAudio = vi.fn(async () => createDecodedAudio());
+    const source = new AudioFileFrameSource(file, {
+      decodeAudio,
+      probeDuration: vi.fn(async () => MAX_AUDIO_FILE_DURATION_SECONDS + 1),
       yieldToEventLoop: vi.fn(async () => {}),
     });
     await expect(
@@ -119,5 +124,59 @@ describe('AudioFileFrameSource', () => {
         onProgress: vi.fn(),
       }),
     ).rejects.toThrow(/30 minutes or shorter/u);
+    expect(arrayBuffer).not.toHaveBeenCalled();
+    expect(decodeAudio).not.toHaveBeenCalled();
+  });
+});
+
+class FakeMetadataAudio extends EventTarget {
+  duration = 12;
+  preload = '';
+  src = '';
+  readonly load = vi.fn();
+  readonly pause = vi.fn();
+  readonly removeAttribute = vi.fn((name: string) => {
+    if (name === 'src') this.src = '';
+  });
+}
+
+describe('probeAudioDuration', () => {
+  it('reads metadata without the file buffer and always releases the object URL', async () => {
+    const file = createFile();
+    const audio = new FakeMetadataAudio();
+    audio.load.mockImplementationOnce(() => {
+      queueMicrotask(() => audio.dispatchEvent(new Event('loadedmetadata')));
+    });
+    const revokeObjectUrl = vi.fn();
+
+    await expect(
+      probeAudioDuration(file, new AbortController().signal, {
+        createAudioElement: () => audio as unknown as HTMLAudioElement,
+        createObjectUrl: () => 'blob:recording',
+        revokeObjectUrl,
+      }),
+    ).resolves.toBe(12);
+
+    expect(audio.src).toBe('');
+    expect(audio.pause).toHaveBeenCalledOnce();
+    expect(revokeObjectUrl).toHaveBeenCalledWith('blob:recording');
+  });
+
+  it('releases the metadata probe immediately when cancelled', async () => {
+    const file = createFile();
+    const audio = new FakeMetadataAudio();
+    const abortController = new AbortController();
+    const revokeObjectUrl = vi.fn();
+
+    const probing = probeAudioDuration(file, abortController.signal, {
+      createAudioElement: () => audio as unknown as HTMLAudioElement,
+      createObjectUrl: () => 'blob:recording',
+      revokeObjectUrl,
+    });
+    abortController.abort();
+
+    await expect(probing).rejects.toMatchObject({ name: 'AbortError' });
+    expect(audio.pause).toHaveBeenCalledOnce();
+    expect(revokeObjectUrl).toHaveBeenCalledWith('blob:recording');
   });
 });

--- a/test/audio-frame-flow-control.test.ts
+++ b/test/audio-frame-flow-control.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { AudioFrameFlowControl } from '../src/audio/audio-frame-flow-control';
+
+describe('AudioFrameFlowControl', () => {
+  it('pauses at catching-up or worse and resumes only when the queue is normal', async () => {
+    const flow = new AudioFrameFlowControl();
+    flow.setTier('catching_up');
+
+    let resumed = false;
+    const waiting = flow.waitUntilReady(new AbortController().signal).then(() => {
+      resumed = true;
+    });
+    await Promise.resolve();
+    expect(resumed).toBe(false);
+
+    flow.setTier('falling_behind');
+    flow.setTier('catching_up');
+    await Promise.resolve();
+    expect(resumed).toBe(false);
+
+    flow.setTier('normal');
+    await waiting;
+    expect(resumed).toBe(true);
+  });
+
+  it('releases a paused producer through abort without waiting for a queue event', async () => {
+    const flow = new AudioFrameFlowControl();
+    const abortController = new AbortController();
+    flow.setTier('saturated');
+
+    const waiting = flow.waitUntilReady(abortController.signal);
+    abortController.abort();
+
+    await expect(waiting).rejects.toMatchObject({ name: 'AbortError' });
+  });
+});

--- a/test/dictation-ribbon.test.ts
+++ b/test/dictation-ribbon.test.ts
@@ -188,6 +188,18 @@ describe('DictationRibbonController paintIcon', () => {
     controller.setState('speech_detected');
     controller.setState('error');
     expect(setIcon).toHaveBeenLastCalledWith(expect.anything(), 'mic-off');
+
+    controller.setState('processing_file');
+    expect(setIcon).toHaveBeenLastCalledWith(expect.anything(), 'loader');
+  });
+
+  it('announces file transcription without implying the microphone is listening', () => {
+    const { controller, element } = makeController();
+
+    controller.setState('processing_file');
+
+    expect(element.attributes['aria-label']).toBe('Local Dictation — transcribing audio file');
+    expect(element.title).toBe('Local Dictation — transcribing audio file');
   });
 
   it('does not call setIcon when entering the animated speech state', () => {

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { AudioFrameSource } from '../src/audio/audio-frame-source';
 import { formatMicrophonePermissionDeniedMessage } from '../src/audio/microphone-permission-message';
 import {
   type DictationControllerState,
@@ -128,6 +129,9 @@ class FakeSidecarConnection {
   public readonly listeners = new Set<(event: SidecarEvent) => void>();
   public readonly requestStopSession = vi.fn((_sessionId: string) => {});
   public readonly sendAudioFrame = vi.fn((_sessionId: string, _frameBytes: Uint8Array) => {});
+  public readonly sendAudioFrameWithBackpressure = vi.fn(
+    async (_sessionId: string, _frameBytes: Uint8Array) => {},
+  );
   public readonly sendContextResponse = vi.fn(
     (_correlationId: string, _context: ContextWindow | null) => {},
   );
@@ -226,6 +230,118 @@ describe('DictationSessionController', () => {
 
     expect(sidecarConnection.sendAudioFrame).toHaveBeenCalledWith(startPayload?.sessionId, frame);
     expect(controller.getState()).toBe('listening');
+  });
+
+  it('streams an audio file through the existing sidecar session without microphone capture', async () => {
+    const captureStream = new FakeCaptureStream();
+    const feedback = { show: vi.fn() };
+    const sidecarConnection = new FakeSidecarConnection();
+    const source: AudioFrameSource = {
+      stream: vi.fn(async ({ onFrame, onProgress }) => {
+        onProgress({ fraction: 0, phase: 'decoding' });
+        onProgress({ fraction: 0.5, phase: 'streaming' });
+        await onFrame(new Uint8Array(640).fill(4));
+        onProgress({ fraction: 1, phase: 'streaming' });
+      }),
+    };
+    const controller = createController({
+      captureStream,
+      feedback,
+      getSettings: () =>
+        createSettings({
+          includeSystemAudio: true,
+          listeningMode: 'one_sentence',
+          selectedModel: createExternalModelSelection(),
+        }),
+      sidecarConnection,
+    });
+
+    await controller.transcribeAudioSource(source);
+
+    expect(captureStream.start).not.toHaveBeenCalled();
+    expect(sidecarConnection.startSession).toHaveBeenCalledWith(
+      expect.objectContaining({ includeSystemAudio: false, mode: 'always_on' }),
+    );
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    expect(sidecarConnection.sendAudioFrameWithBackpressure).toHaveBeenCalledWith(
+      sessionId,
+      expect.objectContaining({ byteLength: 640 }),
+    );
+    expect(sidecarConnection.requestStopSession).toHaveBeenCalledWith(sessionId);
+    expect(feedback.show).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'audio-file-progress',
+        message: expect.stringContaining('100%'),
+      }),
+    );
+    expect(controller.getState()).toBe('idle');
+  });
+
+  it('aborts file ingestion and cancels the shared session when its locked note closes', async () => {
+    const sidecarConnection = new FakeSidecarConnection();
+    let onLockedNoteClosed: (() => void) | undefined;
+    let sourceSignal: AbortSignal | undefined;
+    const source: AudioFrameSource = {
+      stream: vi.fn(
+        ({ abortSignal }) =>
+          new Promise<void>((_resolve, reject) => {
+            sourceSignal = abortSignal;
+            abortSignal.addEventListener('abort', () => {
+              const error = new Error('cancelled');
+              error.name = 'AbortError';
+              reject(error);
+            });
+          }),
+      ),
+    };
+    const controller = createController({
+      createSession: (_session, options) => {
+        onLockedNoteClosed = options.callbacks.onLockedNoteClosed;
+      },
+      sidecarConnection,
+    });
+
+    const transcription = controller.transcribeAudioSource(source);
+    await vi.waitFor(() => {
+      expect(sourceSignal).toBeDefined();
+    });
+    expect(controller.getState()).toBe('processing_file');
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    sidecarConnection.emit({ sessionId, state: 'speech_detected', type: 'session_state_changed' });
+    expect(controller.getState()).toBe('processing_file');
+    onLockedNoteClosed?.();
+
+    await transcription;
+    expect(sourceSignal?.aborted).toBe(true);
+    await vi.waitFor(() => {
+      expect(sidecarConnection.cancelSession).toHaveBeenCalledOnce();
+    });
+    expect(sidecarConnection.requestStopSession).not.toHaveBeenCalled();
+  });
+
+  it('cancels file transcription when the backpressure-aware frame sink fails', async () => {
+    const feedback = { show: vi.fn() };
+    const sidecarConnection = new FakeSidecarConnection();
+    sidecarConnection.sendAudioFrameWithBackpressure.mockRejectedValueOnce(
+      new Error('sidecar write failed'),
+    );
+    const source: AudioFrameSource = {
+      stream: vi.fn(async ({ onFrame }) => {
+        await onFrame(new Uint8Array(640));
+      }),
+    };
+    const controller = createController({ feedback, sidecarConnection });
+
+    await controller.transcribeAudioSource(source);
+
+    expect(sidecarConnection.cancelSession).toHaveBeenCalledOnce();
+    expect(feedback.show).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: 'error',
+        key: 'audio-file-transcription-failed',
+        message: expect.stringContaining('sidecar write failed'),
+      }),
+    );
   });
 
   it('binds ribbon audio levels to the active session and ignores stale level events', async () => {

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -277,8 +277,104 @@ describe('DictationSessionController', () => {
     expect(controller.getState()).toBe('idle');
   });
 
+  it('pauses file frames while the sidecar queue catches up and resumes only at normal', async () => {
+    const sidecarConnection = new FakeSidecarConnection();
+    let releaseSecondFrame: (() => void) | undefined;
+    const secondFrameReady = new Promise<void>((resolve) => {
+      releaseSecondFrame = resolve;
+    });
+    const source: AudioFrameSource = {
+      stream: vi.fn(async ({ onFrame }) => {
+        await onFrame(new Uint8Array(640).fill(1));
+        await secondFrameReady;
+        await onFrame(new Uint8Array(640).fill(2));
+      }),
+    };
+    const controller = createController({ sidecarConnection });
+
+    const transcription = controller.transcribeAudioSource(source);
+    await vi.waitFor(() => {
+      expect(sidecarConnection.sendAudioFrameWithBackpressure).toHaveBeenCalledOnce();
+    });
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    sidecarConnection.emit({
+      queuedUtterances: 3,
+      sessionId,
+      tier: 'catching_up',
+      type: 'transcription_queue_changed',
+    });
+    releaseSecondFrame?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(sidecarConnection.sendAudioFrameWithBackpressure).toHaveBeenCalledOnce();
+
+    sidecarConnection.emit({
+      queuedUtterances: 1,
+      sessionId,
+      tier: 'catching_up',
+      type: 'transcription_queue_changed',
+    });
+    await Promise.resolve();
+    expect(sidecarConnection.sendAudioFrameWithBackpressure).toHaveBeenCalledOnce();
+
+    sidecarConnection.emit({
+      queuedUtterances: 0,
+      sessionId,
+      tier: 'normal',
+      type: 'transcription_queue_changed',
+    });
+    await transcription;
+
+    expect(sidecarConnection.sendAudioFrameWithBackpressure).toHaveBeenCalledTimes(2);
+    expect(sidecarConnection.requestStopSession).toHaveBeenCalledWith(sessionId);
+  });
+
+  it('stops file ingestion gracefully and still accepts already processed transcript events', async () => {
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    let firstFrameSent: (() => void) | undefined;
+    const sent = new Promise<void>((resolve) => {
+      firstFrameSent = resolve;
+    });
+    const source: AudioFrameSource = {
+      stream: vi.fn(async ({ abortSignal, onFrame }) => {
+        await onFrame(new Uint8Array(640));
+        firstFrameSent?.();
+        await new Promise<void>((_resolve, reject) => {
+          abortSignal.addEventListener('abort', () => {
+            const error = new Error('stopped');
+            error.name = 'AbortError';
+            reject(error);
+          });
+        });
+      }),
+    };
+    const controller = createController({
+      createSession: (session) => {
+        sessions.push(session);
+      },
+      sidecarConnection,
+    });
+
+    const transcription = controller.transcribeAudioSource(source);
+    await sent;
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    await controller.stopDictation();
+    await transcription;
+
+    expect(sidecarConnection.requestStopSession).toHaveBeenCalledWith(sessionId);
+    expect(sidecarConnection.cancelSession).not.toHaveBeenCalled();
+    sidecarConnection.emit(transcriptReady(sessionId, 'already accepted audio'));
+    await vi.waitFor(() => {
+      expect(sessions[0]?.acceptTranscript).toHaveBeenCalledWith(
+        expect.objectContaining({ text: 'already accepted audio' }),
+      );
+    });
+  });
+
   it('aborts file ingestion and cancels the shared session when its locked note closes', async () => {
     const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
     let onLockedNoteClosed: (() => void) | undefined;
     let sourceSignal: AbortSignal | undefined;
     const source: AudioFrameSource = {
@@ -296,6 +392,7 @@ describe('DictationSessionController', () => {
     };
     const controller = createController({
       createSession: (_session, options) => {
+        sessions.push(_session);
         onLockedNoteClosed = options.callbacks.onLockedNoteClosed;
       },
       sidecarConnection,
@@ -317,6 +414,9 @@ describe('DictationSessionController', () => {
       expect(sidecarConnection.cancelSession).toHaveBeenCalledOnce();
     });
     expect(sidecarConnection.requestStopSession).not.toHaveBeenCalled();
+    sidecarConnection.emit(transcriptReady(sessionId, 'must be discarded'));
+    await Promise.resolve();
+    expect(sessions[0]?.acceptTranscript).not.toHaveBeenCalled();
   });
 
   it('cancels file transcription when the backpressure-aware frame sink fails', async () => {

--- a/test/pcm-frame-processor.test.ts
+++ b/test/pcm-frame-processor.test.ts
@@ -152,6 +152,20 @@ describe('PcmFrameProcessor', () => {
     }
   });
 
+  it('pads the final partial frame with silence and resets the stream', () => {
+    const processor = new PcmFrameProcessor({ sourceSampleRate: 16000, targetSampleRate: 16000 });
+    processor.push(constantF32(100, 0.5));
+
+    const finalFrame = processor.finish();
+
+    expect(finalFrame).not.toBeNull();
+    expect(finalFrame?.slice(0, 100)).toEqual(new Int16Array(100).fill(quantize(0.5)));
+    expect(finalFrame?.slice(100)).toEqual(new Int16Array(FRAME_SIZE - 100));
+    expect(processor.finish()).toBeNull();
+
+    expect(processor.push(constantF32(FRAME_SIZE, -0.5))).toHaveLength(1);
+  });
+
   it('rejects non-positive sample rates and non-integer frame sizes', () => {
     expect(() => new PcmFrameProcessor({ sourceSampleRate: 0, targetSampleRate: 16000 })).toThrow(
       /positive numbers/,

--- a/test/register-commands.test.ts
+++ b/test/register-commands.test.ts
@@ -31,6 +31,7 @@ describe('registerCommands', () => {
       startDictation: vi.fn(async () => {}),
       stopDictation: vi.fn(async () => {}),
       toggleDictation: vi.fn(async () => {}),
+      transcribeAudioFile: vi.fn(async () => {}),
     });
     const reinsertCommand = commands.find(({ id }) => id === 'reinsert-last-utterance');
     const clearCommand = commands.find(({ id }) => id === 'clear-last-utterance');
@@ -87,6 +88,7 @@ describe('registerCommands', () => {
       startDictation: vi.fn(async () => {}),
       stopDictation: vi.fn(async () => {}),
       toggleDictation: vi.fn(async () => {}),
+      transcribeAudioFile: vi.fn(async () => {}),
     });
     const restoreCommand = commands.find(({ id }) => id === 'restore-raw-transcript');
     const copyCommand = commands.find(({ id }) => id === 'copy-raw-transcript');
@@ -114,5 +116,38 @@ describe('registerCommands', () => {
     expect(copyRawTranscript).toHaveBeenCalledOnce();
     expect(clearRawTranscriptRecovery).toHaveBeenCalledOnce();
     expect(restoreCommand?.checkCallback?.(true)).toBe(false);
+  });
+
+  it('registers audio file transcription as a first-class command', async () => {
+    const commands: Command[] = [];
+    const transcribeAudioFile = vi.fn(async () => {});
+    const plugin = {
+      addCommand: vi.fn((command: Command) => {
+        commands.push(command);
+      }),
+    } as unknown as Plugin;
+
+    registerCommands({
+      cancelDictation: vi.fn(async () => {}),
+      clearLastUtterance: vi.fn(),
+      clearRawTranscriptRecovery: vi.fn(),
+      checkSidecarHealth: vi.fn(async () => {}),
+      copyRawTranscript: vi.fn(),
+      hasLastUtterance: () => false,
+      hasRawTranscriptRecovery: () => false,
+      plugin,
+      reinsertLastUtterance: vi.fn(),
+      restoreRawTranscript: vi.fn(),
+      restartSidecar: vi.fn(async () => {}),
+      startDictation: vi.fn(async () => {}),
+      stopDictation: vi.fn(async () => {}),
+      toggleDictation: vi.fn(async () => {}),
+      transcribeAudioFile,
+    });
+
+    const command = commands.find(({ id }) => id === 'transcribe-audio-file');
+    expect(command?.name).toBe('Transcribe audio file');
+    await command?.callback?.();
+    expect(transcribeAudioFile).toHaveBeenCalledOnce();
   });
 });

--- a/test/sidecar-connection.test.ts
+++ b/test/sidecar-connection.test.ts
@@ -55,6 +55,10 @@ class FakeSidecarProcess {
     this.writtenFrames.push(frameBytes);
   }
 
+  async writeWithBackpressure(frameBytes: Uint8Array): Promise<void> {
+    this.write(frameBytes);
+  }
+
   deliver(event: SidecarEvent): void {
     this.handlers?.onStdoutChunk(encodeJsonFrame(event));
   }
@@ -234,6 +238,19 @@ describe('SidecarConnection', () => {
 
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith(warningEvent({ message: 'first' }));
+  });
+
+  it('writes file audio through the backpressure-aware process boundary', async () => {
+    const { connection, process } = createHarness();
+    await connection.ensureStarted();
+
+    await connection.sendAudioFrameWithBackpressure(
+      crypto.randomUUID(),
+      new Uint8Array(640).fill(3),
+    );
+
+    expect(process.writtenFrames).toHaveLength(1);
+    expect(process.writtenFrames[0]?.byteLength).toBeGreaterThan(640);
   });
 
   it('rejects a waiter when the matching event times out', async () => {

--- a/test/sidecar-process.test.ts
+++ b/test/sidecar-process.test.ts
@@ -154,3 +154,40 @@ describe('SidecarProcess stale-exit race (issue #194)', () => {
     expect(handlers.onExit).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('SidecarProcess write backpressure', () => {
+  it('waits for drain when the child stdin buffer is full', async () => {
+    const process = new SidecarProcess(
+      async () => ({ command: '/tmp/fake-sidecar' }),
+      createHandlers(),
+    );
+    const child = await startChild(process);
+    vi.spyOn(child.stdin, 'write').mockReturnValueOnce(false);
+
+    const writePromise = process.writeWithBackpressure(new Uint8Array([1, 2, 3]));
+    let resolved = false;
+    void writePromise.then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    child.stdin.emit('drain');
+    await writePromise;
+    expect(resolved).toBe(true);
+  });
+
+  it('rejects a blocked write if the sidecar exits before drain', async () => {
+    const process = new SidecarProcess(
+      async () => ({ command: '/tmp/fake-sidecar' }),
+      createHandlers(),
+    );
+    const child = await startChild(process);
+    vi.spyOn(child.stdin, 'write').mockReturnValueOnce(false);
+
+    const writePromise = process.writeWithBackpressure(new Uint8Array([1]));
+    child.reallyExit(1, null);
+
+    await expect(writePromise).rejects.toThrow(/before its audio buffer drained/u);
+  });
+});


### PR DESCRIPTION
## Summary

- Add **Local Dictation: Transcribe audio file** and a `file-audio` ribbon entry for choosing an existing recording.
- Support WAV and MP3 files up to 256 MB and 30 minutes, decoded entirely in Obsidian with Web Audio.
- Require an authoritative, matching capability snapshot for a selected Whisper or Cohere Transcribe batch model before opening the file picker.
- Downmix and resample decoded audio to the existing 16 kHz mono PCM frame format, then feed the existing sidecar session instead of introducing another transcription path.
- Make file-frame writes honor both child-process stdin backpressure and the sidecar's transcription-queue tiers.
- Preserve the existing note lock, stale-surface cancellation, transcript rendering, diarization, timestamp, recovery, and optional LLM cleanup behavior.
- Show truthful decode/send/finalization feedback and a dedicated processing state on the active ribbon control.

Relates to #247.

## User workflow

1. Select a Whisper or Cohere Transcribe batch model.
2. Open the destination Markdown note and place the cursor where the transcript should land.
3. Select the ribbon audio-file icon or run **Local Dictation: Transcribe audio file**.
4. Choose a WAV or MP3 recording.
5. Local Dictation decodes and sends progress locally, then the existing transcript session writes into the locked note target.

The active ribbon control stops ingestion and gracefully drains audio already accepted. **Local Dictation: Cancel dictation** discards the in-progress session.

## Design decisions

- **One engine path:** `AudioFrameSource` is a source-neutral producer boundary. Both the new file producer and microphone capture ultimately send the same framed PCM into the same Rust session/VAD/model pipeline.
- **Capability-gated model selection:** file ingestion starts only when the selected model has a current capability snapshot whose selection exactly matches. Missing models open the existing model picker; stale capability data points to Manage models; streaming models point to a Whisper or Cohere Transcribe batch model. The same preflight runs before and after the native file picker so settings changes while it is open cannot cross the capability boundary.
- **Target safety before decode:** the normal `Session` is created before file decoding begins, so the editor, file, path, placement, and surface lifecycle are locked exactly like live dictation. Closing, deleting, replacing, or desynchronizing the target cancels the file producer and sidecar session.
- **Two-layer flow control:** file ingestion awaits child stdin `drain` and yields frequently enough to receive sidecar events. When the sidecar reports `catching_up` or worse, the producer pauses before the next frame and resumes only after the queue returns to `normal`. The microphone keeps its existing low-latency synchronous writes. This is transport/session behavior, not a second protocol or compatibility shim.
- **Whole-file mode:** file sessions force `always_on` so a user's one-sentence microphone setting cannot truncate an imported recording. System-audio capture is forced off because the selected file is the only audio source. Other session settings continue to apply.
- **Preflight before allocation:** an abort-safe object-URL/audio-metadata probe rejects overlong recordings before `arrayBuffer()` or `decodeAudioData`. The object URL and media element source are always released. The decoded duration is validated again as the authoritative check.
- **Bounded memory:** Web Audio still decodes accepted files into memory. The 256 MB / 30-minute limits make that cost explicit and bounded; longer recordings need a future streaming decoder rather than quietly risking Obsidian memory pressure.
- **Discoverability without settings sprawl:** the operation is a command plus ribbon action. It does not add advanced workflow controls to the settings page or couple to the independent sidebar redesign in #251.

## Privacy

- The selected file is read and decoded in Obsidian memory.
- PCM is sent only over stdin to the local sidecar; no audio is uploaded or copied into the vault.
- File names and audio contents are not included in logs or progress feedback.
- Existing OpenRouter behavior is unchanged: only transcript text and explicitly enabled note context can be sent for optional cleanup; audio is never sent.

## Deliberate scope

This PR does **not** claim arbitrary media support. It does not accept video containers, AAC/M4A, FLAC, Ogg, URLs, or YouTube links. Those formats require container/codec and download-policy decisions that Web Audio cannot guarantee consistently across Electron platforms. WAV/MP3 are the intentionally narrow first release.

Moonshine and other streaming models are also deliberately excluded from file transcription. Their per-frame worker command queue is not governed by the sidecar's finalized-utterance queue tiers, so silently accepting them would bypass this PR's bounded-ingestion guarantee. Batch Whisper and Cohere Transcribe models use the queue-aware path described above.

PRs #233, #236, and #239 also touch orchestration/command files, but this change does not reproduce personal corrections, selection re-dictation, or voice Markdown commands. The shared-session extraction may require a normal rebase after those land.

## Verification

- `npm run check:js`
  - release metadata validation
  - TypeScript typecheck
  - Biome and Obsidian ESLint
  - 65 Vitest files / 791 tests
  - production frontend build
  - all-engine local sidecar build
  - packaged build-output verification
- Focused model capability, audio source/metadata, queue-flow control, resampling, controller, command, ribbon, and sidecar connection/process suite: 118 tests passed.
- `git diff --check`

## Manual gaps and risks

- The native file picker and real Electron `decodeAudioData` behavior were not interactively exercised in this non-interactive environment.
- Decode cancellation is cooperative: cancellation immediately stops sidecar ingestion and discards the session, but the browser's in-flight `decodeAudioData` promise itself cannot be interrupted. Its result is ignored once it resolves.
- This first version decodes in memory; the documented limits are intentional and should not be raised without a streaming decoder design.
