### PR TITLE
Add no-Python Parakeet Unified streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,19 @@ _The first-run wizard installs the native engine and helps you choose between li
 
 | Workflow | What happens | Model fit |
 | --- | --- | --- |
-| **Live dictation** | Provisional words appear and revise in place while you speak. | Moonshine streaming models |
+| **Live dictation** | Provisional words appear and revise in place while you speak. | Moonshine or Parakeet Unified streaming models |
 | **Notes and drafts** | Final text lands at your cursor after each pause. | Whisper or Cohere Transcribe batch models |
 | **Meetings and calls** | Add computer audio to microphone capture, then optionally label speakers and add timestamps. | Whisper or Cohere Transcribe batch models |
 
-All transcription models in the current catalog run locally and support English. Moonshine is optimized for live dictation; speaker labels currently require a batch model.
+All transcription models in the current catalog run locally and support English. Moonshine is the recommended live-dictation default; the experimental Parakeet Unified model offers another high-accuracy streaming option at a much higher CPU and memory cost. Speaker labels currently require a batch model.
 
 ## Features
 
-- **Live text.** Moonshine streaming models show provisional words and revise them in place until each utterance finalizes.
+- **Live text.** Moonshine and Parakeet Unified streaming models show provisional words while each utterance remains open.
 - **Meeting capture.** Include system audio from meetings, calls, or videos alongside your microphone on Windows, Linux, and macOS 14.2 or later.
 - **Speaker labels.** Optional on-device diarization assigns session-stable speaker labels. Set an expected maximum when automatic detection creates extra labels. Speaker embeddings stay in memory and are discarded after the session.
 - **Timestamps.** Add elapsed or wall-clock timestamps at configurable intervals.
-- **Local model choices.** Choose Whisper, Cohere Transcribe, or Moonshine models and download them from Settings.
+- **Local model choices.** Choose Whisper, Cohere Transcribe, Moonshine, or NVIDIA Parakeet Unified models and download them from Settings.
 - **Optional text transformation.** Clean up, summarize, extract action items, or apply a custom prompt through local Ollama or remote OpenRouter models.
 - **Short-lived recovery.** Reinsert the latest finalized utterance, or copy and safely restore the raw text from the most recent replace-style batch cleanup.
 - **Explicit remote controls.** Keep transformations local, allow OpenRouter only for oversized transcripts, or disable remote and LLM features entirely.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -36,6 +36,224 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+## NVIDIA Parakeet Unified model
