### PR TITLE
ci: simplify release gate and attestation

### DIFF
--- a/.github/workflows/multilingual-quality.yml
+++ b/.github/workflows/multilingual-quality.yml
@@ -1,0 +1,85 @@
+name: multilingual-quality
+
+# Exhaustive real-model certification is intentionally independent of release
+# publication. Run it on demand for high-risk ASR changes; the weekly schedule
+# provides continuing coverage without delaying releases or pull requests.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1' # Mondays 06:00 UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: multilingual-quality-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MODEL_CACHE_DIR: ${{ github.workspace }}/.test-models
+
+jobs:
+  multilingual-e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - id: build-config
+        name: Resolve build configuration
+        uses: ./.github/actions/resolve-release-build-config
+
+      - name: Setup Node.js + npm
+        uses: ./.github/actions/setup-node-npm
+        with:
+          node-version: ${{ steps.build-config.outputs.node-version }}
+          cache: 'true'
+          upgrade-npm: 'true'
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-sidecar-rust
+        with:
+          toolchain: ${{ steps.build-config.outputs.rust-toolchain }}
+          components: rustfmt, clippy
+          cache-workspaces: native -> target
+          cache-shared-key: multilingual-quality
+
+      - name: Cache pinned multilingual models
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.MODEL_CACHE_DIR }}
+          key: multilingual-asr-${{ hashFiles('native/catalog.json') }}
+
+      - name: Install JavaScript dependencies
+        run: npm ci
+
+      - name: Run multilingual product-path quality suite
+        env:
+          STT_QUALITY_REPORT_PATH: ${{ runner.temp }}/quality/multilingual.jsonl
+          STT_TEST_MODEL_DIR: ${{ env.MODEL_CACHE_DIR }}
+        run: npm run test:sidecar:multilingual:e2e
+
+      - name: Render multilingual quality report
+        if: always()
+        env:
+          GITHUB_HEAD_SHA: ${{ github.sha }}
+          RUNNER_DESCRIPTION: GitHub Actions Ubuntu 24.04 x86_64 CPU
+        run: >-
+          node scripts/transcription-quality-report.mjs
+          --render-only "${{ runner.temp }}/quality"
+          --output-dir "${{ runner.temp }}/transcription-quality"
+
+      - name: Publish report in the workflow summary
+        if: always()
+        run: cat "${{ runner.temp }}/transcription-quality/transcription-quality.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload multilingual quality evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: multilingual-quality
+          path: |
+            ${{ runner.temp }}/quality/multilingual.jsonl
+            ${{ runner.temp }}/transcription-quality
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,6 @@ jobs:
     needs: metadata
     permissions:
       contents: read
-      id-token: write
-      attestations: write
     runs-on: ubuntu-latest
 
     steps:
@@ -79,17 +77,8 @@ jobs:
       - name: Install JavaScript dependencies
         run: npm ci
 
-      - name: Run frontend quality gates
-        run: npm run check:frontend
-
-      - name: Attest build provenance
-        if: github.event_name == 'push'
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-path: |
-            main.js
-            manifest.json
-            styles.css
+      - name: Build frontend bundle
+        run: npm run build:frontend
 
       - name: Upload plugin bundle
         uses: actions/upload-artifact@v7
@@ -100,110 +89,9 @@ jobs:
             manifest.json
             styles.css
 
