### PR TITLE
Move advanced transcript controls into modals

### DIFF
--- a/src/settings/diarization-setting.ts
+++ b/src/settings/diarization-setting.ts
@@ -1,8 +1,6 @@
-const BASE_DESCRIPTION =
-  'Label each utterance with a detected speaker (Speaker 1, Speaker 2, …). Runs fully on-device; no audio leaves your machine.';
-const STREAMING_LIMITATION =
-  'Not applied while a streaming (live) model is selected — speaker labels currently require a batch model.';
+const BASE_DESCRIPTION = 'Label each phrase by speaker.';
+const STREAMING_LIMITATION = 'Speaker labels require a batch model.';
 
 export function diarizationSettingDescription(streamingModelSelected: boolean): string {
-  return streamingModelSelected ? `${BASE_DESCRIPTION} ${STREAMING_LIMITATION}` : BASE_DESCRIPTION;
+  return streamingModelSelected ? STREAMING_LIMITATION : BASE_DESCRIPTION;
 }

--- a/src/settings/diarization-settings-modal.ts
+++ b/src/settings/diarization-settings-modal.ts
@@ -1,0 +1,107 @@
+import type { App } from 'obsidian';
+import { Modal, Setting } from 'obsidian';
+
+import {
+  DEFAULT_PLUGIN_SETTINGS,
+  MAX_DIARIZATION_MAX_SPEAKERS,
+  MIN_DIARIZATION_MAX_SPEAKERS,
+  type PluginSettings,
+} from './plugin-settings';
+
+interface DiarizationSettingsModalDependencies {
+  getSettings: () => PluginSettings;
+  onSave?: () => void;
+  saveSettings: (settings: PluginSettings) => Promise<void>;
+}
+
+export class DiarizationSettingsModal extends Modal {
+  private maxSpeakers: number | null;
+
+  constructor(
+    app: App,
+    private readonly deps: DiarizationSettingsModalDependencies,
+  ) {
+    super(app);
+    this.maxSpeakers = deps.getSettings().diarizationMaxSpeakers;
+  }
+
+  override onOpen(): void {
+    this.titleEl.setText('Speaker label settings');
+    this.render();
+  }
+
+  override onClose(): void {
+    this.contentEl.empty();
+  }
+
+  private render(): void {
+    this.contentEl.empty();
+
+    this.contentEl.createEl('p', {
+      cls: 'setting-item-description',
+      text: 'Speaker labels run on-device after each voice-detected phrase. They require a batch transcription model.',
+    });
+
+    new Setting(this.contentEl)
+      .setName('Maximum speakers')
+      .setDesc(
+        'Automatic determines the speaker count. Set a limit only if extra speaker labels appear.',
+      )
+      .addDropdown((dropdown) => {
+        dropdown.addOption('auto', 'Automatic');
+        for (
+          let count = MIN_DIARIZATION_MAX_SPEAKERS;
+          count <= MAX_DIARIZATION_MAX_SPEAKERS;
+          count += 1
+        ) {
+          dropdown.addOption(String(count), String(count));
+        }
+        dropdown.setValue(this.maxSpeakers?.toString() ?? 'auto');
+        dropdown.onChange((value) => {
+          if (value === 'auto') {
+            this.maxSpeakers = null;
+            return;
+          }
+
+          const parsed = Number(value);
+          if (
+            Number.isInteger(parsed) &&
+            parsed >= MIN_DIARIZATION_MAX_SPEAKERS &&
+            parsed <= MAX_DIARIZATION_MAX_SPEAKERS
+          ) {
+            this.maxSpeakers = parsed;
+          }
+        });
+      });
+
+    new Setting(this.contentEl)
+      .addButton((button) => {
+        button.setButtonText('Reset').onClick(() => {
+          this.maxSpeakers = DEFAULT_PLUGIN_SETTINGS.diarizationMaxSpeakers;
+          this.render();
+        });
+      })
+      .addButton((button) => {
+        button.setButtonText('Cancel').onClick(() => {
+          this.close();
+        });
+      })
+      .addButton((button) => {
+        button
+          .setCta()
+          .setButtonText('Save')
+          .onClick(() => {
+            void this.handleSave();
+          });
+      });
+  }
+
+  private async handleSave(): Promise<void> {
+    await this.deps.saveSettings({
+      ...this.deps.getSettings(),
+      diarizationMaxSpeakers: this.maxSpeakers,
+    });
+    this.deps.onSave?.();
+    this.close();
+  }
+}

--- a/src/settings/phrase-finalization-setting.ts
+++ b/src/settings/phrase-finalization-setting.ts
@@ -6,12 +6,9 @@ const STYLE_DESCRIPTIONS: Record<SpeakingStyle, string> = {
   patient: 'Waits through longer pauses so a thought is less likely to be split.',
 };
 