+
+- Work: `nvidia/parakeet-unified-en-0.6b`
+- NVIDIA checkpoint revision: `fe53cd885760c96b6a5f51a0bfd362cb4584a98b`
+- Derived int8 ONNX export revision:
+  `7551fd26fc810cc1e4e043e608db4d13b59be31e`
+- Export implementation: sherpa-onnx v1.13.2 (`13d0ae6c539d2809d32f5eaa3ef1db0c459d0b24`)
+- License: NVIDIA Open Model License Agreement, last modified October 24, 2025
+- Canonical agreement:
+  https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/
+
+The catalog downloads the derived ONNX encoder, decoder, joiner, tokenizer, and
+model documentation directly from the pinned export repository. The weights
+are not MIT-licensed. The ONNX conversion and int8 quantization modify the
+original NVIDIA checkpoint's packaging and numerical representation.
+
+`NOTICE`
+
+> Licensed by NVIDIA Corporation under the NVIDIA Open Model License
+
+### NVIDIA Open Model License Agreement
+
+IMPORTANT NOTICE – PLEASE READ AND AGREE BEFORE USING THE NVIDIA MODELS.
+
+Last Modified: October 24, 2025
+
+This NVIDIA Open Model License Agreement (the “Agreement”) is a legal agreement
+between the Legal Entity You represent, or if no entity is identified, You and
+NVIDIA Corporation and its Affiliates (“NVIDIA”) and governs Your use of the
+Models that NVIDIA provides to You under this Agreement. NVIDIA and You are each
+a “party” and collectively the “parties.”
+
+NVIDIA models released under this Agreement are intended to be used
+permissively and enable the further development of AI technologies. Subject to
+the terms of this Agreement, NVIDIA confirms that:
+
+- Models are commercially usable.
+- You are free to create and distribute Derivative Models.
+- NVIDIA does not claim ownership to any outputs generated using the Models or
+  Derivative Models.
+
+By using, reproducing, modifying, distributing, performing or displaying any
+portion or element of the Model or Derivative Model, or otherwise accepting the
+terms of this Agreement, you agree to be bound by this Agreement.
+
+1. **Definitions.** The following definitions apply to this Agreement:
+
+   1. “Derivative Model” means all (a) modifications to the Model, (b) works
+      based on the Model, and (c) any other derivative works of the Model. An
+      output is not a Derivative Model.
+   2. “Legal Entity” means the union of the acting entity and all other entities
+      that control, are controlled by, or are under common control with that
+      entity. For the purposes of this definition, “control” means (a) the
+      power, direct or indirect, to cause the direction or management of such
+      entity, whether by contract or otherwise, or (b) ownership of fifty
+      percent (50%) or more of the outstanding shares, or (c) beneficial
+      ownership of such entity.
+   3. “Model” means the machine learning model, software, checkpoints, learnt
+      weights, algorithms, parameters, configuration files and documentation
+      shared under this Agreement.
+   4. “NVIDIA Cosmos Model” means a multimodal Model shared under this
+      Agreement.
+   5. “Special-Purpose Model” means a Model that is only competent in a narrow
+      set of purpose-specific tasks and should not be used for unintended or
+      general-purpose applications.
+   6. “You” or “Your” means an individual or Legal Entity exercising permissions
+      granted by this Agreement.
+
+2. **Conditions for Use, License Grant, AI Ethics and IP Ownership.**
+
+   1. **Conditions for Use.** The Model and any Derivative Model are subject to
+      additional terms as described in Section 2 and Section 3 of this Agreement
+      and govern Your use.
+
+      If You institute copyright or patent litigation against any entity
+      (including a cross-claim or counterclaim in a lawsuit) alleging that the
+      Model or a Derivative Model constitutes direct or contributory copyright
+      or patent infringement, then any licenses granted to You under this
+      Agreement for that Model or Derivative Model will terminate as of the date
+      such litigation is filed.
+
+      If You bypass, disable, reduce the efficacy of, or circumvent any technical
+      limitation, safety guardrail or associated safety guardrail
+      hyperparameter, encryption, security, digital rights management, or
+      authentication mechanism (collectively “Guardrail”) contained in the
+      Model without a substantially similar Guardrail appropriate for your use
+      case, your rights under this Agreement will automatically terminate.
+      NVIDIA may indicate in relevant documentation that a Model is a
+      Special-Purpose Model.
+
+      NVIDIA may update this Agreement to comply with legal and regulatory
+      requirements at any time and You agree to either comply with any updated
+      license or cease Your copying, use, and distribution of the Model and any
+      Derivative Model.
+
+   2. **License Grant.** The rights granted herein are explicitly conditioned on
+      Your full compliance with the terms of this Agreement. Subject to the
+      terms and conditions of this Agreement, NVIDIA hereby grants to You a
+      perpetual, worldwide, non-exclusive, no-charge, royalty-free, revocable
+      (as stated in Section 2.1) license to publicly perform, publicly display,
+      reproduce, use, create derivative works of, make, have made, sell, offer
+      for sale, distribute (through multiple tiers of distribution) and import
+      the Model.
+
+   3. **AI Ethics.** Use of the Models under the Agreement must be consistent
+      with NVIDIA’s Trustworthy AI terms found at
+      https://www.nvidia.com/en-us/agreements/trustworthy-ai/terms/.
+
+   4. NVIDIA owns the Model and any Derivative Models created by NVIDIA. Subject
+      to NVIDIA’s underlying ownership rights in the Model or its Derivative
+      Models, You are and will be the owner of Your Derivative Models. NVIDIA
+      claims no ownership rights in outputs. You are responsible for outputs and
+      their subsequent uses. Except as expressly granted in this Agreement, (a)
+      NVIDIA reserves all rights, interests and remedies in connection with the
+      Model and (b) no other license or right is granted to you by implication,
+      estoppel or otherwise.
+
+3. **Redistribution.** You may reproduce and distribute copies of the Model or
+   Derivative Models thereof in any medium, with or without modifications,
+   provided that You meet the following conditions:
+
+   1. If you distribute the Model, You must give any other recipients of the
+      Model a copy of this Agreement and include the following attribution notice
+      within a “Notice” text file with such copies: “Licensed by NVIDIA
+      Corporation under the NVIDIA Open Model License”;
+   2. If you distribute or make available a NVIDIA Cosmos Model, or a product or
+      service (including an AI model) that contains or uses a NVIDIA Cosmos
+      Model, use a NVIDIA Cosmos Model to create a Derivative Model, or use a
+      NVIDIA Cosmos Model or its outputs to create, train, fine tune, or
+      otherwise improve an AI model, you will include “Built on NVIDIA Cosmos”
+      on a related website, user interface, blogpost, about page, or product
+      documentation; and
+   3. You may add Your own copyright statement to Your modifications and may
+      provide additional or different license terms and conditions for use,
+      reproduction, or distribution of Your modifications, or for any such
+      Derivative Models as a whole, provided Your use, reproduction, and
+      distribution of the Model otherwise complies with the conditions stated
+      in this Agreement.
+
+4. **Separate Components.** The Models may include or be distributed with
+   components provided with separate legal notices or terms that accompany the
+   components, such as an Open Source Software License or other third-party
+   license. The components are subject to the applicable other licenses,
+   including any proprietary notices, disclaimers, requirements and extended
+   use rights; except that this Agreement will prevail regarding the use of
+   third-party Open Source Software License, unless a third-party Open Source
+   Software License requires its license terms to prevail. “Open Source Software
+   License” means any software, data or documentation subject to any license
+   identified as an open source license by the Open Source Initiative
+   (https://opensource.org), Free Software Foundation (https://www.fsf.org) or
+   other similar open source organization or listed by the Software Package Data
+   Exchange (SPDX) Workgroup under the Linux Foundation
+   (https://www.spdx.org).
+
+5. **Trademarks.** This Agreement does not grant permission to use the trade
+   names, trademarks, service marks, or product names of NVIDIA, except as
+   required for reasonable and customary use in describing the origin of the
+   Model and reproducing the content of the “Notice” text file.
+
+6. **Disclaimer of Warranty.** Unless required by applicable law or agreed to in
+   writing, NVIDIA provides the Model on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied, including, without
+   limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+   MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely
+   responsible for reviewing Model documentation, including any Special-Purpose
+   Model limitations, and determining the appropriateness of using or
+   redistributing the Model, Derivative Models and outputs. You assume any risks
+   associated with Your exercise of permissions under this Agreement.
+
+7. **Limitation of Liability.** In no event and under no legal theory, whether in
+   tort (including negligence), contract, or otherwise, unless required by
+   applicable law (such as deliberate and grossly negligent acts) or agreed to
+   in writing, will NVIDIA be liable to You for damages, including any direct,
+   indirect, special, incidental, or consequential damages of any character
+   arising as a result of this Agreement or out of the use or inability to use
+   the Model, Derivative Models or outputs (including but not limited to damages
+   for loss of goodwill, work stoppage, computer failure or malfunction, or any
+   and all other commercial damages or losses), even if NVIDIA has been advised
+   of the possibility of such damages.
+
+8. **Indemnity.** You will indemnify and hold harmless NVIDIA from and against
+   any claim by any third party arising out of or related to your use or
+   distribution of the Model, Derivative Models or outputs.
+
+9. **Feedback.** NVIDIA appreciates your feedback, and You agree that NVIDIA may
+   use it without restriction or compensation to You.
+
+10. **Governing Law.** This Agreement will be governed in all respects by the
+    laws of the United States and the laws of the State of Delaware, without
+    regard to conflict of laws principles or the United Nations Convention on
+    Contracts for the International Sale of Goods. The state and federal courts
+    residing in Santa Clara County, California will have exclusive jurisdiction
+    over any dispute or claim arising out of or related to this Agreement, and
+    the parties irrevocably consent to personal jurisdiction and venue in those
+    courts; except that, either party may apply for injunctive remedies or an
+    equivalent type of urgent legal relief in any jurisdiction.
+
+11. **Trade and Compliance.** You agree to comply with all applicable export,
+    import, trade and economic sanctions laws and regulations, as amended,
+    including without limitation U.S. Export Administration Regulations and
+    Office of Foreign Assets Control regulations. These laws include
+    restrictions on destinations, end-users and end-use.
+
+### Parakeet export and runtime reference implementations
+
+- Work: sherpa-onnx v1.13.2
+- Copyright (c) 2023-2026 Xiaomi Corporation and sherpa-onnx contributors
+- Source: https://github.com/k2-fsa/sherpa-onnx/tree/v1.13.2
+- Work: kaldi-native-fbank v1.22.3
+- Copyright (c) 2022 Xiaomi Corporation and kaldi-native-fbank contributors
+- Source: https://github.com/csukuangfj/kaldi-native-fbank/tree/v1.22.3
+- License: Apache License 2.0
+  https://www.apache.org/licenses/LICENSE-2.0
+
+The Parakeet adapter's native Rust graph orchestration and feature frontend
+follow these reference implementations' published behavior. No sherpa-onnx or
+kaldi-native-fbank binary is linked or bundled.
+
 ## WeSpeaker speaker-embedding model
 
 - Work: `wespeaker_en_voxceleb_resnet34_LM`

--- a/docs/specs/parakeet-unified.md
+++ b/docs/specs/parakeet-unified.md
@@ -1,0 +1,94 @@
+# NVIDIA Parakeet Unified integration
+
+Local Dictation supports the 560 ms int8 buffered-streaming export of
+`nvidia/parakeet-unified-en-0.6b` as an optional English live-dictation model.
+The installed application runs the model entirely in the Rust sidecar through
+the existing ONNX Runtime. It does not install or invoke Python, PyTorch, NeMo,
+or sherpa-onnx.
+
+Moonshine remains the default live-dictation family. Parakeet is a 632 MiB
+download and recomputes 5.6 seconds of left context for every 160 ms center
+chunk, so it trades substantially more CPU and memory for a different accuracy
+profile.
+
+## Pinned model lineage
+
+The catalog is byte-pinned at every boundary:
+
+| Input | Revision | SHA-256 / role |
+| --- | --- | --- |
+| [NVIDIA checkpoint](https://huggingface.co/nvidia/parakeet-unified-en-0.6b/tree/fe53cd885760c96b6a5f51a0bfd362cb4584a98b) | `fe53cd885760c96b6a5f51a0bfd362cb4584a98b` | `.nemo`: `ec23ed9150c8fde49072c3e2d61678ab903dbcef389d658db833420cbc1da35b` |
+| [sherpa-onnx export implementation](https://github.com/k2-fsa/sherpa-onnx/tree/v1.13.2/scripts/nemo/parakeet-unified-en-0.6b) | v1.13.2 / `13d0ae6c539d2809d32f5eaa3ef1db0c459d0b24` | Reference exporter and parity oracle |
+| [Published int8 ONNX export](https://huggingface.co/csukuangfj2/sherpa-onnx-nemo-parakeet-unified-en-0.6b-int8-streaming-560ms/tree/7551fd26fc810cc1e4e043e608db4d13b59be31e) | `7551fd26fc810cc1e4e043e608db4d13b59be31e` | Exact catalog source |
+
+The runtime artifacts are:
+
+| File | Bytes | SHA-256 |
+| --- | ---: | --- |
+| `encoder.int8.onnx` | 654,046,389 | `e566c3f014598a41724f2df028779a2d4cf7943cbefa324964f6a72e8ee255fb` |
+| `decoder.int8.onnx` | 7,257,777 | `34fea72425d2506600772ba191a6d3f99c0710abdb68d9a3dc89fa8cb2aa473a` |
+| `joiner.int8.onnx` | 1,735,860 | `869f43f7d24595c55581ad3bf249a935fb8a71389fbdaa7504b9f46f93140f8a` |
+| `tokens.txt` | 8,952 | `dc0b4584ab2e4ddbf888425c076c61b736e7356a015250db7d307e6f1a8188ff` |
+
+The installer also preserves NVIDIA's bias, explainability, privacy, and safety
+documents beside the model. It verifies all eight downloads before atomically
+committing the model directory.
+
+The upstream export recipe downloads its NeMo and toolchain dependencies from
+moving branches, so it is not a bit-reproducible build recipe as published.
+This integration therefore makes the narrower claim it can prove: the source
+checkpoint, export implementation, published output revision, sizes, and every
+installed byte are pinned. Regenerating the ONNX files requires a separately
+locked NeMo export environment and is not part of the installed application.
+
+## Runtime contract
+
+The `parakeet_unified` family adapter owns the graph convention and validates it
+before selection:
+
+- encoder: `f32 [B,128,T]` plus `i64 [B]`, producing `f32 [B,1024,Tenc]`;
+- predictor: one `i32` token plus two `f32 [2,B,640]` LSTM states;
+- joiner: one encoder frame plus one predictor output, producing 1,025 logits;
+- token 1024 is the blank token and must be the last entry in `tokens.txt`;
+- encoder metadata must declare `nemo_parakeet_unified_streaming`, per-feature
+  normalization, positive bounded dimensions, and consistent x8 feature/encoder
+  context sizes.
+
+Audio becomes 128-bin log-mel features with the same NeMo/librosa parameters as
+the sherpa-onnx v1.13.2 reference: 16 kHz normalized mono, 25 ms frames, 10 ms
+stride, non-snipping reflected edges, periodic Hann, 512-point FFT, preemphasis
+0.97, no dither, and no DC-offset removal.
+
+At each decode step the adapter builds 560 left + 16 center + 40 right feature
+frames, zero-pads unavailable context, and normalizes that complete 616-frame
+window with population variance. The encoder is rerun for the window; only its
+two center frames are passed to greedy RNNT decoding. Predictor state and tokens
+are retained between chunks. Finalization flushes the short final center with
+zero-padded right context; it does not replay audio already decoded.
+
+## Verification
+
+The normal Rust suite covers metadata bounds, tokenizer invariants, feature
+framing/reflection, periodic Hann behavior, population normalization, padding,
+registry wiring, and catalog validation. The ignored real-model suite verifies
+partial prefix stability, final equivalence with a one-shot feed, corpus WER and
+anchor words, and silence behavior:
+
+```sh
+STT_TEST_PARAKEET_DIR=/path/to/model-directory \
+  cargo test --manifest-path native/Cargo.toml \
+  --features engine-parakeet-unified \
+  --test parakeet_e2e -- --ignored --nocapture
+```
+
+The four required inference files in that directory are `encoder.int8.onnx`,
+`decoder.int8.onnx`, `joiner.int8.onnx`, and `tokens.txt`.
+
+## License
+
+The model and derived weights use the
+[NVIDIA Open Model License](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/),
+not the project's MIT license. The release-bundled `THIRD_PARTY_NOTICES.md`
+contains the agreement, required NVIDIA notice, checkpoint/export attribution,
+and a prominent derived-weight modification notice. The catalog shows the same
+license before download.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -270,10 +270,11 @@ reports what's actually available.
 | Runtime | Crate | Model format | Adapter |
 |---|---|---|---|
 | `whisper_cpp` | whisper-rs (whisper.cpp) | GGML `.bin` | `whisper` |
-| `onnx_runtime` | ort (ONNX Runtime) | ONNX / ORT | `cohere_transcribe`, `moonshine` |
+| `onnx_runtime` | ort (ONNX Runtime) | ONNX / ORT | `cohere_transcribe`, `moonshine`, `parakeet_unified` |
 
 Cargo features: `engine-whisper`, `engine-cohere-transcribe`,
-`engine-moonshine`, `gpu-metal`, `gpu-cuda`, `gpu-ort-cuda`. A missing
+`engine-moonshine`, `engine-parakeet-unified`, `gpu-metal`, `gpu-cuda`,
+`gpu-ort-cuda`. A missing
 `(runtimeId, familyId)` pair surfaces as an `unsupported_engine` error rather
 than a silent failure.
 
@@ -287,6 +288,11 @@ than a silent failure.
   state for the open utterance. It attempts a changed-text partial every 500 ms;
   the single worker thread guarantees one decode in flight, and the wall-time
   gate drops catch-up partials while preserving all PCM for the next decode.
+- Parakeet Unified computes a NeMo-compatible 128-bin frontend, reruns its
+  buffered encoder over 5.6 seconds of left context, and carries the RNNT
+  predictor's two LSTM states across 160 ms center chunks. It uses the same
+  `StreamingModel` lifecycle and partial cadence as Moonshine without linking
+  sherpa-onnx or invoking Python.
 - Partials carry only the engine stage outcome. Finals run the normal post-engine
   chain and receive a revision greater than every emitted partial.
 - Back-pressure: finalized utterances queue while inference is in flight; queue
@@ -310,6 +316,7 @@ than a silent failure.
 | Moonshine Tiny | `onnx_runtime` · `moonshine` | Quantized | 49 MB | Streaming (live), 34M params |
 | Moonshine Small | `onnx_runtime` · `moonshine` | Quantized | 157 MB | Streaming (live), recommended, 123M params |
 | Moonshine Medium | `onnx_runtime` · `moonshine` | Quantized | 289 MB | Streaming (live), 245M params |
+| Parakeet Unified 560 ms | `onnx_runtime` · `parakeet_unified` | INT8 | 632 MiB | Buffered streaming (live), experimental, 600M params |
 
 Moonshine models are streaming (live-dictation) entries in the managed catalog,
 installed through Manage Models like any other model. Each is a multi-file ORT
@@ -318,6 +325,14 @@ tokenizer) fetched from Moonshine AI and verified against pinned sizes and
 SHA-256 hashes. They are English-only and do not apply speaker labels. See
 [`docs/guides/moonshine-live-testing.md`](guides/moonshine-live-testing.md) for
 install and manual acceptance testing.
+
+Parakeet Unified is a separately licensed, English-only streaming entry. Its
+encoder, predictor, joiner, tokenizer, and model documents are pinned by
+revision, size, and SHA-256. The Rust adapter runs those graphs directly through
+the existing ONNX Runtime and owns feature extraction, buffered windowing, and
+RNNT greedy decoding. See
+[`docs/specs/parakeet-unified.md`](specs/parakeet-unified.md) for provenance,
+the exact graph contract, test commands, and NVIDIA license handling.
 
 **Inference is the bottleneck.** Time depends on model size, hardware, and
 utterance length, and is reported as `processing_duration_ms` on each transcript.
@@ -478,7 +493,7 @@ A representative slice of user-facing settings (full list and defaults in
 | **Obsidian Plugin API** | Host runtime: editor access, commands, settings, UI hooks |
 | **Web Audio API / AudioWorklet** | Microphone capture and PCM frame production at 50 fps |
 | **whisper-rs / whisper.cpp** | Primary engine; runs GGML-quantized Whisper on CPU, Metal, or CUDA |
-| **ort (ONNX Runtime)** | Engine for Cohere Transcribe and Moonshine; also runs Silero VAD and diarization models |
+| **ort (ONNX Runtime)** | Engine for Cohere Transcribe, Moonshine, and Parakeet Unified; also runs Silero VAD and diarization models |
 | **Silero VAD** | Speech probability per 32 ms window; drives boundary detection |
 | **Node.js child_process** | Spawns and manages the Rust sidecar |
 | **reqwest + sha2** | Downloads model files and verifies their SHA-256 |

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -34,9 +34,10 @@ default = ["engine-whisper"]
 engine-whisper = []
 engine-cohere-transcribe = ["half", "ort/half"]
 engine-moonshine = []
+engine-parakeet-unified = []
 gpu-metal = ["whisper-rs/metal"]
 gpu-cuda = ["whisper-rs/cuda"]
-gpu-ort-cuda = ["engine-cohere-transcribe", "engine-moonshine", "ort/cuda"]
+gpu-ort-cuda = ["engine-cohere-transcribe", "engine-moonshine", "engine-parakeet-unified", "ort/cuda"]
 
 # Test/bench-only dependencies for the end-to-end quality suite under `tests/`
 # and `benches/`. Runtime `[dependencies]` above (serde, serde_json, sha2, uuid,

--- a/native/catalog.json
+++ b/native/catalog.json
@@ -1,5 +1,5 @@
 {
-  "catalogVersion": 2,
+  "catalogVersion": 3,
   "runtimes": [
     {
       "runtimeId": "whisper_cpp",
@@ -30,6 +30,12 @@
       "runtimeId": "onnx_runtime",
       "displayName": "Moonshine",
       "summary": "Live English transcription while you speak. Start with Small for the recommended balance; Tiny uses fewer resources, while Medium is the most accurate and uses more CPU time and memory."
+    },
+    {
+      "familyId": "parakeet_unified",
+      "runtimeId": "onnx_runtime",
+      "displayName": "NVIDIA Parakeet Unified",
+      "summary": "High-accuracy live English transcription through a buffered 560 ms RNNT model. It is a larger download and substantially more CPU-intensive than Moonshine."
     }
   ],
   "collections": [
@@ -47,6 +53,11 @@
       "collectionId": "moonshine_streaming",
       "displayName": "Moonshine Streaming",
       "summary": "English live-dictation models in three quality tiers."
+    },
+    {
+      "collectionId": "parakeet_streaming",
+      "displayName": "NVIDIA Parakeet Unified",
+      "summary": "English buffered-streaming transcription using the 560 ms int8 Parakeet Unified export."
     }
   ],
   "models": [
@@ -654,6 +665,99 @@
           "downloadUrl": "https://download.moonshine.ai/model/medium-streaming-en/quantized/tokenizer.bin",
           "sha256": "6884b35fd6377d4c4d32336a0bc152f36b64d1e45b6503683cdc238250a8472d",
           "sizeBytes": 249974
+        }
+      ]
+    },
+    {
+      "runtimeId": "onnx_runtime",
+      "familyId": "parakeet_unified",
+      "modelId": "parakeet_unified_en_int8_streaming_560ms",
+      "collectionId": "parakeet_streaming",
+      "displayName": "Parakeet Unified 560 ms",
+      "summary": "NVIDIA's 0.6B English RNNT model with punctuation and capitalization, exported to int8 ONNX for buffered live transcription.",
+      "languageTags": ["en"],
+      "uxTags": ["streaming", "accuracy", "cpu", "experimental"],
+      "licenseLabel": "NVIDIA Open Model License",
+      "licenseUrl": "https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/",
+      "sourceUrl": "https://huggingface.co/csukuangfj2/sherpa-onnx-nemo-parakeet-unified-en-0.6b-int8-streaming-560ms/tree/7551fd26fc810cc1e4e043e608db4d13b59be31e",
+      "modelCardUrl": "https://huggingface.co/nvidia/parakeet-unified-en-0.6b/tree/fe53cd885760c96b6a5f51a0bfd362cb4584a98b",
+      "notes": [
+        "Streams stable incremental text with a 560 ms latency configuration; its 5.6-second left context is recomputed for each chunk.",
+        "The 632 MiB int8 ONNX download is derived from NVIDIA checkpoint fe53cd885760c96b6a5f51a0bfd362cb4584a98b by the sherpa-onnx v1.13.2 export workflow.",
+        "Model weights are separately licensed under the NVIDIA Open Model License, not this project's MIT license. Installing or using the model accepts NVIDIA's terms."
+      ],
+      "artifacts": [
+        {
+          "artifactId": "encoder",
+          "role": "transcription_model",
+          "required": true,
+          "filename": "encoder.int8.onnx",
+          "downloadUrl": "https://huggingface.co/csukuangfj2/sherpa-onnx-nemo-parakeet-unified-en-0.6b-int8-streaming-560ms/resolve/7551fd26fc810cc1e4e043e608db4d13b59be31e/encoder.int8.onnx",
+          "sha256": "e566c3f014598a41724f2df028779a2d4cf7943cbefa324964f6a72e8ee255fb",
+          "sizeBytes": 654046389
+        },
+        {
+          "artifactId": "decoder",
+          "role": "supporting_file",
+          "required": true,
+          "filename": "decoder.int8.onnx",
+          "downloadUrl": "https://huggingface.co/csukuangfj2/sherpa-onnx-nemo-parakeet-unified-en-0.6b-int8-streaming-560ms/resolve/7551fd26fc810cc1e4e043e608db4d13b59be31e/decoder.int8.onnx",
+          "sha256": "34fea72425d2506600772ba191a6d3f99c0710abdb68d9a3dc89fa8cb2aa473a",
+          "sizeBytes": 7257777
+        },
+        {
+          "artifactId": "joiner",
+          "role": "supporting_file",
+          "required": true,
+          "filename": "joiner.int8.onnx",
+          "downloadUrl": "https://huggingface.co/csukuangfj2/sherpa-onnx-nemo-parakeet-unified-en-0.6b-int8-streaming-560ms/resolve/7551fd26fc810cc1e4e043e608db4d13b59be31e/joiner.int8.onnx",
+          "sha256": "869f43f7d24595c55581ad3bf249a935fb8a71389fbdaa7504b9f46f93140f8a",
+          "sizeBytes": 1735860
+        },
+        {
+          "artifactId": "tokens",
+          "role": "supporting_file",
+          "required": true,
+          "filename": "tokens.txt",
+          "downloadUrl": "https://huggingface.co/csukuangfj2/sherpa-onnx-nemo-parakeet-unified-en-0.6b-int8-streaming-560ms/resolve/7551fd26fc810cc1e4e043e608db4d13b59be31e/tokens.txt",
+          "sha256": "dc0b4584ab2e4ddbf888425c076c61b736e7356a015250db7d307e6f1a8188ff",
+          "sizeBytes": 8952
+        },
+        {
+          "artifactId": "bias_documentation",
+          "role": "supporting_file",
+          "required": true,
+          "filename": "bias.md",
+          "downloadUrl": "https://huggingface.co/csukuangfj2/sherpa-onnx-nemo-parakeet-unified-en-0.6b-int8-streaming-560ms/resolve/7551fd26fc810cc1e4e043e608db4d13b59be31e/bias.md",
+          "sha256": "634920adfccd7897759e495166aef1561a04f3d13026afa4fa64fb4097edb9e0",
+          "sizeBytes": 1008
+        },
+        {
+          "artifactId": "explainability_documentation",
+          "role": "supporting_file",
+          "required": true,
+          "filename": "explainability.md",
+          "downloadUrl": "https://huggingface.co/csukuangfj2/sherpa-onnx-nemo-parakeet-unified-en-0.6b-int8-streaming-560ms/resolve/7551fd26fc810cc1e4e043e608db4d13b59be31e/explainability.md",
+          "sha256": "bd13ed3acf31895d29327ad9649cf1c27f45a0e0acaeb8faf8c1e12feba1a748",
+          "sizeBytes": 2428
+        },
+        {
+          "artifactId": "privacy_documentation",
+          "role": "supporting_file",
+          "required": true,
+          "filename": "privacy.md",
+          "downloadUrl": "https://huggingface.co/csukuangfj2/sherpa-onnx-nemo-parakeet-unified-en-0.6b-int8-streaming-560ms/resolve/7551fd26fc810cc1e4e043e608db4d13b59be31e/privacy.md",
+          "sha256": "10ec3440299669a2430cf5450732b3c2b04f7af2008350c231b335797fbec55c",
+          "sizeBytes": 4066
+        },
+        {
+          "artifactId": "safety_documentation",
+          "role": "supporting_file",
+          "required": true,
+          "filename": "safety.md",
+          "downloadUrl": "https://huggingface.co/csukuangfj2/sherpa-onnx-nemo-parakeet-unified-en-0.6b-int8-streaming-560ms/resolve/7551fd26fc810cc1e4e043e608db4d13b59be31e/safety.md",
+          "sha256": "6307181203b91a766440a7b8276d4d53893fb30c8058636ea2965c1756bf5e8c",
+          "sizeBytes": 782
         }
       ]
     }

--- a/native/src/adapters/mod.rs
+++ b/native/src/adapters/mod.rs
@@ -4,5 +4,8 @@ pub mod cohere_transcribe;
 #[cfg(feature = "engine-moonshine")]
 pub mod moonshine;
 
+#[cfg(feature = "engine-parakeet-unified")]
+pub mod parakeet_unified;
+
 #[cfg(feature = "engine-whisper")]
 pub mod whisper;

--- a/native/src/adapters/parakeet_unified.rs
+++ b/native/src/adapters/parakeet_unified.rs
@@ -1,0 +1,1163 @@
+//! No-Python Parakeet Unified buffered RNNT adapter.
+//!
+//! The graph contract and inference behavior follow the Apache-2.0
+//! sherpa-onnx v1.13.2 Parakeet Unified implementation and its pinned
+//! kaldi-native-fbank v1.22.3 frontend. This is a native Rust implementation
+//! over this project's existing ONNX Runtime, not a sherpa-onnx binding.
+
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use ndarray::{Array, Array1, Array2, Array3, IxDyn};
+use ort::session::Session;
+use ort::value::{
+    DynValue, PrimitiveTensorElementType, Tensor, TensorElementType, Value, ValueType,
+};
+use realfft::RealFftPlanner;
+
+use crate::engine::capabilities::{
+    LanguageSupport, ModelFamilyCapabilities, ModelFamilyId, RuntimeId,
+};
+use crate::engine::traits::{LoadedModel, ModelFamilyAdapter, StreamingModel};
+use crate::protocol::{TimestampGranularity, TimestampSource, TranscriptSegment};
+use crate::runtimes::onnx::build_session;
+use crate::transcription::{
+    EngineTranscriptOutput, GpuConfig, TranscriptionError, validate_model_path,
+};
+
+const SAMPLE_RATE: usize = 16_000;
+const FRAME_SHIFT_SAMPLES: usize = 160;
+const FRAME_LENGTH_SAMPLES: usize = 400;
+const FFT_SIZE: usize = 512;
+const FFT_BINS: usize = FFT_SIZE / 2 + 1;
+const FEATURE_DIM: usize = 128;
+const PREEMPHASIS_COEFFICIENT: f32 = 0.97;
+const NORMALIZATION_EPSILON: f32 = 1e-5;
+const MAX_SYMBOLS_PER_FRAME: usize = 10;
+/// The worker asks for partials every 500 ms, which normally makes three
+/// 160 ms center windows ready together. Batch a small bounded number of
+/// independent encoder windows to amortize ORT dispatch without allowing a
+/// one-shot final to allocate an utterance-sized encoder batch.
+const MAX_ENCODER_BATCH: usize = 4;
+
+const ENCODER_FILENAME: &str = "encoder.int8.onnx";
+const DECODER_FILENAME: &str = "decoder.int8.onnx";
+const JOINER_FILENAME: &str = "joiner.int8.onnx";
+const TOKENS_FILENAME: &str = "tokens.txt";
+const STREAMING_MODEL_TYPE: &str = "nemo_parakeet_unified_streaming";
+
+const CAPABILITIES: ModelFamilyCapabilities = ModelFamilyCapabilities {
+    supports_segment_timestamps: false,
+    supports_word_timestamps: false,
+    supports_initial_prompt: false,
+    supports_streaming: true,
+    supports_language_selection: false,
+    supported_languages: LanguageSupport::EnglishOnly,
+    max_audio_duration_secs: None,
+    produces_punctuation: true,
+};
+
+#[derive(Default)]
+pub struct ParakeetUnifiedAdapter;
+
+impl ModelFamilyAdapter for ParakeetUnifiedAdapter {
+    fn runtime_id(&self) -> RuntimeId {
+        RuntimeId::OnnxRuntime
+    }
+
+    fn family_id(&self) -> ModelFamilyId {
+        ModelFamilyId::ParakeetUnified
+    }
+
+    fn capabilities(&self) -> &ModelFamilyCapabilities {
+        &CAPABILITIES
+    }
+
+    fn probe_model(&self, path: &Path) -> Result<(), TranscriptionError> {
+        let paths = resolve_model_paths(path)?;
+        let encoder = build_session(&paths.encoder, GpuConfig { use_gpu: false })
+            .map_err(invalid_session("encoder"))?;
+        let config = ParakeetConfig::from_encoder(&encoder)?;
+        let decoder = build_session(&paths.decoder, GpuConfig { use_gpu: false })
+            .map_err(invalid_session("decoder"))?;
+        let joiner = build_session(&paths.joiner, GpuConfig { use_gpu: false })
+            .map_err(invalid_session("joiner"))?;
+        verify_graph_topology(&encoder, &decoder, &joiner, &config)?;
+        let tokenizer = ParakeetTokenizer::load(&paths.tokens)?;
+        tokenizer.validate(config.vocab_size)?;
+        Ok(())
+    }
+
+    fn load(
+        &self,
+        _path: &Path,
+        _gpu: GpuConfig,
+    ) -> Result<Box<dyn LoadedModel>, TranscriptionError> {
+        Err(TranscriptionError::unsupported_engine(
+            "Parakeet Unified requires the streaming session path".to_string(),
+        ))
+    }
+
+    fn load_streaming(
+        &self,
+        path: &Path,
+        gpu: GpuConfig,
+    ) -> Result<Box<dyn StreamingModel>, TranscriptionError> {
+        Ok(Box::new(LoadedParakeetModel::load(path, gpu)?))
+    }
+}
+
+fn invalid_session(graph: &'static str) -> impl FnOnce(TranscriptionError) -> TranscriptionError {
+    move |error| {
+        TranscriptionError::invalid_model_with_details(format!(
+            "{graph} session failed to load: {}",
+            error.details.unwrap_or_else(|| error.message.to_string())
+        ))
+    }
+}
+
+struct ModelPaths {
+    encoder: PathBuf,
+    decoder: PathBuf,
+    joiner: PathBuf,
+    tokens: PathBuf,
+}
+
+fn resolve_model_paths(path: &Path) -> Result<ModelPaths, TranscriptionError> {
+    validate_model_path(path)?;
+    if path.file_name() != Some(OsStr::new(ENCODER_FILENAME)) {
+        return Err(TranscriptionError::invalid_model_with_details(format!(
+            "Parakeet Unified external models must be selected via {ENCODER_FILENAME}; received {}",
+            path.display()
+        )));
+    }
+
+    let directory = path.parent().ok_or_else(|| {
+        TranscriptionError::invalid_model_with_details(
+            "cannot determine the Parakeet Unified model directory".to_string(),
+        )
+    })?;
+    let paths = ModelPaths {
+        encoder: path.to_path_buf(),
+        decoder: directory.join(DECODER_FILENAME),
+        joiner: directory.join(JOINER_FILENAME),
+        tokens: directory.join(TOKENS_FILENAME),
+    };
+
+    for required in [&paths.decoder, &paths.joiner, &paths.tokens] {
+        validate_model_path(required).map_err(|_| {
+            TranscriptionError::invalid_model_with_details(format!(
+                "required Parakeet Unified asset missing: {}",
+                required.display()
+            ))
+        })?;
+    }
+    Ok(paths)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParakeetConfig {
+    vocab_size: usize,
+    feature_dim: usize,
+    subsampling_factor: usize,
+    left_feature_frames: usize,
+    chunk_feature_frames: usize,
+    right_feature_frames: usize,
+    left_encoder_frames: usize,
+    chunk_encoder_frames: usize,
+    right_encoder_frames: usize,
+    predictor_layers: usize,
+    predictor_hidden: usize,
+}
+
+impl ParakeetConfig {
+    fn from_encoder(encoder: &Session) -> Result<Self, TranscriptionError> {
+        let metadata = encoder.metadata().map_err(|error| {
+            TranscriptionError::invalid_model_with_details(format!(
+                "failed to read Parakeet Unified encoder metadata: {error}"
+            ))
+        })?;
+        let model_type = metadata.custom("streaming_model_type").ok_or_else(|| {
+            TranscriptionError::invalid_model_with_details(
+                "encoder metadata is missing streaming_model_type".to_string(),
+            )
+        })?;
+        if model_type != STREAMING_MODEL_TYPE {
+            return Err(TranscriptionError::invalid_model_with_details(format!(
+                "expected streaming_model_type={STREAMING_MODEL_TYPE}, found {model_type}"
+            )));
+        }
+        let normalization = metadata.custom("normalize_type").unwrap_or_default();
+        if normalization != "per_feature" {
+            return Err(TranscriptionError::invalid_model_with_details(format!(
+                "unsupported Parakeet Unified normalization {normalization:?}; expected per_feature"
+            )));
+        }
+
+        let decoder_vocab_size = metadata_usize(&metadata, "vocab_size")?;
+        let config = Self {
+            vocab_size: decoder_vocab_size.checked_add(1).ok_or_else(|| {
+                TranscriptionError::invalid_model_with_details(
+                    "Parakeet Unified vocabulary size overflow".to_string(),
+                )
+            })?,
+            feature_dim: metadata_usize(&metadata, "feat_dim")?,
+            subsampling_factor: metadata_usize(&metadata, "subsampling_factor")?,
+            left_feature_frames: metadata_usize(&metadata, "left_feature_frames")?,
+            chunk_feature_frames: metadata_usize(&metadata, "chunk_feature_frames")?,
+            right_feature_frames: metadata_usize(&metadata, "right_feature_frames")?,
+            left_encoder_frames: metadata_usize(&metadata, "left_encoder_frames")?,
+            chunk_encoder_frames: metadata_usize(&metadata, "chunk_encoder_frames")?,
+            right_encoder_frames: metadata_usize(&metadata, "right_encoder_frames")?,
+            predictor_layers: metadata_usize(&metadata, "pred_rnn_layers")?,
+            predictor_hidden: metadata_usize(&metadata, "pred_hidden")?,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    fn validate(&self) -> Result<(), TranscriptionError> {
+        if self.feature_dim != FEATURE_DIM {
+            return Err(TranscriptionError::invalid_model_with_details(format!(
+                "unsupported Parakeet feature dimension {}; expected {FEATURE_DIM}",
+                self.feature_dim
+            )));
+        }
+        if self.subsampling_factor == 0
+            || self.chunk_feature_frames == 0
+            || self.chunk_encoder_frames == 0
+            || self.predictor_layers == 0
+            || self.predictor_hidden == 0
+            || self.vocab_size < 2
+        {
+            return Err(TranscriptionError::invalid_model_with_details(
+                "Parakeet Unified metadata contains a zero or invalid dimension".to_string(),
+            ));
+        }
+        if self.left_feature_frames / self.subsampling_factor != self.left_encoder_frames
+            || self.chunk_feature_frames / self.subsampling_factor != self.chunk_encoder_frames
+            || self.right_feature_frames / self.subsampling_factor != self.right_encoder_frames
+        {
+            return Err(TranscriptionError::invalid_model_with_details(
+                "Parakeet Unified feature and encoder context metadata disagree".to_string(),
+            ));
+        }
+        if self.total_feature_frames() > 4_096
+            || self.predictor_layers > 16
+            || self.predictor_hidden > 8_192
+            || self.vocab_size > 100_000
+        {
+            return Err(TranscriptionError::invalid_model_with_details(
+                "Parakeet Unified metadata exceeds supported safety bounds".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn total_feature_frames(&self) -> usize {
+        self.left_feature_frames + self.chunk_feature_frames + self.right_feature_frames
+    }
+}
+
+fn metadata_usize(
+    metadata: &ort::session::ModelMetadata<'_>,
+    key: &str,
+) -> Result<usize, TranscriptionError> {
+    let value = metadata.custom(key).ok_or_else(|| {
+        TranscriptionError::invalid_model_with_details(format!("encoder metadata is missing {key}"))
+    })?;
+    value.parse::<usize>().map_err(|error| {
+        TranscriptionError::invalid_model_with_details(format!(
+            "invalid encoder metadata {key}={value:?}: {error}"
+        ))
+    })
+}
+
+fn verify_graph_topology(
+    encoder: &Session,
+    decoder: &Session,
+    joiner: &Session,
+    config: &ParakeetConfig,
+) -> Result<(), TranscriptionError> {
+    verify_io_count(encoder, "encoder", 2, 2)?;
+    verify_io_count(decoder, "decoder", 4, 4)?;
+    verify_io_count(joiner, "joiner", 2, 1)?;
+
+    verify_tensor(
+        encoder.inputs()[0].dtype(),
+        "encoder input 0",
+        TensorElementType::Float32,
+        3,
+    )?;
+    verify_tensor(
+        encoder.inputs()[1].dtype(),
+        "encoder input 1",
+        TensorElementType::Int64,
+        1,
+    )?;
+    verify_tensor(
+        decoder.inputs()[0].dtype(),
+        "decoder input 0",
+        TensorElementType::Int32,
+        2,
+    )?;
+    verify_tensor(
+        decoder.inputs()[1].dtype(),
+        "decoder input 1",
+        TensorElementType::Int32,
+        1,
+    )?;
+    for (index, input) in decoder.inputs()[2..].iter().enumerate() {
+        verify_tensor(
+            input.dtype(),
+            &format!("decoder state input {index}"),
+            TensorElementType::Float32,
+            3,
+        )?;
+        if let ValueType::Tensor { shape, .. } = input.dtype() {
+            validate_static_dimension(shape, 0, config.predictor_layers, "decoder state layers")?;
+            validate_static_dimension(shape, 2, config.predictor_hidden, "decoder state hidden")?;
+        }
+    }
+    verify_tensor(
+        joiner.inputs()[0].dtype(),
+        "joiner input 0",
+        TensorElementType::Float32,
+        3,
+    )?;
+    verify_tensor(
+        joiner.inputs()[1].dtype(),
+        "joiner input 1",
+        TensorElementType::Float32,
+        3,
+    )?;
+    Ok(())
+}
+
+fn verify_io_count(
+    session: &Session,
+    graph: &str,
+    input_count: usize,
+    output_count: usize,
+) -> Result<(), TranscriptionError> {
+    if session.inputs().len() != input_count || session.outputs().len() != output_count {
+        return Err(TranscriptionError::invalid_model_with_details(format!(
+            "{graph} graph topology mismatch: expected {input_count} inputs/{output_count} outputs, found {}/{}",
+            session.inputs().len(),
+            session.outputs().len()
+        )));
+    }
+    Ok(())
+}
+
+fn verify_tensor(
+    value_type: &ValueType,
+    name: &str,
+    expected_element: TensorElementType,
+    expected_rank: usize,
+) -> Result<(), TranscriptionError> {
+    let ValueType::Tensor { ty, shape, .. } = value_type else {
+        return Err(TranscriptionError::invalid_model_with_details(format!(
+            "{name} is not a tensor"
+        )));
+    };
+    if *ty != expected_element || shape.len() != expected_rank {
+        return Err(TranscriptionError::invalid_model_with_details(format!(
+            "{name} mismatch: expected {expected_element:?} rank {expected_rank}, found {ty:?} {shape:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_static_dimension(
+    shape: &[i64],
+    index: usize,
+    expected: usize,
+    name: &str,
+) -> Result<(), TranscriptionError> {
+    if let Some(&actual) = shape.get(index)
+        && actual > 0
+        && actual != expected as i64
+    {
+        return Err(TranscriptionError::invalid_model_with_details(format!(
+            "{name} mismatch: expected {expected}, found {actual}"
+        )));
+    }
+    Ok(())
+}
+
+struct ParakeetTokenizer {
+    pieces: Vec<String>,
+}
+
+impl ParakeetTokenizer {
+    fn load(path: &Path) -> Result<Self, TranscriptionError> {
+        let text = fs::read_to_string(path).map_err(|error| {
+            TranscriptionError::invalid_model_with_details(format!(
+                "failed to read {}: {error}",
+                path.display()
+            ))
+        })?;
+        let mut pieces = Vec::new();
+        for (line_number, line) in text.lines().enumerate() {
+            let (piece, id) = line.rsplit_once(' ').ok_or_else(|| {
+                TranscriptionError::invalid_model_with_details(format!(
+                    "invalid tokens.txt line {}",
+                    line_number + 1
+                ))
+            })?;
+            let id = id.parse::<usize>().map_err(|error| {
+                TranscriptionError::invalid_model_with_details(format!(
+                    "invalid tokens.txt id on line {}: {error}",
+                    line_number + 1
+                ))
+            })?;
+            if id != pieces.len() || piece.is_empty() {
+                return Err(TranscriptionError::invalid_model_with_details(format!(
+                    "tokens.txt must contain contiguous non-empty pieces; line {} declares id {id}",
+                    line_number + 1
+                )));
+            }
+            pieces.push(piece.to_string());
+        }
+        Ok(Self { pieces })
+    }
+
+    fn validate(&self, vocab_size: usize) -> Result<(), TranscriptionError> {
+        if self.pieces.len() != vocab_size
+            || self.pieces.last().map(String::as_str) != Some("<blk>")
+        {
+            return Err(TranscriptionError::invalid_model_with_details(format!(
+                "tokenizer mismatch: expected {vocab_size} pieces ending in <blk>, found {}",
+                self.pieces.len()
+            )));
+        }
+        Ok(())
+    }
+
+    fn decode(&self, token_ids: &[i32]) -> Result<String, TranscriptionError> {
+        let mut text = String::new();
+        for &id in token_ids {
+            let piece = usize::try_from(id)
+                .ok()
+                .and_then(|id| self.pieces.get(id))
+                .ok_or_else(|| {
+                    TranscriptionError::transcription_failure(
+                        "Parakeet tokenizer",
+                        format!("token id {id} is outside the vocabulary"),
+                    )
+                })?;
+            text.push_str(piece);
+        }
+        Ok(text.replace('▁', " ").trim().to_string())
+    }
+}
+
+#[derive(Clone)]
+struct PredictorState {
+    hidden: Vec<f32>,
+    cell: Vec<f32>,
+}
+
+impl PredictorState {
+    fn zeros(config: &ParakeetConfig) -> Self {
+        let length = config.predictor_layers * config.predictor_hidden;
+        Self {
+            hidden: vec![0.0; length],
+            cell: vec![0.0; length],
+        }
+    }
+}
+
+struct DecoderStep {
+    output: Vec<f32>,
+    output_shape: Vec<usize>,
+    next_state: PredictorState,
+}
+
+struct LoadedParakeetModel {
+    config: ParakeetConfig,
+    decoder: Session,
+    encoder: Session,
+    features: OnlineParakeetFeatures,
+    joiner: Session,
+    last_token: Option<i32>,
+    predictor_state_before_last: PredictorState,
+    processed_feature_frames: usize,
+    sample_count: usize,
+    tokenizer: ParakeetTokenizer,
+    tokens: Vec<i32>,
+}
+
+impl LoadedParakeetModel {
+    fn load(path: &Path, gpu: GpuConfig) -> Result<Self, TranscriptionError> {
+        let paths = resolve_model_paths(path)?;
+        let encoder = build_session(&paths.encoder, gpu)?;
+        let config = ParakeetConfig::from_encoder(&encoder)?;
+        let decoder = build_session(&paths.decoder, GpuConfig { use_gpu: false })?;
+        let joiner = build_session(&paths.joiner, GpuConfig { use_gpu: false })?;
+        verify_graph_topology(&encoder, &decoder, &joiner, &config)?;
+        let tokenizer = ParakeetTokenizer::load(&paths.tokens)?;
+        tokenizer.validate(config.vocab_size)?;
+        let predictor_state_before_last = PredictorState::zeros(&config);
+        Ok(Self {
+            config,
+            decoder,
+            encoder,
+            features: OnlineParakeetFeatures::new(),
+            joiner,
+            last_token: None,
+            predictor_state_before_last,
+            processed_feature_frames: 0,
+            sample_count: 0,
+            tokenizer,
+            tokens: Vec::new(),
+        })
+    }
+
+    fn blank_id(&self) -> i32 {
+        (self.config.vocab_size - 1) as i32
+    }
+
+    fn process_ready_chunks(&mut self, finalizing: bool) -> Result<(), TranscriptionError> {
+        if finalizing {
+            self.features.finish();
+        }
+        loop {
+            let ready = self.features.len();
+            let mut consumed_features = 0_usize;
+            let mut valid_encoder_counts = Vec::new();
+            let mut windows = Vec::new();
+            while windows.len() < MAX_ENCODER_BATCH {
+                let processed = self.processed_feature_frames + consumed_features;
+                let remaining = ready.saturating_sub(processed);
+                let can_decode = if finalizing {
+                    remaining > 0
+                } else {
+                    remaining >= self.config.chunk_feature_frames + self.config.right_feature_frames
+                };
+                if !can_decode {
+                    break;
+                }
+
+                let valid_center = remaining.min(self.config.chunk_feature_frames);
+                windows.push(self.features.normalized_window(
+                    processed,
+                    self.config.left_feature_frames,
+                    self.config.chunk_feature_frames,
+                    self.config.right_feature_frames,
+                ));
+                valid_encoder_counts.push(
+                    valid_center
+                        .div_ceil(self.config.subsampling_factor)
+                        .min(self.config.chunk_encoder_frames),
+                );
+                consumed_features += valid_center;
+            }
+            if windows.is_empty() {
+                break;
+            }
+
+            let encoder_batches = self.run_encoder_batch(&windows, &valid_encoder_counts)?;
+            for encoder_frames in encoder_batches {
+                self.decode_encoder_frames(&encoder_frames)?;
+            }
+            self.processed_feature_frames += consumed_features;
+        }
+        Ok(())
+    }
+
+    fn run_encoder_batch(
+        &mut self,
+        normalized_windows: &[Vec<f32>],
+        valid_encoder_counts: &[usize],
+    ) -> Result<Vec<Vec<Vec<f32>>>, TranscriptionError> {
+        debug_assert_eq!(normalized_windows.len(), valid_encoder_counts.len());
+        let batch = normalized_windows.len();
+        let time = self.config.total_feature_frames();
+        let input_batch_stride = self.config.feature_dim * time;
+        let mut transposed = vec![0.0_f32; batch * input_batch_stride];
+        for (batch_index, normalized_window) in normalized_windows.iter().enumerate() {
+            for frame in 0..time {
+                for feature in 0..self.config.feature_dim {
+                    transposed[batch_index * input_batch_stride + feature * time + frame] =
+                        normalized_window[frame * self.config.feature_dim + feature];
+                }
+            }
+        }
+        let features = value(
+            Array3::from_shape_vec((batch, self.config.feature_dim, time), transposed),
+            "Parakeet encoder features",
+        )?;
+        let length = value(
+            Ok(Array1::from_vec(vec![time as i64; batch])),
+            "Parakeet encoder length",
+        )?;
+        let outputs = self
+            .encoder
+            .run(ort::inputs![features, length])
+            .map_err(|error| {
+                TranscriptionError::transcription_failure("Parakeet encoder", &error)
+            })?;
+        let (shape, encoded) = tensor_f32(output_at(&outputs, 0, "encoder output")?, "encoder")?;
+        if shape.len() != 3 || shape[0] != batch as i64 || shape[1] <= 0 || shape[2] <= 0 {
+            return Err(graph_shape_error("encoder output", &shape));
+        }
+        let encoder_dim = dimension(&shape, 1, "encoder output")?;
+        let encoder_time = dimension(&shape, 2, "encoder output")?;
+        let start = self.config.left_encoder_frames;
+        let output_batch_stride = encoder_dim * encoder_time;
+        let mut batches = Vec::with_capacity(batch);
+        for (batch_index, &valid_encoder_frames) in valid_encoder_counts.iter().enumerate() {
+            let end = start.saturating_add(valid_encoder_frames);
+            if valid_encoder_frames == 0 || end > encoder_time {
+                return Err(graph_shape_error("encoder center slice", &shape));
+            }
+            let mut frames = Vec::with_capacity(valid_encoder_frames);
+            for time_index in start..end {
+                let mut frame = Vec::with_capacity(encoder_dim);
+                for column in 0..encoder_dim {
+                    frame.push(
+                        encoded[batch_index * output_batch_stride
+                            + column * encoder_time
+                            + time_index],
+                    );
+                }
+                frames.push(frame);
+            }
+            batches.push(frames);
+        }
+        Ok(batches)
+    }
+
+    fn decode_encoder_frames(
+        &mut self,
+        encoder_frames: &[Vec<f32>],
+    ) -> Result<(), TranscriptionError> {
+        let decoder_input = self.last_token.unwrap_or_else(|| self.blank_id());
+        let mut decoder_step =
+            self.run_decoder(decoder_input, &self.predictor_state_before_last.clone())?;
+
+        for encoder_frame in encoder_frames {
+            for _ in 0..MAX_SYMBOLS_PER_FRAME {
+                let next_token = self.run_joiner(encoder_frame, &decoder_step)?;
+                if next_token == self.blank_id() {
+                    break;
+                }
+                if next_token < 0 || next_token as usize >= self.config.vocab_size - 1 {
+                    return Err(TranscriptionError::transcription_failure(
+                        "Parakeet joiner",
+                        format!("emitted invalid token id {next_token}"),
+                    ));
+                }
+
+                self.tokens.push(next_token);
+                self.last_token = Some(next_token);
+                self.predictor_state_before_last = decoder_step.next_state.clone();
+                decoder_step =
+                    self.run_decoder(next_token, &self.predictor_state_before_last.clone())?;
+            }
+        }
+        Ok(())
+    }
+
+    fn run_decoder(
+        &mut self,
+        token: i32,
+        state: &PredictorState,
+    ) -> Result<DecoderStep, TranscriptionError> {
+        let targets = value(
+            Array2::from_shape_vec((1, 1), vec![token]),
+            "Parakeet decoder target",
+        )?;
+        let target_length = value(
+            Ok(Array1::from_vec(vec![1_i32])),
+            "Parakeet decoder target length",
+        )?;
+        let state_shape = (
+            self.config.predictor_layers,
+            1,
+            self.config.predictor_hidden,
+        );
+        let hidden = value(
+            Array3::from_shape_vec(state_shape, state.hidden.clone()),
+            "Parakeet decoder hidden state",
+        )?;
+        let cell = value(
+            Array3::from_shape_vec(state_shape, state.cell.clone()),
+            "Parakeet decoder cell state",
+        )?;
+        let outputs = self
+            .decoder
+            .run(ort::inputs![targets, target_length, hidden, cell])
+            .map_err(|error| {
+                TranscriptionError::transcription_failure("Parakeet decoder", &error)
+            })?;
+        let (output_shape, output) =
+            tensor_f32(output_at(&outputs, 0, "decoder output")?, "decoder output")?;
+        if output_shape.len() != 3 {
+            return Err(graph_shape_error("decoder output", &output_shape));
+        }
+        let hidden = tensor_f32_data(
+            output_at(&outputs, 2, "decoder hidden state")?,
+            state.hidden.len(),
+            "decoder hidden state",
+        )?;
+        let cell = tensor_f32_data(
+            output_at(&outputs, 3, "decoder cell state")?,
+            state.cell.len(),
+            "decoder cell state",
+        )?;
+        Ok(DecoderStep {
+            output,
+            output_shape: output_shape
+                .iter()
+                .map(|&value| usize::try_from(value).unwrap_or(0))
+                .collect(),
+            next_state: PredictorState { hidden, cell },
+        })
+    }
+
+    fn run_joiner(
+        &mut self,
+        encoder_frame: &[f32],
+        decoder_step: &DecoderStep,
+    ) -> Result<i32, TranscriptionError> {
+        let encoder = value(
+            Array3::from_shape_vec((1, encoder_frame.len(), 1), encoder_frame.to_vec()),
+            "Parakeet joiner encoder input",
+        )?;
+        let decoder = dynamic_value(
+            &decoder_step.output_shape,
+            decoder_step.output.clone(),
+            "Parakeet joiner decoder input",
+        )?;
+        let outputs = self
+            .joiner
+            .run(ort::inputs![encoder, decoder])
+            .map_err(|error| {
+                TranscriptionError::transcription_failure("Parakeet joiner", &error)
+            })?;
+        let (_, logits) = tensor_f32(output_at(&outputs, 0, "joiner output")?, "joiner")?;
+        if logits.len() != self.config.vocab_size {
+            return Err(TranscriptionError::transcription_failure(
+                "Parakeet joiner",
+                format!(
+                    "expected {} logits, found {}",
+                    self.config.vocab_size,
+                    logits.len()
+                ),
+            ));
+        }
+        logits
+            .iter()
+            .enumerate()
+            .max_by(|(_, left), (_, right)| left.total_cmp(right))
+            .map(|(index, _)| index as i32)
+            .ok_or_else(|| {
+                TranscriptionError::transcription_failure("Parakeet joiner", "logits were empty")
+            })
+    }
+
+    fn output(&self) -> Result<EngineTranscriptOutput, TranscriptionError> {
+        let text = self.tokenizer.decode(&self.tokens)?;
+        let segments = if text.is_empty() {
+            Vec::new()
+        } else {
+            vec![TranscriptSegment {
+                end_ms: (self.sample_count as u64 * 1_000) / SAMPLE_RATE as u64,
+                speaker: None,
+                start_ms: 0,
+                text,
+                timestamp_granularity: TimestampGranularity::Utterance,
+                timestamp_source: TimestampSource::Vad,
+            }]
+        };
+        Ok(EngineTranscriptOutput {
+            segments,
+            diagnostics: Vec::new(),
+        })
+    }
+}
+
+impl StreamingModel for LoadedParakeetModel {
+    fn accept_audio(&mut self, samples: &[i16]) -> Result<(), TranscriptionError> {
+        self.sample_count = self.sample_count.saturating_add(samples.len());
+        self.features.accept(samples);
+        Ok(())
+    }
+
+    fn partial(&mut self) -> Result<EngineTranscriptOutput, TranscriptionError> {
+        self.process_ready_chunks(false)?;
+        self.output()
+    }
+
+    fn finalize_utterance(&mut self) -> Result<EngineTranscriptOutput, TranscriptionError> {
+        let result = self.process_ready_chunks(true).and_then(|()| self.output());
+        self.reset_utterance();
+        result
+    }
+
+    fn reset_utterance(&mut self) {
+        self.features.reset();
+        self.last_token = None;
+        self.predictor_state_before_last = PredictorState::zeros(&self.config);
+        self.processed_feature_frames = 0;
+        self.sample_count = 0;
+        self.tokens.clear();
+    }
+}
+
+struct OnlineParakeetFeatures {
+    audio: Vec<f32>,
+    features: Vec<[f32; FEATURE_DIM]>,
+    filterbank: Vec<[f32; FFT_BINS]>,
+    fft_planner: RealFftPlanner<f32>,
+    finished: bool,
+    window: [f32; FRAME_LENGTH_SAMPLES],
+}
+
+impl OnlineParakeetFeatures {
+    fn new() -> Self {
+        Self {
+            audio: Vec::new(),
+            features: Vec::new(),
+            filterbank: build_librosa_filterbank(),
+            fft_planner: RealFftPlanner::new(),
+            finished: false,
+            window: build_periodic_hann_window(),
+        }
+    }
+
+    fn accept(&mut self, samples: &[i16]) {
+        debug_assert!(!self.finished);
+        self.audio
+            .extend(samples.iter().map(|&sample| sample as f32 / 32768.0));
+        self.compute_available(false);
+    }
+
+    fn finish(&mut self) {
+        if !self.finished {
+            self.finished = true;
+            self.compute_available(true);
+        }
+    }
+
+    fn reset(&mut self) {
+        self.audio.clear();
+        self.features.clear();
+        self.finished = false;
+    }
+
+    fn len(&self) -> usize {
+        self.features.len()
+    }
+
+    fn compute_available(&mut self, flush: bool) {
+        if self.audio.is_empty() {
+            return;
+        }
+        let target = frame_count(self.audio.len(), flush);
+        while self.features.len() < target {
+            let frame = self.compute_frame(self.features.len());
+            self.features.push(frame);
+        }
+    }
+
+    fn compute_frame(&mut self, frame_index: usize) -> [f32; FEATURE_DIM] {
+        let start = frame_index as isize * FRAME_SHIFT_SAMPLES as isize
+            + (FRAME_SHIFT_SAMPLES / 2) as isize
+            - (FRAME_LENGTH_SAMPLES / 2) as isize;
+        let mut fft_input = vec![0.0_f32; FFT_SIZE];
+        for (offset, sample) in fft_input[..FRAME_LENGTH_SAMPLES].iter_mut().enumerate() {
+            let source = reflected_index(start + offset as isize, self.audio.len());
+            *sample = self.audio[source];
+        }
+        for index in (1..FRAME_LENGTH_SAMPLES).rev() {
+            fft_input[index] -= PREEMPHASIS_COEFFICIENT * fft_input[index - 1];
+        }
+        fft_input[0] -= PREEMPHASIS_COEFFICIENT * fft_input[0];
+        for (sample, coefficient) in fft_input[..FRAME_LENGTH_SAMPLES]
+            .iter_mut()
+            .zip(self.window)
+        {
+            *sample *= coefficient;
+        }
+
+        let fft = self.fft_planner.plan_fft_forward(FFT_SIZE);
+        let mut fft_output = fft.make_output_vec();
+        fft.process(&mut fft_input, &mut fft_output)
+            .expect("Parakeet FFT buffers match the planned size");
+        let mut power = [0.0_f32; FFT_BINS];
+        for (index, value) in fft_output.iter().enumerate() {
+            power[index] = value.re * value.re + value.im * value.im;
+        }
+
+        let mut result = [0.0_f32; FEATURE_DIM];
+        for (mel_index, weights) in self.filterbank.iter().enumerate() {
+            let energy = weights
+                .iter()
+                .zip(power)
+                .map(|(weight, value)| weight * value)
+                .sum::<f32>();
+            result[mel_index] = energy.max(f32::EPSILON).ln();
+        }
+        result
+    }
+
+    fn normalized_window(
+        &self,
+        processed: usize,
+        left: usize,
+        center: usize,
+        right: usize,
+    ) -> Vec<f32> {
+        let total = left + center + right;
+        let window_start = processed as isize - left as isize;
+        let mut window = vec![0.0_f32; total * FEATURE_DIM];
+        for target_frame in 0..total {
+            let source_frame = window_start + target_frame as isize;
+            if let Some(source) = usize::try_from(source_frame)
+                .ok()
+                .and_then(|source| self.features.get(source))
+            {
+                window[target_frame * FEATURE_DIM..(target_frame + 1) * FEATURE_DIM]
+                    .copy_from_slice(source);
+            }
+        }
+        normalize_per_feature(&mut window, total);
+        window
+    }
+}
+
+fn frame_count(sample_count: usize, flush: bool) -> usize {
+    let mut count = (sample_count + FRAME_SHIFT_SAMPLES / 2) / FRAME_SHIFT_SAMPLES;
+    if flush {
+        return count;
+    }
+    while count > 0 {
+        let last_start = (count - 1) as isize * FRAME_SHIFT_SAMPLES as isize
+            + (FRAME_SHIFT_SAMPLES / 2) as isize
+            - (FRAME_LENGTH_SAMPLES / 2) as isize;
+        if last_start + FRAME_LENGTH_SAMPLES as isize <= sample_count as isize {
+            break;
+        }
+        count -= 1;
+    }
+    count
+}
+
+fn reflected_index(mut index: isize, length: usize) -> usize {
+    let length = length as isize;
+    while index < 0 || index >= length {
+        index = if index < 0 {
+            -index - 1
+        } else {
+            2 * length - 1 - index
+        };
+    }
+    index as usize
+}
+
+fn build_periodic_hann_window() -> [f32; FRAME_LENGTH_SAMPLES] {
+    std::array::from_fn(|index| {
+        let phase = 2.0 * std::f32::consts::PI * index as f32 / FRAME_LENGTH_SAMPLES as f32;
+        0.5 - 0.5 * phase.cos()
+    })
+}
+
+fn build_librosa_filterbank() -> Vec<[f32; FFT_BINS]> {
+    let mel_min = hz_to_slaney_mel(0.0);
+    let mel_max = hz_to_slaney_mel(SAMPLE_RATE as f32 / 2.0);
+    let mel_step = (mel_max - mel_min) / (FEATURE_DIM + 1) as f32;
+    (0..FEATURE_DIM)
+        .map(|bin| {
+            let left = slaney_mel_to_hz(mel_min + bin as f32 * mel_step);
+            let center = slaney_mel_to_hz(mel_min + (bin + 1) as f32 * mel_step);
+            let right = slaney_mel_to_hz(mel_min + (bin + 2) as f32 * mel_step);
+            let normalization = 2.0 / (right - left);
+            std::array::from_fn(|fft_bin| {
+                let hz = SAMPLE_RATE as f32 / FFT_SIZE as f32 * fft_bin as f32;
+                if hz > left && hz <= center {
+                    (hz - left) / (center - left) * normalization
+                } else if hz > center && hz < right {
+                    (right - hz) / (right - center) * normalization
+                } else {
+                    0.0
+                }
+            })
+        })
+        .collect()
+}
+
+fn hz_to_slaney_mel(hz: f32) -> f32 {
+    if hz <= 1_000.0 {
+        hz * 3.0 / 200.0
+    } else {
+        15.0 + 14.545_078 * (hz / 1_000.0).ln()
+    }
+}
+
+fn slaney_mel_to_hz(mel: f32) -> f32 {
+    if mel <= 15.0 {
+        200.0 / 3.0 * mel
+    } else {
+        1_000.0 * ((mel - 15.0) * 0.068_751_775).exp()
+    }
+}
+
+fn normalize_per_feature(window: &mut [f32], frame_count: usize) {
+    for feature in 0..FEATURE_DIM {
+        let mean = (0..frame_count)
+            .map(|frame| window[frame * FEATURE_DIM + feature])
+            .sum::<f32>()
+            / frame_count as f32;
+        let variance = ((0..frame_count)
+            .map(|frame| {
+                let value = window[frame * FEATURE_DIM + feature];
+                value * value
+            })
+            .sum::<f32>()
+            / frame_count as f32
+            - mean * mean)
+            .max(0.0);
+        let inverse_stddev = 1.0 / (variance.sqrt() + NORMALIZATION_EPSILON);
+        for frame in 0..frame_count {
+            let value = &mut window[frame * FEATURE_DIM + feature];
+            *value = (*value - mean) * inverse_stddev;
+        }
+    }
+}
+
+fn value<T, D>(
+    result: Result<ndarray::Array<T, D>, ndarray::ShapeError>,
+    context: &str,
+) -> Result<Tensor<T>, TranscriptionError>
+where
+    T: PrimitiveTensorElementType + Clone + std::fmt::Debug + 'static,
+    D: ndarray::Dimension + 'static,
+{
+    let array =
+        result.map_err(|error| TranscriptionError::transcription_failure(context, &error))?;
+    Value::from_array(array)
+        .map_err(|error| TranscriptionError::transcription_failure(context, &error))
+}
+
+fn dynamic_value(
+    shape: &[usize],
+    data: Vec<f32>,
+    context: &str,
+) -> Result<Tensor<f32>, TranscriptionError> {
+    value(Array::from_shape_vec(IxDyn(shape), data), context)
+}
+
+fn output_at<'a>(
+    outputs: &'a ort::session::SessionOutputs<'_>,
+    index: usize,
+    name: &str,
+) -> Result<&'a DynValue, TranscriptionError> {
+    if index >= outputs.len() {
+        return Err(TranscriptionError::transcription_failure(
+            "Parakeet graph output",
+            format!("missing {name} at index {index}"),
+        ));
+    }
+    Ok(&outputs[index])
+}
+
+fn tensor_f32(value: &DynValue, name: &str) -> Result<(Vec<i64>, Vec<f32>), TranscriptionError> {
+    let (shape, data) = value
+        .try_extract_tensor::<f32>()
+        .map_err(|error| TranscriptionError::transcription_failure(name, &error))?;
+    Ok((shape.to_vec(), data.to_vec()))
+}
+
+fn tensor_f32_data(
+    value: &DynValue,
+    expected_len: usize,
+    name: &str,
+) -> Result<Vec<f32>, TranscriptionError> {
+    let (shape, data) = tensor_f32(value, name)?;
+    if data.len() != expected_len {
+        return Err(graph_shape_error(name, &shape));
+    }
+    Ok(data)
+}
+
+fn dimension(shape: &[i64], index: usize, name: &str) -> Result<usize, TranscriptionError> {
+    shape
+        .get(index)
+        .and_then(|value| usize::try_from(*value).ok())
+        .ok_or_else(|| graph_shape_error(name, shape))
+}
+
+fn graph_shape_error(name: &str, shape: &[i64]) -> TranscriptionError {
+    TranscriptionError::transcription_failure(
+        "Parakeet graph shape",
+        format!("unexpected {name} shape {shape:?}"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_snipping_frame_count_waits_for_complete_frames_until_flush() {
+        assert_eq!(frame_count(0, false), 0);
+        assert_eq!(frame_count(320, false), 1);
+        assert_eq!(frame_count(320, true), 2);
+        assert_eq!(frame_count(16_000, false), 99);
+        assert_eq!(frame_count(16_000, true), 100);
+    }
+
+    #[test]
+    fn reflected_index_matches_kaldi_edge_rules() {
+        assert_eq!(reflected_index(-1, 4), 0);
+        assert_eq!(reflected_index(-2, 4), 1);
+        assert_eq!(reflected_index(4, 4), 3);
+        assert_eq!(reflected_index(5, 4), 2);
+        assert_eq!(reflected_index(9, 4), 1);
+    }
+
+    #[test]
+    fn periodic_hann_has_expected_endpoints() {
+        let window = build_periodic_hann_window();
+        assert_eq!(window[0], 0.0);
+        assert!(window[FRAME_LENGTH_SAMPLES / 2] > 0.999);
+        assert!(window[FRAME_LENGTH_SAMPLES - 1] > 0.0);
+    }
+
+    #[test]
+    fn per_feature_normalization_uses_population_variance() {
+        let frames = 3;
+        let mut window = vec![0.0_f32; frames * FEATURE_DIM];
+        window[0] = 1.0;
+        window[FEATURE_DIM] = 2.0;
+        window[2 * FEATURE_DIM] = 3.0;
+        normalize_per_feature(&mut window, frames);
+        assert!(window[0] < -1.22 && window[0] > -1.23);
+        assert!(window[FEATURE_DIM].abs() < 1e-5);
+        assert!(window[2 * FEATURE_DIM] > 1.22 && window[2 * FEATURE_DIM] < 1.23);
+    }
+
+    #[test]
+    fn tokenizer_requires_contiguous_ids_and_blank_last() {
+        let tokenizer = ParakeetTokenizer {
+            pieces: vec!["▁hello".to_string(), "<blk>".to_string()],
+        };
+        tokenizer.validate(2).unwrap();
+        assert_eq!(tokenizer.decode(&[0]).unwrap(), "hello");
+        assert!(tokenizer.validate(3).is_err());
+    }
+
+    #[test]
+    fn feature_windows_zero_pad_context_before_normalization() {
+        let mut extractor = OnlineParakeetFeatures::new();
+        extractor.accept(&vec![0_i16; 8_000]);
+        let window = extractor.normalized_window(0, 560, 16, 40);
+        assert_eq!(window.len(), 616 * FEATURE_DIM);
+        assert!(window.iter().all(|value| value.is_finite()));
+    }
+}

--- a/native/src/app.rs
+++ b/native/src/app.rs
@@ -1913,6 +1913,10 @@ mod tests {
             RuntimeId::OnnxRuntime,
             ModelFamilyId::CohereTranscribe,
         )));
+        registry.register_adapter(Box::new(FakeAdapter::for_family(
+            RuntimeId::OnnxRuntime,
+            ModelFamilyId::ParakeetUnified,
+        )));
         Arc::new(registry)
     }
 
@@ -2073,6 +2077,7 @@ mod tests {
                     vec![
                         (RuntimeId::OnnxRuntime, ModelFamilyId::CohereTranscribe),
                         (RuntimeId::OnnxRuntime, ModelFamilyId::Moonshine),
+                        (RuntimeId::OnnxRuntime, ModelFamilyId::ParakeetUnified),
                         (RuntimeId::WhisperCpp, ModelFamilyId::Whisper),
                     ]
                 );

--- a/native/src/catalog.rs
+++ b/native/src/catalog.rs
@@ -301,6 +301,33 @@ mod tests {
     }
 
     #[test]
+    fn bundled_parakeet_model_is_pinned_and_within_footprint_gate() {
+        let catalog = ModelCatalog::load_bundled().expect("bundled catalog should load");
+        let model = catalog
+            .find_model(
+                RuntimeId::OnnxRuntime,
+                ModelFamilyId::ParakeetUnified,
+                "parakeet_unified_en_int8_streaming_560ms",
+            )
+            .expect("Parakeet Unified 560 ms model should be cataloged");
+
+        assert_eq!(model.license_label, "NVIDIA Open Model License");
+        assert_eq!(model.artifacts.len(), 8);
+        assert!(model.artifacts.iter().all(|artifact| {
+            artifact
+                .download_url
+                .contains("7551fd26fc810cc1e4e043e608db4d13b59be31e")
+        }));
+        assert!(model.required_download_bytes() <= 700 * 1024 * 1024);
+        assert_eq!(
+            model
+                .primary_artifact()
+                .map(|artifact| artifact.filename.as_str()),
+            Some("encoder.int8.onnx")
+        );
+    }
+
+    #[test]
     fn validate_rejects_duplicate_runtime_ids() {
         let error = ModelCatalog {
             catalog_version: 2,

--- a/native/src/engine/capabilities.rs
+++ b/native/src/engine/capabilities.rs
@@ -32,6 +32,7 @@ impl RuntimeId {
 pub enum ModelFamilyId {
     CohereTranscribe,
     Moonshine,
+    ParakeetUnified,
     Whisper,
 }
 
@@ -40,6 +41,7 @@ impl ModelFamilyId {
         match self {
             Self::CohereTranscribe => "cohere_transcribe",
             Self::Moonshine => "moonshine",
+            Self::ParakeetUnified => "parakeet_unified",
             Self::Whisper => "whisper",
         }
     }
@@ -48,6 +50,7 @@ impl ModelFamilyId {
         match self {
             Self::CohereTranscribe => "Cohere Transcribe",
             Self::Moonshine => "Moonshine",
+            Self::ParakeetUnified => "NVIDIA Parakeet Unified",
             Self::Whisper => "Whisper",
         }
     }

--- a/native/src/engine/registry.rs
+++ b/native/src/engine/registry.rs
@@ -29,7 +29,11 @@ impl EngineRegistry {
             registry.register_adapter(Box::new(crate::adapters::whisper::WhisperAdapter));
         }
 
-        #[cfg(any(feature = "engine-cohere-transcribe", feature = "engine-moonshine"))]
+        #[cfg(any(
+            feature = "engine-cohere-transcribe",
+            feature = "engine-moonshine",
+            feature = "engine-parakeet-unified"
+        ))]
         registry.register_runtime(Box::new(crate::runtimes::onnx::OnnxRuntime::probe()));
 
         #[cfg(feature = "engine-cohere-transcribe")]
@@ -41,6 +45,11 @@ impl EngineRegistry {
 
         #[cfg(feature = "engine-moonshine")]
         registry.register_adapter(Box::new(crate::adapters::moonshine::MoonshineAdapter));
+
+        #[cfg(feature = "engine-parakeet-unified")]
+        registry.register_adapter(Box::new(
+            crate::adapters::parakeet_unified::ParakeetUnifiedAdapter,
+        ));
 
         registry
     }

--- a/native/src/protocol.rs
+++ b/native/src/protocol.rs
@@ -606,6 +606,9 @@ pub fn system_info_string() -> String {
     #[cfg(feature = "engine-moonshine")]
     parts.push("moonshine: enabled".to_string());
 
+    #[cfg(feature = "engine-parakeet-unified")]
+    parts.push("parakeet-unified: enabled".to_string());
+
     parts.join(" | ")
 }
 

--- a/native/src/runtimes/mod.rs
+++ b/native/src/runtimes/mod.rs
@@ -1,4 +1,8 @@
-#[cfg(any(feature = "engine-cohere-transcribe", feature = "engine-moonshine"))]
+#[cfg(any(
+    feature = "engine-cohere-transcribe",
+    feature = "engine-moonshine",
+    feature = "engine-parakeet-unified"
+))]
 pub mod onnx;
 
 #[cfg(feature = "engine-whisper")]

--- a/native/tests/common/model.rs
+++ b/native/tests/common/model.rs
@@ -22,6 +22,13 @@ const MOONSHINE_SIBLINGS: &[&str] = &[
     "tokenizer.bin",
 ];
 
+const PARAKEET_SIBLINGS: &[&str] = &[
+    "encoder.int8.onnx",
+    "decoder.int8.onnx",
+    "joiner.int8.onnx",
+    "tokens.txt",
+];
+
 /// Smallest bundled whisper model — fast to download and load on CPU, which
 /// keeps the suite cheap while still exercising the real inference path.
 pub const TEST_MODEL_ID: &str = "whisper_tiny_en_q8_0";
@@ -137,6 +144,33 @@ pub fn require_moonshine_model(tier: MoonshineTier) -> PathBuf {
              to reuse local assets, or ensure network access for the catalog download."
         )
     })
+}
+
+/// Resolve the entry point for a local Parakeet Unified buffered-streaming
+/// export. The 632 MiB model is intentionally not auto-downloaded by the test
+/// helper; installing it through the catalog separately exercises the normal
+/// download and integrity-verification path without surprising test runners.
+pub fn require_parakeet_model() -> PathBuf {
+    let dir = std::env::var_os("STT_TEST_PARAKEET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            panic!(
+                "STT_TEST_PARAKEET_DIR must point at a directory containing {}",
+                PARAKEET_SIBLINGS.join(", ")
+            )
+        });
+    let missing: Vec<&str> = PARAKEET_SIBLINGS
+        .iter()
+        .copied()
+        .filter(|filename| !dir.join(filename).is_file())
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "Parakeet model directory {} is missing: {}",
+        dir.display(),
+        missing.join(", ")
+    );
+    dir.join("encoder.int8.onnx")
 }
 
 fn verify_moonshine_siblings(dir: &Path) -> Result<(), String> {

--- a/native/tests/parakeet_e2e.rs
+++ b/native/tests/parakeet_e2e.rs
@@ -1,0 +1,152 @@
+//! Real-model Parakeet Unified smoke and streaming-consistency tests.
+//!
+//! Run with a model installed from the bundled catalog:
+//! `STT_TEST_PARAKEET_DIR=/path/to/parakeet cargo test --manifest-path native/Cargo.toml \
+//!   --features engine-parakeet-unified --test parakeet_e2e -- --ignored --nocapture`
+
+mod common;
+
+use common::manifest::Corpus;
+use common::model::require_parakeet_model;
+use common::text::{missing_anchors, word_error_rate};
+use common::{audio, driver};
+use local_dictation_sidecar::adapters::parakeet_unified::ParakeetUnifiedAdapter;
+use local_dictation_sidecar::engine::traits::ModelFamilyAdapter;
+use local_dictation_sidecar::engine::{ModelFamilyId, RuntimeId};
+use local_dictation_sidecar::protocol::SelectedModel;
+use local_dictation_sidecar::transcription::{EngineTranscriptOutput, GpuConfig};
+
+fn joined_text(output: &EngineTranscriptOutput) -> String {
+    output
+        .segments
+        .iter()
+        .map(|segment| segment.text.trim())
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn selection(encoder: &std::path::Path) -> SelectedModel {
+    SelectedModel::ExternalFile {
+        runtime_id: RuntimeId::OnnxRuntime,
+        family_id: ModelFamilyId::ParakeetUnified,
+        file_path: encoder.display().to_string(),
+    }
+}
+
+#[test]
+#[ignore = "needs the 632 MiB Parakeet Unified model; run with --ignored"]
+fn parakeet_runs_through_vad_worker_and_revision_protocol() {
+    let encoder = require_parakeet_model();
+    let fixture = Corpus::load()
+        .fixtures
+        .into_iter()
+        .find(|fixture| fixture.id == "7021-79740-0000")
+        .unwrap();
+    let samples = audio::decode_wav_16k_mono(&fixture.audio_path()).unwrap();
+    let frames = audio::fixture_frames_with_trailing_silence(&samples);
+
+    let outcome = driver::stream_in_process(selection(&encoder), &frames);
+    assert!(outcome.stopped, "session should stop after the final");
+    assert!(outcome.errors.is_empty(), "errors: {:?}", outcome.errors);
+    assert!(
+        !outcome.partials.is_empty(),
+        "expected live partial revisions"
+    );
+    assert!(
+        outcome
+            .partials
+            .windows(2)
+            .all(|pair| pair[1].revision > pair[0].revision),
+        "partial revisions must be strictly increasing"
+    );
+    let wer = word_error_rate(&fixture.reference, &outcome.final_text);
+    eprintln!(
+        "Parakeet worker final: {}\nWER: {wer:.3}",
+        outcome.final_text
+    );
+    assert!(
+        wer <= fixture.max_wer,
+        "WER {wer:.3} exceeded {}",
+        fixture.max_wer
+    );
+    let missing = missing_anchors(&outcome.final_text, &fixture.anchors);
+    assert!(missing.is_empty(), "missing anchor words: {missing:?}");
+}
+
+#[test]
+#[ignore = "needs the 632 MiB Parakeet Unified model; run with --ignored"]
+fn parakeet_streams_stable_partials_and_matches_one_shot_final() {
+    let encoder = require_parakeet_model();
+    let samples =
+        audio::decode_wav_16k_mono(&common::fixtures_dir().join("audio/7021-79740-0000.wav"))
+            .unwrap();
+
+    let mut streaming = ParakeetUnifiedAdapter
+        .load_streaming(&encoder, GpuConfig { use_gpu: false })
+        .unwrap();
+    let mut partials = Vec::new();
+    for chunk in samples.chunks(8_000) {
+        streaming.accept_audio(chunk).unwrap();
+        let text = joined_text(&streaming.partial().unwrap());
+        if partials.last() != Some(&text) && !text.is_empty() {
+            partials.push(text);
+        }
+    }
+    let streaming_final = streaming.finalize_utterance().unwrap();
+    let final_text = joined_text(&streaming_final);
+    assert!(
+        joined_text(&streaming.partial().unwrap()).is_empty(),
+        "finalization must reset the open utterance"
+    );
+
+    streaming.accept_audio(&samples).unwrap();
+    let reused_final = streaming.finalize_utterance().unwrap();
+    assert_eq!(
+        streaming_final, reused_final,
+        "a finalized model must be reusable for the next utterance"
+    );
+
+    let mut one_shot = ParakeetUnifiedAdapter
+        .load_streaming(&encoder, GpuConfig { use_gpu: false })
+        .unwrap();
+    one_shot.accept_audio(&samples).unwrap();
+    let one_shot_final = one_shot.finalize_utterance().unwrap();
+
+    assert!(
+        !partials.is_empty(),
+        "expected at least one non-empty partial"
+    );
+    assert!(
+        partials
+            .windows(2)
+            .all(|pair| pair[1].starts_with(&pair[0])),
+        "Parakeet RNNT partials must preserve their committed prefix: {partials:?}"
+    );
+    assert_eq!(streaming_final, one_shot_final);
+    let fixture = Corpus::load()
+        .fixtures
+        .into_iter()
+        .find(|fixture| fixture.id == "7021-79740-0000")
+        .unwrap();
+    let wer = word_error_rate(&fixture.reference, &final_text);
+    eprintln!("Parakeet final: {final_text}\nWER: {wer:.3}");
+    assert!(
+        wer <= fixture.max_wer,
+        "WER {wer:.3} exceeded {}",
+        fixture.max_wer
+    );
+    let missing = missing_anchors(&final_text, &fixture.anchors);
+    assert!(missing.is_empty(), "missing anchor words: {missing:?}");
+}
+
+#[test]
+#[ignore = "needs the 632 MiB Parakeet Unified model; run with --ignored"]
+fn parakeet_silence_produces_no_text() {
+    let encoder = require_parakeet_model();
+    let mut model = ParakeetUnifiedAdapter
+        .load_streaming(&encoder, GpuConfig { use_gpu: false })
+        .unwrap();
+    model.accept_audio(&vec![0_i16; 3 * 16_000]).unwrap();
+    assert!(joined_text(&model.finalize_utterance().unwrap()).is_empty());
+}

--- a/native/tests/registry_smoke.rs
+++ b/native/tests/registry_smoke.rs
@@ -81,6 +81,30 @@ fn moonshine_pair_is_registered_when_compiled() {
     );
 }
 
+#[cfg(feature = "engine-parakeet-unified")]
+#[test]
+fn parakeet_unified_pair_is_registered_when_compiled() {
+    let registry = EngineRegistry::build();
+
+    let adapter = registry
+        .adapter(RuntimeId::OnnxRuntime, ModelFamilyId::ParakeetUnified)
+        .expect("Parakeet Unified adapter must be registered when its engine feature is on");
+    assert_eq!(adapter.runtime_id(), RuntimeId::OnnxRuntime);
+    assert_eq!(adapter.family_id(), ModelFamilyId::ParakeetUnified);
+
+    let merged = registry
+        .merged_capabilities(RuntimeId::OnnxRuntime, ModelFamilyId::ParakeetUnified)
+        .expect("merged capabilities must be present for compiled pair");
+    assert!(merged.family.supports_streaming);
+    assert!(merged.family.produces_punctuation);
+    assert!(
+        merged
+            .runtime
+            .available_accelerators
+            .contains(&AcceleratorId::Cpu)
+    );
+}
+
 #[test]
 fn probe_against_missing_path_surfaces_structured_error_for_registered_pair() {
     let registry = EngineRegistry::build();

--- a/scripts/build-cuda.sh
+++ b/scripts/build-cuda.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build sidecar: Whisper + Cohere + CUDA GPU. Linux only.
+# Build sidecar: all speech families + CUDA GPU. Linux only.
 # Output goes to target-cuda/ to avoid overwriting the CPU binary.
 set -euo pipefail
 
@@ -7,7 +7,7 @@ usage() {
   cat <<'EOF'
 Usage: bash scripts/build-cuda.sh [OPTIONS]
 
-Build the CUDA-enabled native sidecar (Whisper+CUDA, Cohere+CUDA).
+Build the CUDA-enabled native sidecar (Whisper, Cohere, Moonshine, and Parakeet Unified).
 Output: native/target-cuda/{debug|release}/local-dictation-sidecar
 
 Options:

--- a/scripts/build-sidecar.mjs
+++ b/scripts/build-sidecar.mjs
@@ -5,8 +5,8 @@ const args = new Set(process.argv.slice(2));
 
 const features =
   process.platform === 'darwin'
-    ? 'engine-whisper,engine-cohere-transcribe,engine-moonshine,gpu-metal'
-    : 'engine-whisper,engine-cohere-transcribe,engine-moonshine';
+    ? 'engine-whisper,engine-cohere-transcribe,engine-moonshine,engine-parakeet-unified,gpu-metal'
+    : 'engine-whisper,engine-cohere-transcribe,engine-moonshine,engine-parakeet-unified';
 
 const cargoArgs = [
   'build',

--- a/scripts/check-rust.mjs
+++ b/scripts/check-rust.mjs
@@ -16,7 +16,7 @@ run(
     'native/Cargo.toml',
     '--all-targets',
     '--features',
-    'engine-cohere-transcribe,engine-moonshine,engine-whisper',
+    'engine-cohere-transcribe,engine-moonshine,engine-parakeet-unified,engine-whisper',
     '--',
     '-D',
     'warnings',
@@ -31,5 +31,5 @@ run('cargo', [
   '--manifest-path',
   'native/Cargo.toml',
   '--features',
-  'engine-cohere-transcribe,engine-moonshine,engine-whisper',
+  'engine-cohere-transcribe,engine-moonshine,engine-parakeet-unified,engine-whisper',
 ]);

--- a/src/models/external-model-file.ts
+++ b/src/models/external-model-file.ts
@@ -10,7 +10,22 @@ export interface ExternalFileEngineOption {
   selection: Pick<ExternalFileModelSelection, 'familyId' | 'runtimeId'>;
 }
 
+export const DEFAULT_EXTERNAL_FILE_ENGINE_SELECTION = {
+  familyId: 'whisper',
+  runtimeId: 'whisper_cpp',
+} as const satisfies Pick<ExternalFileModelSelection, 'familyId' | 'runtimeId'>;
+
 export const EXTERNAL_FILE_ENGINES: readonly ExternalFileEngineOption[] = [
+  {
+    label: 'NVIDIA Parakeet Unified (ONNX Runtime)',
+    placeholder: '/absolute/path/to/parakeet/encoder.int8.onnx',
+    requirements: [
+      'Select encoder.int8.onnx from a Parakeet Unified buffered-streaming export.',
+      'The same directory must contain decoder.int8.onnx, joiner.int8.onnx, and tokens.txt.',
+      'Legacy Parakeet TDT and non-streaming exports are not compatible.',
+    ],
+    selection: { familyId: 'parakeet_unified', runtimeId: 'onnx_runtime' },
+  },
   {
     label: 'Moonshine (ONNX Runtime)',
     placeholder: '/absolute/path/to/moonshine/frontend.ort',
@@ -29,7 +44,7 @@ export const EXTERNAL_FILE_ENGINES: readonly ExternalFileEngineOption[] = [
       'The loader validates the file contents; a filename extension alone does not establish compatibility.',
       'Local Dictation currently runs Whisper models in English.',
     ],
-    selection: { familyId: 'whisper', runtimeId: 'whisper_cpp' },
+    selection: DEFAULT_EXTERNAL_FILE_ENGINE_SELECTION,
   },
 ];
 
@@ -54,6 +69,12 @@ export async function validateExternalModelFilePath(
   if (engine.familyId === 'moonshine' && basename(normalizedPath) !== 'frontend.ort') {
     throw new Error(
       'Moonshine requires its primary frontend.ort artifact. Select frontend.ort from the streaming model directory.',
+    );
+  }
+
+  if (engine.familyId === 'parakeet_unified' && basename(normalizedPath) !== 'encoder.int8.onnx') {
+    throw new Error(
+      'Parakeet Unified requires its encoder.int8.onnx artifact. Select encoder.int8.onnx from the buffered-streaming model directory.',
     );
   }
 

--- a/src/models/model-management-modals.ts
+++ b/src/models/model-management-modals.ts
@@ -5,6 +5,7 @@ import { formatBytes } from '../shared/format-utils';
 import type { UserFeedback } from '../shared/user-feedback';
 import { buildCapabilityLabels } from './capability-view';
 import {
+  DEFAULT_EXTERNAL_FILE_ENGINE_SELECTION,
   EXTERNAL_FILE_ENGINES,
   formatExternalModelValidationError,
   getExternalFileEngineOption,
@@ -167,12 +168,7 @@ export class ExternalModelFileModal extends Modal {
         return option.selection;
       }
     }
-    return (
-      EXTERNAL_FILE_ENGINES[1]?.selection ?? {
-        familyId: 'whisper',
-        runtimeId: 'whisper_cpp',
-      }
-    );
+    return DEFAULT_EXTERNAL_FILE_ENGINE_SELECTION;
   }
 }
 

--- a/src/models/model-management-types.ts
+++ b/src/models/model-management-types.ts
@@ -4,7 +4,12 @@ export const RUNTIME_IDS = ['onnx_runtime', 'whisper_cpp'] as const;
 
 export type RuntimeId = (typeof RUNTIME_IDS)[number];
 
-export const MODEL_FAMILY_IDS = ['cohere_transcribe', 'moonshine', 'whisper'] as const;
+export const MODEL_FAMILY_IDS = [
+  'cohere_transcribe',
+  'moonshine',
+  'parakeet_unified',
+  'whisper',
+] as const;
 
 export type ModelFamilyId = (typeof MODEL_FAMILY_IDS)[number];
 

--- a/src/models/model-row-state.ts
+++ b/src/models/model-row-state.ts
@@ -285,6 +285,8 @@ function resolveFamilyDisplayName(
       return 'Cohere Transcribe';
     case 'moonshine':
       return 'Moonshine';
+    case 'parakeet_unified':
+      return 'NVIDIA Parakeet Unified';
     case 'whisper':
       return 'Whisper';
   }

--- a/test/external-model-file.test.ts
+++ b/test/external-model-file.test.ts
@@ -5,21 +5,26 @@ import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import {
+  DEFAULT_EXTERNAL_FILE_ENGINE_SELECTION,
+  EXTERNAL_FILE_ENGINES,
   formatExternalModelValidationError,
   getExternalFileEngineOption,
   validateExternalModelFilePath,
 } from '../src/models/external-model-file';
 
 let modelDirectory: string;
+let parakeetEncoderPath: string;
 let frontendPath: string;
 let whisperPath: string;
 
 beforeAll(async () => {
   modelDirectory = await mkdtemp(join(tmpdir(), 'external-model-file-test-'));
   frontendPath = join(modelDirectory, 'frontend.ort');
+  parakeetEncoderPath = join(modelDirectory, 'encoder.int8.onnx');
   whisperPath = join(modelDirectory, 'ggml-small.en-q5_1.bin');
   await Promise.all([
     writeFile(frontendPath, 'frontend fixture', 'utf8'),
+    writeFile(parakeetEncoderPath, 'Parakeet encoder fixture', 'utf8'),
     writeFile(whisperPath, 'whisper fixture', 'utf8'),
   ]);
 });
@@ -55,9 +60,37 @@ describe('validateExternalModelFilePath', () => {
       }),
     ).resolves.toBe(frontendPath);
   });
+
+  it('requires encoder.int8.onnx as the selected Parakeet artifact', async () => {
+    await expect(
+      validateExternalModelFilePath(frontendPath, {
+        familyId: 'parakeet_unified',
+        runtimeId: 'onnx_runtime',
+      }),
+    ).rejects.toThrow(/requires its encoder\.int8\.onnx artifact/);
+
+    await expect(
+      validateExternalModelFilePath(parakeetEncoderPath, {
+        familyId: 'parakeet_unified',
+        runtimeId: 'onnx_runtime',
+      }),
+    ).resolves.toBe(parakeetEncoderPath);
+  });
 });
 
 describe('external model guidance', () => {
+  it('keeps Whisper as the explicit default independent of option ordering', () => {
+    expect(DEFAULT_EXTERNAL_FILE_ENGINE_SELECTION).toEqual({
+      familyId: 'whisper',
+      runtimeId: 'whisper_cpp',
+    });
+    expect(
+      EXTERNAL_FILE_ENGINES.find(
+        (option) => option.selection === DEFAULT_EXTERNAL_FILE_ENGINE_SELECTION,
+      ),
+    ).toBeDefined();
+  });
+
   it('documents the exact Moonshine entry artifact and companion set', () => {
     const option = getExternalFileEngineOption({
       familyId: 'moonshine',
@@ -84,6 +117,20 @@ describe('external model guidance', () => {
 
     expect(guidance).toContain('GGML');
     expect(guidance).toContain('GGUF');
+  });
+
+  it('documents the exact Parakeet graph set and rejects legacy exports', () => {
+    const option = getExternalFileEngineOption({
+      familyId: 'parakeet_unified',
+      runtimeId: 'onnx_runtime',
+    });
+    const guidance = option?.requirements.join(' ') ?? '';
+
+    expect(guidance).toContain('encoder.int8.onnx');
+    expect(guidance).toContain('decoder.int8.onnx');
+    expect(guidance).toContain('joiner.int8.onnx');
+    expect(guidance).toContain('tokens.txt');
+    expect(guidance).toContain('Legacy Parakeet');
   });
 
   it('preserves an actionable probe error for display', () => {

--- a/test/package-sidecar-base-files.test.ts
+++ b/test/package-sidecar-base-files.test.ts
@@ -38,5 +38,8 @@ describe('stageSidecarBaseFiles', () => {
     expect(notices).toContain('Silero VAD');
     expect(notices).toContain('Copyright (c) 2020-present Silero Team');
     expect(notices).toContain('MIT License');
+    expect(notices).toContain('NVIDIA Parakeet Unified');
+    expect(notices).toContain('NVIDIA Open Model License Agreement');
+    expect(notices).toContain('Licensed by NVIDIA Corporation under the NVIDIA Open Model License');
   });
 });


### PR DESCRIPTION
## Summary

- adds a native Rust `parakeet_unified` family adapter on the existing `ort` runtime
- implements the NeMo-compatible 128-bin frontend, buffered 560 ms encoder windowing, stateful RNNT greedy decoding, partial/final output, and lifecycle reset without Python, PyTorch, NeMo, sherpa-onnx, or another inference runtime in the installed app
- adds the pinned 560 ms int8 model to the managed catalog, external-model guidance, sidecar feature/build wiring, provenance/license documentation, and focused regression/real-model tests
- keeps Moonshine as the recommended default and marks Parakeet experimental because of its CPU/memory cost

Addresses #242.

## Model and runtime

The catalog pins the NVIDIA checkpoint, sherpa-onnx v1.13.2 export implementation, published ONNX revision, every artifact size, and every SHA-256. Required runtime artifacts total 663,057,262 bytes (~632 MiB).

The adapter validates the graph metadata/topology and tokenizer before use. It computes the exact non-snipping reflected-edge, periodic-Hann, 128-bin Slaney/librosa frontend expected by this export. Encoder dispatch is bounded to four independent windows; RNNT predictor state is retained across chunks and reset after every final, including error paths.

## Verification

- `npm run check`
  - 67 Vitest files / 809 tests
  - 289 Rust unit tests, all non-ignored integration tests
  - TypeScript, Biome, ESLint, frontend/sidecar builds, packaging verification
  - Clippy with all speech-family features and `-D warnings`
- real pinned model, release build:
  - full VAD/worker/revision-protocol path passes
  - streamed partials preserve their committed prefix
  - streamed final equals one-shot final
  - post-final model reuse returns identical output
  - 3 seconds of silence produces no transcript
  - LibriSpeech fixture transcript WER: 0.000 with every anchor present
- local worker-path measurement: 15.24 s wall time including model load and a ~12.1 s fixture/trailing-silence path; peak RSS 1.557 GB

## License and provenance

The model remains separately licensed under the NVIDIA Open Model License, not MIT. `THIRD_PARTY_NOTICES.md` includes the full agreement, required NVIDIA Notice, and derived-weight modification notice and is bundled with sidecar archives. The catalog links the license and preserves NVIDIA's bias, explainability, privacy, and safety documents.

The published sherpa export recipe is not bit-reproducible as written because it resolves NeMo/toolchain dependencies from moving branches. This PR pins and verifies the published bytes and documents that narrower guarantee; it does not claim a reproducible derivation.

## Draft / rollout gates

This is intentionally a draft. Issue #242's production gates are not all resolved:

- explicit maintainer/legal approval and per-installed-copy Agreement/Notice handling
- a locked conversion/quantization workflow that reproduces the catalog bytes
- committed NeMo/sherpa golden frontend/token parity
- first-partial/final latency, 1/10/30-second non-growth, RTF, and peak-RSS measurements on macOS arm64, Windows x64, and Linux x64
- same-corpus product-value comparison against Moonshine Medium

The implementation is suitable for CI and maintainer evaluation, but should not merge as a production catalog enablement until those decisions and measurements are recorded.