-  native-quality:
-    needs: metadata
-    runs-on: ubuntu-latest
-    env:
-      # These values must exist before rust-cache computes its environment key.
-      GGML_NATIVE: ${{ needs.metadata.outputs.ggml_native }}
-      ORT_CUDA_VERSION: ${{ needs.metadata.outputs.ort_cuda_version }}
-      CUDA_TOOLKIT_VERSION: ${{ needs.metadata.outputs.cuda_toolkit_version }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup Node.js + npm
-        uses: ./.github/actions/setup-node-npm
-        with:
-          node-version: ${{ needs.metadata.outputs.node_version }}
-          cache: 'true'
-          upgrade-npm: 'true'
-
-      - name: Setup Rust
-        uses: ./.github/actions/setup-sidecar-rust
-        with:
-          toolchain: ${{ needs.metadata.outputs.rust_toolchain }}
-          components: rustfmt, clippy
-          cache-workspaces: native -> target
-          cache-shared-key: native-quality
-
-      - name: Install JavaScript dependencies
-        run: npm ci
-
-      - name: Build sidecar
-        run: npm run build:sidecar
-
-      - name: Run Rust quality gates
-        run: npm run check:rust
-
-  multilingual-quality:
-    # Run the expensive real-model matrix in parallel with release builds, then
-    # make publication depend on it. This keeps PR feedback fast without
-    # weakening the release gate.
-    needs: metadata
-    runs-on: ubuntu-latest
-    env:
-      MODEL_CACHE_DIR: ${{ github.workspace }}/.test-models
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup Node.js + npm
-        uses: ./.github/actions/setup-node-npm
-        with:
-          node-version: ${{ needs.metadata.outputs.node_version }}
-          cache: 'true'
-          upgrade-npm: 'true'
-
-      - name: Setup Rust
-        uses: ./.github/actions/setup-sidecar-rust
-        with:
-          toolchain: ${{ needs.metadata.outputs.rust_toolchain }}
-          components: rustfmt, clippy
-          cache-workspaces: native -> target
-          cache-shared-key: release-multilingual-quality
-
-      - name: Cache pinned multilingual models
-        uses: actions/cache@v6
-        with:
-          path: ${{ env.MODEL_CACHE_DIR }}
-          key: multilingual-asr-${{ hashFiles('native/catalog.json') }}
-
-      - name: Install JavaScript dependencies
-        run: npm ci
-
-      - name: Run multilingual product-path quality suite
-        env:
-          STT_QUALITY_REPORT_PATH: ${{ runner.temp }}/quality/multilingual.jsonl
-          STT_TEST_MODEL_DIR: ${{ env.MODEL_CACHE_DIR }}
-        run: npm run test:sidecar:multilingual:e2e
-
-      - name: Render multilingual quality report
-        if: always()
-        env:
-          GITHUB_HEAD_SHA: ${{ github.sha }}
-          RUNNER_DESCRIPTION: GitHub Actions Ubuntu 24.04 x86_64 CPU
-        run: >-
-          node scripts/transcription-quality-report.mjs
-          --render-only "${{ runner.temp }}/quality"
-          --output-dir "${{ runner.temp }}/transcription-quality"
-
-      - name: Upload multilingual quality evidence
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: release-multilingual-quality
-          path: |
-            ${{ runner.temp }}/quality/multilingual.jsonl
-            ${{ runner.temp }}/transcription-quality
-          if-no-files-found: error
-
   build-sidecar-posix:
-    # Depend on metadata only — not native-quality. The native build is the long
-    # pole, so start it as soon as the version/notes are validated. publish still
-    # requires native-quality, so the release gate is unchanged. See #143.
+    # Start the native build as soon as version and notes are validated; release
+    # publication depends only on successful production builds and packaging.
     needs:
       - metadata
     permissions:
@@ -439,15 +327,13 @@ jobs:
   publish:
     needs:
       - metadata
-      # native-quality is the release gate. The build jobs no longer depend on
-      # it (they start after metadata), so publish must require it explicitly.
-      - native-quality
-      - multilingual-quality
       - plugin-bundle
       - build-sidecar-posix
       - build-sidecar-windows
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     runs-on: ubuntu-latest
 
     steps:
@@ -492,6 +378,25 @@ jobs:
           body_path: ${{ needs.metadata.outputs.notes_path }}
           draft: true
 
+      - name: Stage exact release assets for attestation
+        if: github.event_name == 'push'
+        run: |
+          cp dist/release/main.js main.js
+          cp dist/release/manifest.json manifest.json
+          cp dist/release/styles.css styles.css
+
+      # Sign the exact assembled plugin files after release upload and directly
+      # before publication. This keeps the short-lived signing certificate valid
+      # when Obsidian's release scanner first sees the assets.
+      - name: Attest plugin release assets
+        if: github.event_name == 'push'
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: |
+            main.js
+            manifest.json
+            styles.css
+
       - name: Publish release
         if: github.event_name == 'push'
         env:
@@ -507,8 +412,6 @@ jobs:
   release-report:
     needs:
       - metadata
-      - native-quality
-      - multilingual-quality
       - plugin-bundle
       - build-sidecar-posix
       - build-sidecar-windows

--- a/.github/workflows/sidecar-e2e.yml
+++ b/.github/workflows/sidecar-e2e.yml
@@ -4,8 +4,8 @@ name: sidecar-e2e
 # fixtures through the full pipeline and asserts the transcript (accuracy +
 # wire-protocol). Kept out of the general `ci` workflow because it downloads
 # large model artifacts and runs real inference. English smoke coverage runs on
-# relevant PR paths; the exhaustive multilingual matrix runs manually, weekly,
-# and as a blocking release gate in release.yml.
+# relevant PR paths. Multilingual certification has its own manually
+# dispatchable, weekly workflow in multilingual-quality.yml.
 
 on:
   pull_request:
@@ -124,57 +124,8 @@ jobs:
           path: ${{ runner.temp }}/quality/nemotron-english.jsonl
           if-no-files-found: error
 
-  multilingual-e2e:
-    # The exhaustive matrix is a release/weekly certification gate. Keep it
-    # manually dispatchable for high-risk ASR changes without adding ~18
-    # minutes to every native-code PR update.
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup Node.js + npm
-        uses: ./.github/actions/setup-node-npm
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'true'
-          upgrade-npm: 'true'
-
-      - name: Setup Rust
-        uses: ./.github/actions/setup-sidecar-rust
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          components: rustfmt, clippy
-          cache-workspaces: native -> target
-          cache-shared-key: multilingual-e2e
-
-      - name: Cache pinned multilingual models
-        uses: actions/cache@v6
-        with:
-          path: ${{ env.MODEL_CACHE_DIR }}
-          key: multilingual-asr-${{ hashFiles('native/catalog.json') }}
-
-      - name: Install JavaScript dependencies
-        run: npm ci
-
-      - name: Run multilingual product-path quality suite
-        env:
-          STT_QUALITY_REPORT_PATH: ${{ runner.temp }}/quality/multilingual.jsonl
-          STT_TEST_MODEL_DIR: ${{ env.MODEL_CACHE_DIR }}
-        run: npm run test:sidecar:multilingual:e2e
-
-      - name: Upload quality measurements
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: quality-measurements-multilingual
-          path: ${{ runner.temp }}/quality/multilingual.jsonl
-          if-no-files-found: error
-
   quality-report:
-    needs: [transcription-e2e, nemotron-e2e, multilingual-e2e]
+    needs: [transcription-e2e, nemotron-e2e]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
 

--- a/docs/release/cutting-a-release.md
+++ b/docs/release/cutting-a-release.md
@@ -141,10 +141,13 @@ git tag <version> origin/main
 git push origin <version>                               # fires .github/workflows/release.yml
 ```
 
-The workflow runs: `metadata` gate → `plugin-bundle` (`check:frontend`) + native
-sidecar builds (macOS arm64, Linux x86_64 cpu+cuda, Windows cpu+cuda) →
-`native-quality` → `publish` (creates a **draft** release with the notes file as
-the body, then un-drafts it) → `release-report` (timing summary).
+The workflow runs: `metadata` validation → production plugin + native sidecar
+builds (macOS arm64, Linux x86_64 cpu+cuda, Windows cpu+cuda) → package and
+attest the final assets → `publish` (creates a **draft** release with the notes
+file as the body, then un-drafts it) → `release-report` (timing summary).
+Unit, lint, and static-analysis gates run on pull requests and `main` in
+`ci.yml`; real-model certification runs in the scheduled or manually
+dispatchable E2E workflows and does not delay publication.
 
 ## Watch and verify
 

--- a/docs/specs/multilingual-support.md
+++ b/docs/specs/multilingual-support.md
@@ -124,7 +124,7 @@ Multilingual support is first-class only when all of these are true:
 - Confirm punctuation, capitalization, speaker labels, timestamps, and smart
   paragraphs remain structurally correct for the supported scripts.
 
-### 5. Verification and release gate
+### 5. Verification
 
 - Unit-test tag normalization, model eligibility, persisted-settings migration,
   protocol round trips, and adapter rejection paths.
@@ -135,6 +135,10 @@ Multilingual support is first-class only when all of these are true:
   rejection, context prompting, LLM cleanup, and English regression.
 - Document code-switching policy explicitly; do not imply it from monolingual
   fixtures.
+
+The exhaustive real-model matrix runs in the manually dispatchable, weekly
+`multilingual-quality` workflow. It is certification evidence, not a release
+publication gate.
 
 The first multilingual release should enable a small, verified language/model
 matrix. Breadth follows evidence; it is not a prerequisite for a sound model-level


### PR DESCRIPTION
## What changed

- reduce the release workflow to metadata validation, production builds, packaging, attestation, and publication
- move multilingual real-model certification into a dedicated manual and weekly workflow
- attest the exact plugin release assets after draft upload and immediately before publication
- keep frontend, Rust, lint, and unit quality gates in PR/default-branch CI

## Why

Obsidian reported invalid attestations for `main.js` and `styles.css` even though GitHub verified their digests, repository, workflow, tag, and source commit. The signing certificates expired before the release became visible to Obsidian's scanner. Late attestation removes that timing window, while simplifying the release gate avoids rerunning quality suites already enforced by CI.

## Impact

Releases still fail on invalid metadata, failed production builds, incomplete packaging, or failed attestations. Test and static-analysis coverage remains on pull requests and `main`; multilingual certification remains available on demand and weekly without blocking publication.

## Verification

- `npm run check:release`
- `npm run check:frontend` (860 tests passed in the sandbox; the 8 localhost-binding Ollama tests were rerun outside the sandbox and passed)
- `npm run build:frontend`
- targeted release assembly and transcription quality report tests: 13 passed
- workflow YAML parsing and `git diff --check`