-const SHARED_DESCRIPTION =
-  'Applies to every transcription model, including live models; live words can still update before the phrase is final.';
-
 export const PHRASE_FINALIZATION_TOOLTIP =
-  'This changes voice-activity boundaries, not writing style or model accuracy. Responsive favors speed; Patient favors keeping pauses inside one phrase.';
+  'Applies to every transcription model. Live words can still update before the phrase is final. This changes voice-activity boundaries, not writing style or model accuracy. Responsive favors speed; Patient favors keeping pauses inside one phrase.';
 
 export function phraseFinalizationDescription(style: SpeakingStyle): string {
-  return `${STYLE_DESCRIPTIONS[style]} ${SHARED_DESCRIPTION}`;
+  return STYLE_DESCRIPTIONS[style];
 }

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -17,6 +17,7 @@ import {
 } from '../sidecar/sidecar-install-manager';
 import { readInstallManifest, variantDirectoryPath } from '../sidecar/sidecar-installer';
 import { diarizationSettingDescription } from './diarization-setting';
+import { DiarizationSettingsModal } from './diarization-settings-modal';
 import { renderActiveInstallCard } from './install-progress-row';
 import { renderMicrophonePicker } from './microphone-picker';
 import { renderModelSection } from './model-settings-section';
@@ -31,8 +32,6 @@ import {
   isRemoteLlmEffectivelyEnabled,
   isSpeakingStyle,
   isTranscriptFormattingMode,
-  MAX_DIARIZATION_MAX_SPEAKERS,
-  MIN_DIARIZATION_MAX_SPEAKERS,
   type PluginSettings,
   type TranscriptFormattingMode,
 } from './plugin-settings';
