### PR TITLE
Harden release correctness and integration coverage

### DIFF
--- a/native/src/diarize/registry.rs
+++ b/native/src/diarize/registry.rs
@@ -63,7 +63,10 @@ impl SpeakerRegistry {
         let best = self.best_match(embedding);
 
         match best {
-            Some((idx, sim)) if sim >= NEW_SPEAKER_THRESHOLD || voiced_ms < MIN_NEW_SPEAKER_MS => {
+            Some((idx, sim))
+                if sim >= NEW_SPEAKER_THRESHOLD
+                    || (voiced_ms < MIN_NEW_SPEAKER_MS && !self.speaker_limit_reached()) =>
+            {
                 self.update_centroid(idx, embedding);
                 Assignment {
                     speaker_index: idx as u32,
@@ -236,7 +239,7 @@ mod tests {
         let third_voice = registry.assign(&[0.1, 0.2, 1.0], LONG);
 
         assert!(!third_voice.is_new_speaker);
-        assert!(third_voice.speaker_index < 2);
+        assert_eq!(third_voice.speaker_index, 1);
         assert_eq!(third_voice.speaker_count, 2);
         assert_eq!(
             registry
@@ -246,6 +249,41 @@ mod tests {
                 .collect::<Vec<_>>(),
             centroids_before,
             "a forced assignment must not contaminate an existing voice centroid"
+        );
+    }
+
+    #[test]
+    fn speaker_limit_does_not_learn_from_a_short_dissimilar_forced_assignment() {
+        let mut registry = SpeakerRegistry::with_max_speakers(Some(1));
+        registry.assign(&[1.0, 0.0], LONG);
+
+        let noise = registry.assign(&[0.0, 1.0], 300);
+        let original_voice = registry.assign(&[1.0, 0.0], LONG);
+
+        assert_eq!(noise.speaker_index, 0);
+        assert!(!noise.is_new_speaker);
+        assert_eq!(noise.speaker_count, 1);
+        assert!(
+            original_voice.similarity > 0.99,
+            "forced noise changed the enrolled voice centroid: {}",
+            original_voice.similarity,
+        );
+    }
+
+    #[test]
+    fn speaker_limit_still_learns_from_a_matching_voice() {
+        let mut registry = SpeakerRegistry::with_max_speakers(Some(1));
+        registry.assign(&[1.0, 0.0], LONG);
+
+        let first_match = registry.assign(&[0.8, 0.6], LONG);
+        let second_match = registry.assign(&[0.8, 0.6], LONG);
+
+        assert_eq!(first_match.speaker_count, 1);
+        assert!(
+            second_match.similarity > first_match.similarity,
+            "matching speech should refine a capped cluster: {} <= {}",
+            second_match.similarity,
+            first_match.similarity,
         );
     }
 }

--- a/native/src/stages/hallucination_filter.rs
+++ b/native/src/stages/hallucination_filter.rs
@@ -674,7 +674,7 @@ mod tests {
     use super::*;
     use crate::audio_metadata::VoiceActivityEvidence;
     use crate::engine::capabilities::{LanguageSupport, ModelFamilyCapabilities};
-    use crate::protocol::{ContextWindow, TimestampGranularity, TimestampSource};
+    use crate::protocol::{ContextWindow, TimestampGranularity, TimestampSource, TranscriptWord};
     use crate::stages::StageEnablement;
     use uuid::Uuid;
 
@@ -950,6 +950,45 @@ mod tests {
                 .and_then(|value| value.as_str()),
             Some("Gorglosa: Let me join"),
         );
+    }
+
+    #[test]
+    fn speaker_label_scrub_clears_the_stale_word_alignment() {
+        let mut transcript = transcript("Gorglosa: Let me join");
+        transcript.segments[0].words = vec![
+            TranscriptWord {
+                end_ms: 200,
+                start_ms: 0,
+                text: "Gorglosa:".to_string(),
+                timestamp_source: TimestampSource::Engine,
+            },
+            TranscriptWord {
+                end_ms: 400,
+                start_ms: 200,
+                text: "Let".to_string(),
+                timestamp_source: TimestampSource::Engine,
+            },
+            TranscriptWord {
+                end_ms: 600,
+                start_ms: 400,
+                text: "me".to_string(),
+                timestamp_source: TimestampSource::Engine,
+            },
+            TranscriptWord {
+                end_ms: 800,
+                start_ms: 600,
+                text: "join".to_string(),
+                timestamp_source: TimestampSource::Engine,
+            },
+        ];
+
+        let result = HallucinationFilterStage.process(&transcript, &ctx(&[], &[], None, true));
+        let StageProcess::Ok { segments, .. } = result else {
+            panic!("expected speaker label edit");
+        };
+
+        assert_eq!(segments[0].text, "Let me join");
+        assert!(segments[0].words.is_empty());
     }
 
     #[test]

--- a/native/tests/common/driver.rs
+++ b/native/tests/common/driver.rs
@@ -525,7 +525,7 @@ fn write_frame(writer: &mut impl Write, kind: u8, payload: &[u8]) {
     writer.write_all(payload).expect("write frame payload");
 }
 
-fn write_command_frame(writer: &mut impl Write, command: &serde_json::Value) {
+pub fn write_command_frame(writer: &mut impl Write, command: &serde_json::Value) {
     let payload = serde_json::to_vec(command).expect("serialize command");
     write_frame(writer, JSON_FRAME_KIND, &payload);
 }
@@ -536,9 +536,12 @@ fn write_audio_frame(writer: &mut impl Write, session_id: &str, frame_bytes: &[u
     write_frame(writer, AUDIO_FRAME_KIND, &envelope);
 }
 
-fn read_event_frame(reader: &mut impl Read) -> Option<serde_json::Value> {
+pub fn read_event_frame(reader: &mut impl Read) -> Option<serde_json::Value> {
     let mut header = [0_u8; FRAME_HEADER_LEN];
     read_exact_or_eof(reader, &mut header)?;
+    if header[0] != JSON_FRAME_KIND {
+        return None;
+    }
     let len = u32::from_le_bytes([header[1], header[2], header[3], header[4]]) as usize;
     let mut payload = vec![0_u8; len];
     reader.read_exact(&mut payload).ok()?;
@@ -559,7 +562,7 @@ fn read_exact_or_eof(reader: &mut impl Read, buffer: &mut [u8]) -> Option<()> {
     Some(())
 }
 
-fn wait_with_timeout(child: &mut Child, timeout: Duration) -> Option<std::process::ExitStatus> {
+pub fn wait_with_timeout(child: &mut Child, timeout: Duration) -> Option<std::process::ExitStatus> {
     let deadline = Instant::now() + timeout;
     loop {
         match child.try_wait() {

--- a/native/tests/sidecar_protocol_e2e.rs
+++ b/native/tests/sidecar_protocol_e2e.rs
@@ -7,7 +7,8 @@
 //! faithful "full sidecar" contract guard — if framing, command/event JSON, or
 //! the process loop regress, this fails even when the in-process path passes.
 //!
-//! `#[ignore]`d (needs the model + spawns a process). Run:
+//! The model-free `get_system_info` smoke runs in the normal suite. The real
+//! transcription test is `#[ignore]`d because it needs a model. Run it with:
 //!
 //! ```sh
 //! cargo test --manifest-path native/Cargo.toml --test sidecar_protocol_e2e -- --ignored --nocapture
@@ -15,12 +16,91 @@
 
 mod common;
 
+use std::io::Write;
+use std::process::{Child, Command as ProcessCommand, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
 use common::{audio, driver, manifest::Corpus, model, score, text};
+use local_dictation_sidecar::engine::{ModelFamilyId, RuntimeId};
+use local_dictation_sidecar::protocol::Event;
 use local_dictation_sidecar::session::SpeakingStyle;
+use serde_json::json;
 
 /// Path to the freshly built sidecar binary, provided by Cargo to integration
 /// tests. Spawning this exercises the exact executable end users run.
 const SIDECAR_BIN: &str = env!("CARGO_BIN_EXE_local-dictation-sidecar");
+const SMOKE_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[test]
+#[cfg(feature = "engine-whisper")]
+fn get_system_info_round_trips_through_the_real_binary() {
+    let mut child = ChildGuard::spawn();
+    let mut stdin = child
+        .child
+        .stdin
+        .take()
+        .expect("sidecar stdin should be piped");
+    let stdout = child
+        .child
+        .stdout
+        .take()
+        .expect("sidecar stdout should be piped");
+    let (event_tx, event_rx) = mpsc::channel();
+    let reader = thread::spawn(move || {
+        let mut stdout = stdout;
+        let _ = event_tx.send(driver::read_event_frame(&mut stdout));
+    });
+
+    driver::write_command_frame(&mut stdin, &json!({ "type": "get_system_info" }));
+    stdin.flush().expect("get_system_info should flush");
+
+    let event_json = event_rx
+        .recv_timeout(SMOKE_TIMEOUT)
+        .expect("sidecar should answer get_system_info before the timeout")
+        .expect("sidecar should return a valid length-prefixed JSON event");
+    let event: Event =
+        serde_json::from_value(event_json).expect("system_info event should deserialize");
+    let Event::SystemInfo {
+        sidecar_version,
+        compiled_runtimes,
+        compiled_adapters,
+        system_info,
+    } = event
+    else {
+        panic!("expected system_info event");
+    };
+
+    assert_eq!(sidecar_version, env!("CARGO_PKG_VERSION"));
+    assert!(!system_info.trim().is_empty());
+    assert!(
+        compiled_runtimes
+            .iter()
+            .any(|runtime| runtime.runtime_id == RuntimeId::WhisperCpp),
+        "real binary should report the compiled whisper.cpp runtime",
+    );
+    let whisper = compiled_adapters
+        .iter()
+        .find(|adapter| {
+            adapter.runtime_id == RuntimeId::WhisperCpp
+                && adapter.family_id == ModelFamilyId::Whisper
+        })
+        .expect("real binary should report the compiled Whisper adapter");
+    assert!(
+        whisper.family_capabilities.supports_word_timestamps,
+        "real Whisper adapter should advertise word timing",
+    );
+
+    driver::write_command_frame(&mut stdin, &json!({ "type": "shutdown" }));
+    stdin.flush().expect("shutdown should flush");
+    drop(stdin);
+
+    let status = driver::wait_with_timeout(&mut child.child, SMOKE_TIMEOUT)
+        .expect("sidecar should exit after shutdown before the timeout");
+    assert!(status.success(), "sidecar exited unsuccessfully: {status}");
+    reader.join().expect("event reader should not panic");
+}
 
 #[test]
 #[ignore = "spawns the built binary + real inference; run with --ignored"]
@@ -53,4 +133,29 @@ fn jfk_transcribes_through_the_wire_protocol() {
         failures.join("\n  "),
         outcome.text,
     );
+}
+
+struct ChildGuard {
+    child: Child,
+}
+
+impl ChildGuard {
+    fn spawn() -> Self {
+        let child = ProcessCommand::new(SIDECAR_BIN)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap_or_else(|error| panic!("failed to spawn sidecar {SIDECAR_BIN}: {error}"));
+        Self { child }
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if self.child.try_wait().ok().flatten().is_none() {
+            let _ = self.child.kill();
+        }
+        let _ = self.child.wait();
+    }
 }

--- a/src/models/model-install-manager.ts
+++ b/src/models/model-install-manager.ts
@@ -385,6 +385,7 @@ export class ModelInstallManager {
       // The user explicitly (re-)probed this exact selection and it's
       // confirmed broken now — drop any cached "ready" snapshot for it so a
       // future startup doesn't trust stale, now-incorrect capabilities.
+      await this.applyProbeResultToCapabilities(selection, probeResult);
       await this.invalidateCapabilitiesSnapshot(selection);
       throw new Error(createProbeFailureMessage(probeResult));
     }

--- a/src/settings/diarization-settings-modal.ts
+++ b/src/settings/diarization-settings-modal.ts
@@ -36,6 +36,7 @@ export class DiarizationSettingsModal extends Modal {
 
   private render(): void {
     this.contentEl.empty();
+    const diarizationEnabled = this.deps.getSettings().diarizationEnabled;
 
     this.contentEl.createEl('p', {
       cls: 'setting-item-description',
@@ -45,7 +46,9 @@ export class DiarizationSettingsModal extends Modal {
     new Setting(this.contentEl)
       .setName('Maximum speakers')
       .setDesc(
-        'Automatic determines the speaker count. Set a limit only if extra speaker labels appear.',
+        diarizationEnabled
+          ? 'Automatic determines the speaker count. Set a limit only if extra speaker labels appear.'
+          : 'Enable speaker labels before configuring a speaker limit.',
       )
       .addDropdown((dropdown) => {
         dropdown.addOption('auto', 'Automatic');
@@ -57,6 +60,7 @@ export class DiarizationSettingsModal extends Modal {
           dropdown.addOption(String(count), String(count));
         }
         dropdown.setValue(this.maxSpeakers?.toString() ?? 'auto');
+        dropdown.setDisabled(!diarizationEnabled);
         dropdown.onChange((value) => {
           if (value === 'auto') {
             this.maxSpeakers = null;

--- a/src/settings/timestamp-settings-modal.ts
+++ b/src/settings/timestamp-settings-modal.ts
@@ -43,9 +43,12 @@ const TIMESTAMP_DENSITY_OPTIONS: ReadonlyArray<DropdownOption<TimestampDensity>>
 const MIN_INTERVAL_SECONDS = MIN_TIMESTAMP_SPARSE_INTERVAL_MS / 1000;
 const MAX_INTERVAL_SECONDS = MAX_TIMESTAMP_SPARSE_INTERVAL_MS / 1000;
 const INTERVAL_DESCRIPTION = `Seconds between timestamp landmarks (${MIN_INTERVAL_SECONDS}-${MAX_INTERVAL_SECONDS}).`;
+let nextIntervalDescriptionId = 0;
 
 export class TimestampSettingsModal extends Modal {
   private draft: TimestampSettingsDraft;
+  private readonly intervalDescriptionId =
+    `local-dictation-timestamp-interval-description-${++nextIntervalDescriptionId}`;
   private intervalInput: TextComponent | null = null;
   private intervalSetting: Setting | null = null;
   private frequencySetting: Setting | null = null;
@@ -140,12 +143,16 @@ export class TimestampSettingsModal extends Modal {
         text.inputEl.min = String(MIN_INTERVAL_SECONDS);
         text.inputEl.max = String(MAX_INTERVAL_SECONDS);
         text.inputEl.step = '1';
+        text.inputEl.setAttribute('aria-label', 'Interval');
+        text.inputEl.setAttribute('aria-describedby', this.intervalDescriptionId);
         text.setValue(this.draft.sparseIntervalSeconds);
         text.onChange((value) => {
           this.draft = { ...this.draft, sparseIntervalSeconds: value };
           this.refreshIntervalState();
         });
       });
+    this.intervalSetting.descEl.id = this.intervalDescriptionId;
+    this.intervalSetting.descEl.setAttribute('aria-live', 'polite');
 
     new Setting(this.contentEl)
       .addButton((button) => {
@@ -188,6 +195,10 @@ export class TimestampSettingsModal extends Modal {
     this.intervalInput?.setDisabled(!intervalIsActive);
     this.intervalInput?.inputEl.setCustomValidity(
       intervalIsActive && !validation.valid ? validation.message : '',
+    );
+    this.intervalInput?.inputEl.toggleAttribute(
+      'aria-invalid',
+      intervalIsActive && !validation.valid,
     );
     this.intervalSetting?.setDesc(
       intervalIsActive && !validation.valid

--- a/src/transcript/renderer.ts
+++ b/src/transcript/renderer.ts
@@ -360,10 +360,7 @@ export function buildTranscriptSpans(
   }
 
   const textSegments = segments.filter((segment) => segment.text.trim().length > 0);
-  if (
-    textSegments.length > 0 &&
-    textSegments.every((segment) => (segment.words?.length ?? 0) > 0)
-  ) {
+  if (textSegments.length > 0 && textSegments.every(hasCompleteWordTiming)) {
     return groupDetailedSegments(
       textSegments.map((segment) => ({
         speakerIndex: segment.speaker,
@@ -412,6 +409,22 @@ export function buildTranscriptSpans(
     return [{ speakerIndex: normalizeSpeakerIndex(fallbackSpeakerIndex), text: phraseLandmark }];
   }
   return [{ ...first, text: `${phraseLandmark} ${first.text}` }, ...rest];
+}
+
+function hasCompleteWordTiming(segment: TranscriptSegment): boolean {
+  const words = segment.words;
+  if (words === undefined || words.length === 0 || words.some((word) => word.text.trim() === '')) {
+    return false;
+  }
+
+  return (
+    normalizeWhitespace(words.map((word) => word.text).join(' ')) ===
+    normalizeWhitespace(segment.text)
+  );
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.trim().split(/\s+/u).join(' ');
 }
 
 function groupDetailedSegments(

--- a/src/ui/local-dictation-view.ts
+++ b/src/ui/local-dictation-view.ts
@@ -208,6 +208,9 @@ export class LocalDictationView extends ItemView {
     });
 
     const status = header.createDiv({ cls: 'local-dictation-sidebar__summary' });
+    status.setAttribute('role', 'status');
+    status.setAttribute('aria-live', 'polite');
+    status.setAttribute('aria-atomic', 'true');
     status.createSpan({
       cls: `local-dictation-sidebar__badge local-dictation-sidebar__badge--${presentation.state}`,
       text: presentation.statusLabel,

--- a/test/__mocks__/obsidian.ts
+++ b/test/__mocks__/obsidian.ts
@@ -25,19 +25,22 @@ export class TestElement {
     this.className = [this.className, className].filter(Boolean).join(' ');
   }
 
-  createDiv(options: { cls?: string; text?: string } = {}): TestElement {
+  createDiv(options: TestElementOptions = {}): TestElement {
     return this.createEl('div', options);
   }
 
-  createEl(_tag: string, options: { cls?: string; text?: string } = {}): TestElement {
+  createEl(_tag: string, options: TestElementOptions = {}): TestElement {
     const element = new TestElement();
     element.className = options.cls ?? '';
     element.textContent = options.text ?? '';
+    for (const [name, value] of Object.entries(options.attr ?? {})) {
+      element.setAttribute(name, value);
+    }
     this.children.push(element);
     return element;
   }
 
-  createSpan(options: { cls?: string; text?: string } = {}): TestElement {
+  createSpan(options: TestElementOptions = {}): TestElement {
     return this.createEl('span', options);
   }
 
@@ -49,6 +52,17 @@ export class TestElement {
 
   setAttribute(name: string, value: string): void {
     this.attributes.set(name, value);
+  }
+
+  findByClass(className: string): TestElement | undefined {
+    if (this.className.split(/\s+/u).includes(className)) {
+      return this;
+    }
+    for (const child of this.children) {
+      const match = child.findByClass(className);
+      if (match !== undefined) return match;
+    }
+    return undefined;
   }
 
   setText(text: string): void {
@@ -63,6 +77,23 @@ export class TestElement {
       this.attributes.delete(name);
     }
   }
+
+  toggleClass(className: string, force?: boolean): void {
+    const classes = new Set(this.className.split(/\s+/u).filter(Boolean));
+    const enabled = force ?? !classes.has(className);
+    if (enabled) {
+      classes.add(className);
+    } else {
+      classes.delete(className);
+    }
+    this.className = [...classes].join(' ');
+  }
+}
+
+interface TestElementOptions {
+  attr?: Record<string, string>;
+  cls?: string;
+  text?: string;
 }
 
 export class TestInputElement extends TestElement {
@@ -142,15 +173,84 @@ export class ButtonComponent {
   }
 }
 
+interface TestSelectOption {
+  disabled: boolean;
+  label: string;
+  value: string;
+}
+
+class TestSelectElement extends TestElement {
+  readonly options: TestSelectOption[] = [];
+  value = '';
+}
+
+export class DropdownComponent {
+  readonly selectEl = new TestSelectElement();
+  private changeHandler: (value: string) => unknown = () => {};
+
+  addOption(value: string, label: string): this {
+    this.selectEl.options.push({ disabled: false, label, value });
+    return this;
+  }
+
+  change(value: string): void {
+    this.selectEl.value = value;
+    this.changeHandler(value);
+  }
+
+  onChange(callback: (value: string) => unknown): this {
+    this.changeHandler = callback;
+    return this;
+  }
+
+  setDisabled(disabled: boolean): this {
+    this.selectEl.disabled = disabled;
+    return this;
+  }
+
+  setValue(value: string): this {
+    this.selectEl.value = value;
+    return this;
+  }
+}
+
+export class ToggleComponent {
+  readonly toggleEl = new TestInputElement();
+  private changeHandler: (value: boolean) => unknown = () => {};
+  value = false;
+
+  change(value: boolean): void {
+    this.value = value;
+    this.changeHandler(value);
+  }
+
+  onChange(callback: (value: boolean) => unknown): this {
+    this.changeHandler = callback;
+    return this;
+  }
+
+  setDisabled(disabled: boolean): this {
+    this.toggleEl.disabled = disabled;
+    return this;
+  }
+
+  setValue(value: boolean): this {
+    this.value = value;
+    return this;
+  }
+}
+
 export class Setting {
   static readonly instances: Setting[] = [];
 
   readonly buttonComponents: ButtonComponent[] = [];
   readonly controlEl = new TestElement();
   readonly descEl = new TestElement();
+  readonly dropdownComponents: DropdownComponent[] = [];
   readonly nameEl = new TestElement();
   readonly settingEl = new TestElement();
   readonly textComponents: TextComponent[] = [];
+  readonly toggleComponents: ToggleComponent[] = [];
   name = '';
 
   constructor(parent?: TestElement) {
@@ -183,6 +283,13 @@ export class Setting {
     return this;
   }
 
+  addDropdown(callback: (dropdown: DropdownComponent) => void): this {
+    const dropdown = new DropdownComponent();
+    this.dropdownComponents.push(dropdown);
+    callback(dropdown);
+    return this;
+  }
+
   addText(callback: (text: TextComponent) => void): this {
     const text = new TextComponent();
     this.textComponents.push(text);
@@ -190,11 +297,32 @@ export class Setting {
     return this;
   }
 
+  addToggle(callback: (toggle: ToggleComponent) => void): this {
+    const toggle = new ToggleComponent();
+    this.toggleComponents.push(toggle);
+    callback(toggle);
+    return this;
+  }
+
+  onlyDropdown(): DropdownComponent {
+    if (this.dropdownComponents.length !== 1) {
+      throw new Error(`Expected one dropdown component for ${this.name}`);
+    }
+    return this.dropdownComponents[0] as DropdownComponent;
+  }
+
   onlyText(): TextComponent {
     if (this.textComponents.length !== 1) {
       throw new Error(`Expected one text component for ${this.name}`);
     }
     return this.textComponents[0] as TextComponent;
+  }
+
+  onlyToggle(): ToggleComponent {
+    if (this.toggleComponents.length !== 1) {
+      throw new Error(`Expected one toggle component for ${this.name}`);
+    }
+    return this.toggleComponents[0] as ToggleComponent;
   }
 
   setDesc(description: string): this {
@@ -230,6 +358,17 @@ export class Modal {
   open(): void {
     this.onOpen();
   }
+}
+
+export class ItemView {
+  readonly app: unknown;
+  readonly contentEl = new TestElement();
+
+  constructor(readonly leaf: { app?: unknown }) {
+    this.app = leaf.app ?? {};
+  }
+
+  registerDomEvent(): void {}
 }
 
 export class SecretComponent {

--- a/test/audio-capture-stream.test.ts
+++ b/test/audio-capture-stream.test.ts
@@ -113,6 +113,24 @@ describe('AudioCaptureStream', () => {
     expect(track.listenerCount()).toBe(1);
   });
 
+  it('reports a device that ends while the capture graph is being initialized', async () => {
+    const track = new FakeMediaStreamTrack();
+    track.readyState = 'ended';
+    const mediaStream = new FakeMediaStream(track);
+    vi.stubGlobal('navigator', {
+      mediaDevices: { getUserMedia: vi.fn(async () => mediaStream as unknown as MediaStream) },
+    });
+    const onUnexpectedEnd = vi.fn();
+    const capture = new AudioCaptureStream({ onUnexpectedEnd });
+
+    await capture.start({ sessionId: 'session-raced' }, vi.fn());
+
+    expect(onUnexpectedEnd).toHaveBeenCalledOnce();
+    expect(onUnexpectedEnd).toHaveBeenCalledWith('session-raced');
+    await capture.stop();
+    expect(onUnexpectedEnd).toHaveBeenCalledOnce();
+  });
+
   it('removes the old track listener before teardown and rapid restart', async () => {
     const firstTrack = new FakeMediaStreamTrack();
     const secondTrack = new FakeMediaStreamTrack();

--- a/test/dictation-session-controller.test.ts
+++ b/test/dictation-session-controller.test.ts
@@ -223,9 +223,36 @@ describe('DictationSessionController', () => {
     );
   });
 
-  it('requests engine word timing only for enabled detailed timestamps', async () => {
+  it.each([
+    [true, 'detailed', true],
+    [false, 'detailed', false],
+    [false, 'sparse', true],
+  ] as const)('sets detailedTimestampsEnabled=%s when density=%s and timestampsEnabled=%s', async (expected, timestampDensity, timestampsEnabled) => {
     const sidecarConnection = new FakeSidecarConnection();
     const controller = createController({
+      sidecarConnection,
+      getSettings: () =>
+        createSettings({
+          selectedModel: createExternalModelSelection(),
+          timestampDensity,
+          timestampsEnabled,
+        }),
+    });
+
+    await controller.startDictation();
+
+    expect(sidecarConnection.startSession).toHaveBeenCalledWith(
+      expect.objectContaining({ detailedTimestampsEnabled: expected }),
+    );
+  });
+
+  it('projects sidecar word timing through the controller into detailed transcript spans', async () => {
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const controller = createController({
+      createSession: (session) => {
+        sessions.push(session);
+      },
       sidecarConnection,
       getSettings: () =>
         createSettings({
@@ -236,10 +263,35 @@ describe('DictationSessionController', () => {
     });
 
     await controller.startDictation();
-
-    expect(sidecarConnection.startSession).toHaveBeenCalledWith(
-      expect.objectContaining({ detailedTimestampsEnabled: true }),
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    sidecarConnection.emit(
+      transcriptReady(sessionId, 'Hello world.', {
+        segments: [
+          {
+            endMs: 1_000,
+            speaker: null,
+            startMs: 0,
+            text: 'Hello world.',
+            timestampGranularity: 'segment',
+            timestampSource: 'engine',
+            words: [
+              { endMs: 400, startMs: 100, text: 'Hello', timestampSource: 'engine' },
+              { endMs: 900, startMs: 500, text: 'world.', timestampSource: 'engine' },
+            ],
+          },
+        ],
+        utteranceEndMsInSession: 11_000,
+        utteranceStartMsInSession: 10_000,
+      }),
     );
+
+    await vi.waitFor(() => {
+      expect(sessions[0]?.acceptTranscript).toHaveBeenCalledWith(
+        expect.objectContaining({
+          spans: [{ speakerIndex: null, text: '(0:10.1) Hello (0:10.5) world.' }],
+        }),
+      );
+    });
   });
 
   it('includes system audio without skipping microphone capture', async () => {
@@ -511,6 +563,63 @@ describe('DictationSessionController', () => {
       expect(session.acceptTranscript).toHaveBeenCalledTimes(4);
     });
     expect(onFinalizedUtteranceAccepted).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the accepted cleaned final as the last recoverable utterance', async () => {
+    let lastRecoverableUtterance: string | null = null;
+    const sidecarConnection = new FakeSidecarConnection();
+    const sessions: FakeSession[] = [];
+    const cleanup = vi
+      .fn<() => Promise<LlmRouterCleanupResult>>()
+      .mockResolvedValueOnce({ model: 'm', providerId: 'ollama', text: 'Clean recovery text.' })
+      .mockResolvedValueOnce({ model: 'm', providerId: 'ollama', text: 'Stale cleaned text.' })
+      .mockResolvedValueOnce({ model: 'm', providerId: 'ollama', text: 'Rejected cleaned text.' });
+    const controller = createController({
+      createSession: (session) => {
+        sessions.push(session);
+      },
+      getSettings: () =>
+        createSettings({
+          llmFeaturesEnabled: true,
+          llmPostprocessMode: 'per_utterance',
+          llmPostprocessSkipMinWords: 0,
+          selectedModel: createExternalModelSelection(),
+        }),
+      llmRouter: createFakeLlmRouter({ cleanup }),
+      onFinalizedUtteranceAccepted: (text) => {
+        lastRecoverableUtterance = text;
+      },
+      sidecarConnection,
+    });
+
+    await controller.startDictation();
+    const sessionId = sidecarConnection.startSession.mock.calls[0]?.[0].sessionId ?? '';
+    const session = sessions[0];
+    if (session === undefined) {
+      throw new Error('expected session fixture');
+    }
+
+    sidecarConnection.emit(transcriptReady(sessionId, 'raw recovery text'));
+    await vi.waitFor(() => {
+      expect(lastRecoverableUtterance).toBe('Clean recovery text.');
+    });
+
+    session.acceptTranscript.mockReturnValueOnce({ kind: 'stale' });
+    sidecarConnection.emit(transcriptReady(sessionId, 'stale raw text'));
+    await vi.waitFor(() => {
+      expect(session.acceptTranscript).toHaveBeenCalledTimes(2);
+    });
+
+    session.acceptTranscript.mockReturnValueOnce({
+      kind: 'rejected',
+      reason: 'note no longer accepts transcript updates',
+    });
+    sidecarConnection.emit(transcriptReady(sessionId, 'rejected raw text'));
+    await vi.waitFor(() => {
+      expect(sidecarConnection.cancelSession).toHaveBeenCalledWith(sessionId);
+    });
+
+    expect(lastRecoverableUtterance).toBe('Clean recovery text.');
   });
 
   it('silently enforces the five-session active plus draining cap', async () => {

--- a/test/fixtures/state-backed-editor-view.ts
+++ b/test/fixtures/state-backed-editor-view.ts
@@ -1,0 +1,25 @@
+import {
+  EditorSelection,
+  EditorState,
+  type Extension,
+  type TransactionSpec,
+} from '@codemirror/state';
+import { vi } from 'vitest';
+
+export class StateBackedEditorView {
+  state: EditorState;
+  readonly dispatch = vi.fn((spec: TransactionSpec) => {
+    this.state = this.state.update(spec).state;
+  });
+
+  constructor(
+    documentText: string,
+    options: { extensions?: Extension; selectionHead?: number } = {},
+  ) {
+    this.state = EditorState.create({
+      doc: documentText,
+      extensions: options.extensions ?? [],
+      selection: EditorSelection.cursor(options.selectionHead ?? 0),
+    });
+  }
+}

--- a/test/local-dictation-view.test.ts
+++ b/test/local-dictation-view.test.ts
@@ -1,0 +1,26 @@
+import type { WorkspaceLeaf } from 'obsidian';
+import { expect, it, vi } from 'vitest';
+
+import { DEFAULT_PLUGIN_SETTINGS } from '../src/settings/plugin-settings';
+import { LocalDictationView } from '../src/ui/local-dictation-view';
+import type { TestElement } from './__mocks__/obsidian';
+
+it('announces the changing sidebar workflow summary as one atomic status', () => {
+  const view = new LocalDictationView({ app: {} } as unknown as WorkspaceLeaf, {
+    feedback: { show: vi.fn() },
+    getOpenRouterApiKey: () => '',
+    getSettings: () => ({ ...DEFAULT_PLUGIN_SETTINGS, llmFeaturesEnabled: false }),
+    mutatePresetState: vi.fn(async () => {}),
+    saveSettings: vi.fn(async () => {}),
+    synchronizePresets: vi.fn(async () => {}),
+  });
+
+  view.refresh();
+
+  const status = (view.contentEl as unknown as TestElement).findByClass(
+    'local-dictation-sidebar__summary',
+  );
+  expect(status?.attributes.get('role')).toBe('status');
+  expect(status?.attributes.get('aria-live')).toBe('polite');
+  expect(status?.attributes.get('aria-atomic')).toBe('true');
+});

--- a/test/model-install-manager.test.ts
+++ b/test/model-install-manager.test.ts
@@ -805,7 +805,7 @@ describe('ModelInstallManager', () => {
       });
     });
 
-    it('re-selecting a model whose probe now fails invalidates its persisted snapshot', async () => {
+    it('re-selecting a now-unavailable model clears stale ready capabilities and notifies', async () => {
       harness = createManagerHarness({
         selectedModel: sampleSelection(),
         selectedModelCapabilitiesSnapshot: {
@@ -816,6 +816,9 @@ describe('ModelInstallManager', () => {
       configureSidecarForInit(harness.sidecarConnection);
       await harness.manager.init();
       expect(harness.sidecarConnection.probeModelSelection).not.toHaveBeenCalled();
+      expect(harness.manager.getState().selectedModelCapabilities.status).toBe('ready');
+      const onStateChange = vi.fn();
+      harness.manager.subscribe(onStateChange);
 
       harness.sidecarConnection.probeModelSelection.mockResolvedValueOnce({
         ...sampleReadyProbeResult(),
@@ -832,7 +835,14 @@ describe('ModelInstallManager', () => {
       await expect(harness.manager.select(sampleSelection())).rejects.toThrow(
         'Model is not installed. (file removed)',
       );
+      expect(harness.manager.getState().selectedModelCapabilities).toEqual({
+        details: 'Model is not installed. (file removed)',
+        reason: 'missing',
+        selection: sampleSelection(),
+        status: 'unavailable',
+      });
       expect(harness.getSettings().selectedModelCapabilitiesSnapshot).toBeNull();
+      expect(onStateChange).toHaveBeenCalledOnce();
     });
 
     it('clearSelection() clears the persisted capabilities snapshot', async () => {

--- a/test/output-settings-modals.test.ts
+++ b/test/output-settings-modals.test.ts
@@ -1,0 +1,143 @@
+import type { App } from 'obsidian';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ModelFamilyCapabilitiesRecord } from '../src/models/model-management-types';
+import { DiarizationSettingsModal } from '../src/settings/diarization-settings-modal';
+import { DEFAULT_PLUGIN_SETTINGS, type PluginSettings } from '../src/settings/plugin-settings';
+import { TimestampSettingsModal } from '../src/settings/timestamp-settings-modal';
+import { Setting as MockSetting } from './__mocks__/obsidian';
+
+describe('transcript output settings modals', () => {
+  beforeEach(() => {
+    MockSetting.reset();
+  });
+
+  it('announces an invalid timestamp interval and blocks saving it', async () => {
+    const saveSettings = vi.fn(async () => {});
+    new TimestampSettingsModal({} as App, {
+      getModelCapabilities: () => capabilities({ supportsWordTimestamps: true }),
+      getSettings: () => DEFAULT_PLUGIN_SETTINGS,
+      saveSettings,
+    }).open();
+
+    const intervalSetting = MockSetting.named('Interval');
+    const interval = intervalSetting.onlyText();
+    interval.change('2.5');
+
+    expect(interval.inputEl.validationMessage).toBe('Enter a whole number from 10 to 600 seconds.');
+    expect(interval.inputEl.attributes.get('aria-label')).toBe('Interval');
+    expect(interval.inputEl.attributes.get('aria-describedby')).toBe(intervalSetting.descEl.id);
+    expect(interval.inputEl.attributes.has('aria-invalid')).toBe(true);
+    expect(intervalSetting.descEl.attributes.get('aria-live')).toBe('polite');
+    expect(MockSetting.buttonNamed('Save').disabled).toBe(true);
+
+    await MockSetting.buttonNamed('Save').click();
+    expect(saveSettings).not.toHaveBeenCalled();
+  });
+
+  it('renders model-aware detailed timing and persists a merged draft', async () => {
+    let settings: PluginSettings = {
+      ...DEFAULT_PLUGIN_SETTINGS,
+      timestampSparseIntervalMs: 45_000,
+    };
+    const saveSettings = vi.fn(async (next: PluginSettings) => {
+      settings = next;
+    });
+    const onSave = vi.fn();
+    new TimestampSettingsModal({} as App, {
+      getModelCapabilities: () =>
+        capabilities({ supportsSegmentTimestamps: true, supportsWordTimestamps: true }),
+      getSettings: () => settings,
+      onSave,
+      saveSettings,
+    }).open();
+
+    const frequency = MockSetting.named('Frequency').onlyDropdown();
+    expect(frequency.selectEl.options).toContainEqual({
+      disabled: false,
+      label: 'Every word · model timed',
+      value: 'detailed',
+    });
+    frequency.change('detailed');
+    MockSetting.named('Reference clock').onlyDropdown().change('wallclock');
+    MockSetting.named('Session header').onlyToggle().change(false);
+    expect(MockSetting.named('Interval').onlyText().inputEl.disabled).toBe(true);
+
+    // Settings may change elsewhere while the modal is open. Saving should
+    // merge the draft onto the latest authoritative object.
+    const concurrentSettings = { ...settings, developerMode: true };
+    settings = concurrentSettings;
+    await MockSetting.buttonNamed('Save').click();
+
+    expect(saveSettings).toHaveBeenCalledWith({
+      ...concurrentSettings,
+      timestampClock: 'wallclock',
+      timestampDensity: 'detailed',
+      timestampSessionHeader: false,
+    });
+    expect(onSave).toHaveBeenCalledOnce();
+  });
+
+  it('prevents selecting detailed timing when the model cannot provide it', () => {
+    new TimestampSettingsModal({} as App, {
+      getModelCapabilities: () => capabilities(),
+      getSettings: () => DEFAULT_PLUGIN_SETTINGS,
+      saveSettings: vi.fn(async () => {}),
+    }).open();
+
+    const detailed = MockSetting.named('Frequency')
+      .onlyDropdown()
+      .selectEl.options.find((option) => option.value === 'detailed');
+    expect(detailed).toEqual({
+      disabled: true,
+      label: 'Detailed model timing · unavailable',
+      value: 'detailed',
+    });
+  });
+
+  it('disables speaker-limit editing while speaker labels are off', () => {
+    new DiarizationSettingsModal({} as App, {
+      getSettings: () => DEFAULT_PLUGIN_SETTINGS,
+      saveSettings: vi.fn(async () => {}),
+    }).open();
+
+    const maximumSpeakers = MockSetting.named('Maximum speakers');
+    expect(maximumSpeakers.onlyDropdown().selectEl.disabled).toBe(true);
+    expect(maximumSpeakers.descEl.textContent).toContain('Enable speaker labels');
+  });
+
+  it('persists an enabled speaker limit through the modal boundary', async () => {
+    const settings = { ...DEFAULT_PLUGIN_SETTINGS, diarizationEnabled: true };
+    const saveSettings = vi.fn(async () => {});
+    const onSave = vi.fn();
+    new DiarizationSettingsModal({} as App, {
+      getSettings: () => settings,
+      onSave,
+      saveSettings,
+    }).open();
+
+    const maximumSpeakers = MockSetting.named('Maximum speakers').onlyDropdown();
+    expect(maximumSpeakers.selectEl.disabled).toBe(false);
+    maximumSpeakers.change('4');
+    await MockSetting.buttonNamed('Save').click();
+
+    expect(saveSettings).toHaveBeenCalledWith({ ...settings, diarizationMaxSpeakers: 4 });
+    expect(onSave).toHaveBeenCalledOnce();
+  });
+});
+
+function capabilities(
+  overrides: Partial<ModelFamilyCapabilitiesRecord> = {},
+): ModelFamilyCapabilitiesRecord {
+  return {
+    maxAudioDurationSecs: null,
+    producesPunctuation: true,
+    supportedLanguages: { kind: 'english_only' },
+    supportsInitialPrompt: false,
+    supportsLanguageSelection: false,
+    supportsSegmentTimestamps: false,
+    supportsStreaming: false,
+    supportsWordTimestamps: false,
+    ...overrides,
+  };
+}

--- a/test/raw-transcript-recovery.test.ts
+++ b/test/raw-transcript-recovery.test.ts
@@ -1,4 +1,4 @@
-import { EditorState, type TransactionSpec } from '@codemirror/state';
+import { EditorState } from '@codemirror/state';
 import type { EditorView } from '@codemirror/view';
 import type { TFile } from 'obsidian';
 import { describe, expect, it, vi } from 'vitest';
@@ -7,17 +7,7 @@ import {
   RawTranscriptRecovery,
   type RawTranscriptRecoveryReceipt,
 } from '../src/editor/raw-transcript-recovery';
-
-class StateBackedEditorView {
-  state: EditorState;
-  readonly dispatch = vi.fn((spec: TransactionSpec) => {
-    this.state = this.state.update(spec).state;
-  });
-
-  constructor(documentText: string) {
-    this.state = EditorState.create({ doc: documentText });
-  }
-}
+import { StateBackedEditorView } from './fixtures/state-backed-editor-view';
 
 describe('RawTranscriptRecovery', () => {
   it('overwrites the prior record and copies only the latest raw transcript', async () => {
@@ -116,6 +106,33 @@ describe('RawTranscriptRecovery', () => {
 
     expect(harness.view.dispatch).toHaveBeenCalledOnce();
     expect(harness.recovery.hasRecovery()).toBe(true);
+    expect(harness.feedback.show).toHaveBeenLastCalledWith({
+      intent: 'error',
+      key: 'raw-transcript-restore-failed',
+      message: 'Could not restore the raw transcript.',
+    });
+  });
+
+  it('retains recovery without exposing transcript content when the restore edit fails', () => {
+    const rawText = 'private raw transcript';
+    const transformedText = 'private transformed transcript';
+    const harness = createHarness(transformedText, {
+      rawText,
+      to: transformedText.length,
+      transformedText,
+    });
+    harness.recovery.record(harness.receipt());
+    harness.view.dispatch.mockImplementationOnce(() => {
+      throw new Error(`editor rejected ${rawText} after reading ${transformedText}`);
+    });
+
+    expect(harness.recovery.restoreRawTranscript()).toBe(false);
+
+    expect(harness.recovery.hasRecovery()).toBe(true);
+    expect(harness.view.state.doc.toString()).toBe(transformedText);
+    const serializedFeedback = JSON.stringify(harness.feedback.show.mock.calls);
+    expect(serializedFeedback).not.toContain(rawText);
+    expect(serializedFeedback).not.toContain(transformedText);
     expect(harness.feedback.show).toHaveBeenLastCalledWith({
       intent: 'error',
       key: 'raw-transcript-restore-failed',

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -2,6 +2,7 @@ import type { EditorView } from '@codemirror/view';
 import type { App, EventRef, TFile } from 'obsidian';
 import { describe, expect, it, vi } from 'vitest';
 
+import { dictationAnchorExtension } from '../src/editor/dictation-anchor-extension';
 import type {
   AppendResult,
   NotePlacementOptions,
@@ -12,6 +13,9 @@ import type {
   RewriteResult,
   SurfaceDesynchronization,
 } from '../src/editor/note-surface';
+import { provisionalTranscriptExtension } from '../src/editor/provisional-transcript-extension';
+import { RawTranscriptRecovery } from '../src/editor/raw-transcript-recovery';
+import { sessionProcessingExtension } from '../src/editor/session-processing-extension';
 import { TemporaryLeafPinLeaseManager } from '../src/editor/temporary-leaf-pin';
 import { Session } from '../src/session/session';
 import type { PluginLogger } from '../src/shared/plugin-logger';
@@ -19,6 +23,7 @@ import type {
   TranscriptInsertProjection,
   TranscriptRenderOptions,
 } from '../src/transcript/renderer';
+import { StateBackedEditorView } from './fixtures/state-backed-editor-view';
 import { transcript } from './fixtures/transcript';
 import { renderOptions, timestamps } from './helpers/render-options';
 
@@ -766,6 +771,43 @@ describe('Session', () => {
     expect(surface.documentText).toBe('Polished tail.');
   });
 
+  it('restores the exact raw session range after replace-style batch cleanup', () => {
+    const { recovery, session, view } = createRecoveryIntegrationHarness('Existing note');
+    const rawTranscript = 'raw transcript';
+    const cleanedTranscript = 'Cleaned transcript.';
+
+    expect(
+      session.acceptTranscript(
+        transcript({
+          isFinal: true,
+          sessionId: 'recovery-integration',
+          text: rawTranscript,
+          utteranceId: 'recoverable',
+        }),
+      ),
+    ).toEqual({ kind: 'accepted' });
+    const originalDocument = view.state.doc.toString();
+    expect(originalDocument).toBe('Existing note raw transcript');
+
+    const replacement = session.replaceSessionRangeWithCleaned(cleanedTranscript, {
+      rawTextForCallout: rawTranscript,
+      showRawBelow: true,
+    });
+    if (replacement.kind !== 'replaced') {
+      throw new Error('expected batch replacement receipt');
+    }
+    recovery.record(replacement.recovery);
+
+    expect(view.state.doc.toString()).toBe(
+      'Existing note Cleaned transcript.\n\n> [!note]- raw\n> raw transcript',
+    );
+    expect(recovery.restoreRawTranscript()).toBe(true);
+    expect(view.state.doc.toString()).toBe(originalDocument);
+    expect(recovery.hasRecovery()).toBe(false);
+
+    session.dispose();
+  });
+
   it('omits emptied finalized utterances from joined raw session text', () => {
     const { session } = createSessionHarness();
 
@@ -1011,6 +1053,52 @@ function createSessionHarness(
     vault,
     workspace,
   };
+}
+
+function createRecoveryIntegrationHarness(documentText: string): {
+  recovery: RawTranscriptRecovery;
+  session: Session;
+  view: StateBackedEditorView;
+} {
+  const lockedFile = fakeFile('note.md');
+  const vault = new FakeEvents();
+  const workspace = new FakeWorkspace(lockedFile);
+  const targetLeaf = workspace.leaves[0];
+  if (targetLeaf === undefined) {
+    throw new Error('expected target leaf fixture');
+  }
+  const view = new StateBackedEditorView(documentText, {
+    extensions: [
+      dictationAnchorExtension(),
+      provisionalTranscriptExtension(),
+      sessionProcessingExtension(),
+    ],
+    selectionHead: documentText.length,
+  });
+  targetLeaf.view.editor.cm = view as unknown as EditorView;
+  workspace.activeEditor = targetLeaf.view;
+  const app = { vault, workspace } as unknown as Pick<App, 'vault' | 'workspace'>;
+  const session = new Session({
+    app,
+    callbacks: {
+      onLockedNoteClosed: vi.fn(),
+      onLockedNoteDeleted: vi.fn(),
+      onSurfaceDesynchronized: vi.fn(),
+    },
+    leafPinManager: new TemporaryLeafPinLeaseManager(),
+    lockedFile,
+    placement: { anchor: 'at_cursor' },
+    rendererOptions: renderOptions(),
+    sessionId: 'recovery-integration',
+    view: view as unknown as EditorView,
+  });
+  const recovery = new RawTranscriptRecovery({
+    feedback: { show: vi.fn() },
+    getClipboard: () => null,
+    workspace: workspace as never,
+  });
+
+  return { recovery, session, view };
 }
 
 class FakeEvents {

--- a/test/transcript-renderer.test.ts
+++ b/test/transcript-renderer.test.ts
@@ -70,6 +70,27 @@ describe('buildTranscriptSpans detailed timestamps', () => {
     expect(spans).toEqual([{ speakerIndex: null, text: '(0:10.1) Hello (0:10.5) world.' }]);
   });
 
+  it('falls back to complete segment text when word timing covers only part of it', () => {
+    const spans = buildTranscriptSpans(
+      [
+        {
+          endMs: 1_000,
+          speaker: null,
+          startMs: 250,
+          text: 'Hello world.',
+          timestampGranularity: 'segment',
+          timestampSource: 'engine',
+          words: [{ endMs: 500, startMs: 300, text: 'Hello', timestampSource: 'engine' }],
+        },
+      ],
+      'Hello world.',
+      null,
+      detailedOptions,
+    );
+
+    expect(spans).toEqual([{ speakerIndex: null, text: '(0:10.2) Hello world.' }]);
+  });
+
   it('uses engine segment timing when word timing is incomplete', () => {
     const spans = buildTranscriptSpans(
       [


### PR DESCRIPTION
## Summary

This is the post-`2026.7.5` release-quality pass requested after #265 merged. It adds high-ROI integration and regression coverage across native speech processing, controller/rendering, recovery, model state, audio lifecycle, and settings UI boundaries.

### Correctness fixes

- Clear stale ready/model-capability state when an explicit model revalidation fails.
- Preserve complete transcript text when word timing is only partial by falling back to segment or phrase timing.
- Prevent capped diarization assignments from contaminating speaker centroids with dissimilar short/noisy input.
- Clear word alignments when the hallucination filter rewrites speaker-label text.

### UX and accessibility

- Disable maximum-speaker editing while speaker labels are off, with actionable guidance.
- Give timestamp interval validation an accessible name, live description, and invalid state.
- Announce the sidebar workflow summary as an atomic polite status.

### Coverage added

- Real compiled sidecar process + length-prefixed `get_system_info` wire smoke, with bounded cleanup.
- Controller opt-in/opt-out timestamp propagation and sidecar-word-to-rendered-span integration.
- Real Session → NoteSurface → raw-transcript receipt → restore integration.
- Cleaned last-utterance recovery and privacy-safe restore-failure coverage.
- Microphone track-ended-during-initialization race coverage.
- Behavioral timestamp and diarization modal render/change/save coverage.

## Root causes

The defects were boundary and completeness failures: cached state was invalidated on disk but not in memory; non-empty word arrays were mistaken for complete alignments; the short-utterance branch ran before the reached-speaker-cap guard; and modal extraction dropped the prior disabled-state behavior.

## Validation

- `npm run check`
  - release metadata validation
  - TypeScript typecheck
  - Biome and Obsidian lint
  - 74 frontend test files / 856 tests
  - frontend production build
  - sidecar build and build-output verification
  - Rust format and all-target clippy
  - complete fast Rust test suite, including the real-binary protocol smoke
- `git diff --check`

The PR remains draft while the final independent standards review and GitHub CI complete.
