### PR TITLE
Keep preset labels visible in narrow sidebars

### DIFF
--- a/src/ui/local-dictation-view.ts
+++ b/src/ui/local-dictation-view.ts
@@ -36,8 +36,7 @@ const LOCAL_DICTATION_VIEW_TITLE = 'Local Dictation';
 const LOCAL_DICTATION_VIEW_ICON = 'audio-lines';
 const HEADING_TOOLTIP =
   'Uses an LLM provider to transform the dictated transcript — cleaning, rewriting, summarizing, reformatting, or running custom prompts.';
-const STYLE_PICKER_TOOLTIP =
-  'A preset bundles a transform prompt with optional timing, output behavior, and setting overrides. Use Manage presets to view a prompt or create, edit, duplicate, and delete presets.';
+const NARROW_SIDEBAR_WIDTH_PX = 420;
 
 const CLEANUP_MODE_OPTIONS: ReadonlyArray<{ label: string; value: LlmPresetTiming }> = [
   { label: 'After each phrase', value: 'per_utterance' },
@@ -145,7 +144,10 @@ export class LocalDictationView extends ItemView {
     this.narrowObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
         const width = entry.contentRect.width;
-        target.toggleClass('local-dictation-sidebar--narrow', width > 0 && width < 360);
+        target.toggleClass(
+          'local-dictation-sidebar--narrow',
+          width > 0 && width < NARROW_SIDEBAR_WIDTH_PX,
+        );
       }
     });
     this.narrowObserver.observe(target);
@@ -335,15 +337,14 @@ export class LocalDictationView extends ItemView {
         });
       });
     setting.settingEl.addClass('local-dictation-preset-setting');
-    setting.descEl.setAttribute('title', description);
-    appendInfoTooltip(setting, STYLE_PICKER_TOOLTIP);
 
-    setting.addButton((button) => {
-      button.setButtonText('Manage presets');
-      button.setTooltip('Manage presets');
-      button.onClick(() => {
-        void this.openPresetManager();
-      });
+    setting.addExtraButton((button) => {
+      button
+        .setIcon('settings')
+        .setTooltip('Manage presets')
+        .onClick(() => {
+          void this.openPresetManager();
+        });
     });
   }
 

--- a/styles.css
+++ b/styles.css
@@ -787,6 +787,11 @@
   max-width: 100%;
 }
 
+.local-dictation-sidebar .local-dictation-preset-setting .setting-item-control > select {
+  flex: 1 1 10rem;
+  min-width: min(10rem, 100%);
+}
+
 /* When the sidebar is dragged narrow, stack setting rows vertically so labels
    and controls don't get squeezed onto a single short line. */
 


### PR DESCRIPTION
## Summary

- Give the Active preset select a real minimum width so its selected label cannot collapse to an empty-looking native control.
- Switch the sidebar to its stacked layout below 420 px, before the setting label and controls compete for the same row.
- Remove the redundant preset info tooltip and hover-only description copy.
- Replace the full-width Manage presets button with one compact settings action that opens the same manager.

## Root cause

Preset enumeration and active-reference hydration are deterministic for Clean up and Professional writing. The presentation row was the failing boundary: it combined a select, an info icon, and a full text button while globally allowing selects to shrink to zero. The stacked layout did not activate until the pane was below 360 px, leaving a common intermediate sidebar width where the native select value could disappear visually.

A direct settings icon is used instead of a one-item overflow menu; it preserves the same destination with less width and fewer clicks.

Closes #261
Refs #247

## Verification

- npm run check:frontend
  - 67 files / 806 tests passed
  - TypeScript, Biome, Obsidian ESLint, and production frontend build passed
- Manual Obsidian acceptance remains required across narrow and wide panes plus representative themes.