@@ -226,14 +225,10 @@ export class LocalSttSettingTab extends PluginSettingTab {
 
     this.renderTranscriptFormattingSetting(outputCard);
 
-    let setSpeakerLimitEnabled = (_enabled: boolean): void => {};
     const diarizationSetting = addToggleSetting(outputCard, this.access, {
-      name: 'Speaker labels (diarization)',
+      name: 'Speaker labels',
       desc: '',
       key: 'diarizationEnabled',
-      onChange: (enabled) => {
-        setSpeakerLimitEnabled(enabled);
-      },
     });
     const updateDiarizationDesc = (): void => {
       const caps = manager.getState().selectedModelCapabilities;
@@ -245,44 +240,21 @@ export class LocalSttSettingTab extends PluginSettingTab {
     };
     updateDiarizationDesc();
     this.disposeDiarizationDesc = manager.subscribe(updateDiarizationDesc);
-
-    const speakerLimitSetting = new Setting(outputCard)
-      .setName('Maximum speakers')
-      .setDesc(
-        'Use Automatic unless extra speaker labels appear. Setting the expected count prevents the session from creating labels beyond that limit.',
-      );
-    speakerLimitSetting.addDropdown((dropdown) => {
-      dropdown.addOption('auto', 'Automatic');
-      for (
-        let count = MIN_DIARIZATION_MAX_SPEAKERS;
-        count <= MAX_DIARIZATION_MAX_SPEAKERS;
-        count += 1
-      ) {
-        dropdown.addOption(String(count), String(count));
-      }
-      dropdown.setValue(settings.diarizationMaxSpeakers?.toString() ?? 'auto');
-      dropdown.setDisabled(!settings.diarizationEnabled);
-      setSpeakerLimitEnabled = (enabled) => {
-        dropdown.setDisabled(!enabled);
-      };
-      dropdown.onChange(async (value) => {
-        const parsed = value === 'auto' ? null : Number(value);
-        if (
-          parsed !== null &&
-          (!Number.isInteger(parsed) ||
-            parsed < MIN_DIARIZATION_MAX_SPEAKERS ||
-            parsed > MAX_DIARIZATION_MAX_SPEAKERS)
-        ) {
-          return;
-        }
-        await this.access.persistOne('diarizationMaxSpeakers', parsed);
-      });
-    });
-
-    addToggleSetting(outputCard, this.access, {
-      name: 'Keep recovery text in memory',
-      desc: 'Keep the latest utterance and one raw/transformed batch-cleanup record with its document snapshot. Nothing is saved to disk; disabling this clears it immediately.',
-      key: 'retainLastUtterance',
+    diarizationSetting.addExtraButton((button) => {
+      button
+        .setIcon('sliders-horizontal')
+        .setTooltip('Speaker label settings')
+        .onClick(() => {
+          new DiarizationSettingsModal(this.app, {
+            getSettings: () => this.dependencies.getSettings(),
+            onSave: () => {
+              this.display();
+            },
+            saveSettings: async (nextSettings) => {
+              await this.dependencies.saveSettings(nextSettings);
+            },
+          }).open();
+        });
     });
 
     const timestampsCard = createSettingGroup(containerEl, 'Timestamps');
@@ -339,6 +311,12 @@ export class LocalSttSettingTab extends PluginSettingTab {
       resolvePluginDirectory: this.dependencies.resolvePluginDirectory,
     });
     this.disposeSidecarSection = sidecarSection.init();
+
+    addToggleSetting(advancedSection, this.access, {
+      name: 'Keep recovery text in memory',
+      desc: 'Keep the latest recoverable text and note snapshot in memory. Nothing is written to disk.',
+      key: 'retainLastUtterance',
+    });
 
     addTextSetting(advancedSection, this.access, {
       name: 'Model store folder override',
@@ -417,7 +395,6 @@ export class LocalSttSettingTab extends PluginSettingTab {
     const setting = addEnumSetting(parent, this.access, {
       name: 'Transcript formatting',
       desc: 'How phrases are joined together.',
-      tooltip: 'Smart paragraphs use longer pauses as line or paragraph breaks.',
       key: 'transcriptFormatting',
       options: TRANSCRIPT_FORMATTING_OPTIONS,
       isValid: isTranscriptFormattingMode,

--- a/src/settings/smart-paragraph-settings-modal.ts
+++ b/src/settings/smart-paragraph-settings-modal.ts
@@ -42,6 +42,11 @@ export class SmartParagraphSettingsModal extends Modal {
   private render(): void {
     this.contentEl.empty();
 
+    this.contentEl.createEl('p', {
+      cls: 'setting-item-description',
+      text: 'Smart paragraphs turn longer pauses into line or paragraph breaks. These values apply only when transcript formatting is set to Smart paragraphs.',
+    });
+
     this.addSecondsSetting({
       desc: `Seconds before a single line break (${MIN_PAUSE_SECONDS}-${MAX_PAUSE_SECONDS}).`,
       name: 'Line break pause',

--- a/test/diarization-setting.test.ts
+++ b/test/diarization-setting.test.ts
@@ -4,9 +4,10 @@ import { diarizationSettingDescription } from '../src/settings/diarization-setti
 
 describe('diarizationSettingDescription', () => {
   it('shows the speaker-label limitation only for a streaming model', () => {
-    const limitation = 'Not applied while a streaming (live) model is selected';
+    const limitation = 'require a batch model';
 
     expect(diarizationSettingDescription(true)).toContain(limitation);
     expect(diarizationSettingDescription(false)).not.toContain(limitation);
+    expect(diarizationSettingDescription(false)).toBe('Label each phrase by speaker.');
   });
 });

--- a/test/phrase-finalization-setting.test.ts
+++ b/test/phrase-finalization-setting.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { phraseFinalizationDescription } from '../src/settings/phrase-finalization-setting';
+import {
+  PHRASE_FINALIZATION_TOOLTIP,
+  phraseFinalizationDescription,
+} from '../src/settings/phrase-finalization-setting';
 
 describe('phraseFinalizationDescription', () => {
   it.each([
@@ -14,13 +17,8 @@ describe('phraseFinalizationDescription', () => {
     expect(description).toContain(outcome);
   });
 
-  it.each([
-    'responsive',
-    'balanced',
-    'patient',
-  ] as const)('makes live-model behavior explicit for %s', (style) => {
-    expect(phraseFinalizationDescription(style)).toContain(
-      'every transcription model, including live models',
-    );
+  it('keeps shared model behavior in the tooltip', () => {
+    expect(PHRASE_FINALIZATION_TOOLTIP).toContain('every transcription model');
+    expect(PHRASE_FINALIZATION_TOOLTIP).toContain('Live words can still update');
   });
 });


### PR DESCRIPTION
## Summary

- Keep Speaker labels as one concise top-level toggle and move Maximum speakers into a dedicated settings modal.
- Shorten the phrase-finalization row while preserving model and timing details in its existing info tooltip.
- Move smart-paragraph guidance into the settings modal and remove the redundant row tooltip.
- Move recovery-text retention to Advanced instead of deleting the privacy opt-out.

## Product decisions

The recovery setting remains because the short-lived receipt can include recoverable text and a note snapshot. Moving it out of the primary workflow reduces settings density without silently removing user control over in-memory retention.

This slice does not change diarization, formatting, phrase-boundary, or recovery behavior.

Refs #247

## Verification

- npm run check:frontend
  - 67 files / 804 tests passed
  - TypeScript, Biome, Obsidian ESLint, and production frontend build passed
- Focused diarization, phrase-finalization, and settings normalization tests passed